### PR TITLE
Deference properties with *uint64 type

### DIFF
--- a/data/openapi-test1.yaml
+++ b/data/openapi-test1.yaml
@@ -83,6 +83,7 @@ paths:
           format: uuid
           pattern: ^(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12})$
           type: string
+          maxLength: 29
       - in: header
         name: X-Auth-Name
         required: true

--- a/data/openapi-test3.yaml
+++ b/data/openapi-test3.yaml
@@ -40,6 +40,7 @@ paths:
           format: uuid
           pattern: ^(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12})$
           type: string
+          maxLength: 30
       - in: header
         name: X-Auth-Name
         required: true

--- a/diff/method_diff.go
+++ b/diff/method_diff.go
@@ -92,7 +92,7 @@ func (methodDiff *MethodDiff) Patch(operation *openapi3.Operation) error {
 		return nil
 	}
 
-	methodDiff.DescriptionDiff.PatchString(&operation.Description)
+	methodDiff.DescriptionDiff.patchString(&operation.Description)
 	err := methodDiff.ParametersDiff.Patch(operation.Parameters)
 	if err != nil {
 		return err

--- a/diff/parameter_diff.go
+++ b/diff/parameter_diff.go
@@ -71,7 +71,7 @@ func getParameterDiffInternal(config *Config, param1, param2 *openapi3.Parameter
 
 // Patch applies the patch to a parameter
 func (diff *ParameterDiff) Patch(parameter *openapi3.Parameter) error {
-	diff.DescriptionDiff.PatchString(&parameter.Description)
+	diff.DescriptionDiff.patchString(&parameter.Description)
 
 	schema, err := derefSchema(parameter.Schema)
 	if err != nil {

--- a/diff/parameter_diff.go
+++ b/diff/parameter_diff.go
@@ -75,9 +75,9 @@ func (diff *ParameterDiff) Patch(parameter *openapi3.Parameter) error {
 
 	schema, err := derefSchema(parameter.Schema)
 	if err != nil {
-		return err
+		// no schema to patch, continue.
+		return nil
 	}
 
-	diff.SchemaDiff.Patch(schema)
-	return nil
+	return diff.SchemaDiff.Patch(schema)
 }

--- a/diff/patch_error_test.go
+++ b/diff/patch_error_test.go
@@ -1,0 +1,51 @@
+package diff_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tufin/oasdiff/diff"
+)
+
+func TestPatch_StringTypeMismatch_Nil(t *testing.T) {
+	s1 := l(t, 1)
+	s2 := l(t, 1)
+
+	s2.Paths["/api/{domain}/{project}/install-command"].Get.Parameters.GetByInAndName("path", "domain").Schema.Value.Description = "reuven"
+
+	d1, err := diff.Get(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+
+	d1.PathsDiff.Modified["/api/{domain}/{project}/install-command"].OperationsDiff.Modified["GET"].ParametersDiff.Modified["path"]["domain"].SchemaDiff.DescriptionDiff.To = nil
+
+	require.EqualError(t, d1.Patch(s1), "diff value is nil instead of string")
+}
+
+func TestPatch_StringTypeMismatch_Int(t *testing.T) {
+	s1 := l(t, 1)
+	s2 := l(t, 1)
+
+	s2.Paths["/api/{domain}/{project}/install-command"].Get.Parameters.GetByInAndName("path", "domain").Schema.Value.Description = "reuven"
+
+	d1, err := diff.Get(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+
+	d1.PathsDiff.Modified["/api/{domain}/{project}/install-command"].OperationsDiff.Modified["GET"].ParametersDiff.Modified["path"]["domain"].SchemaDiff.DescriptionDiff.To = 4
+
+	require.EqualError(t, d1.Patch(s1), "diff value type mismatch: string vs. \"int\"")
+}
+
+func TestPatch_UINT64TypeMismatch(t *testing.T) {
+	s1 := l(t, 1)
+	s2 := l(t, 1)
+
+	maxLength := uint64(13)
+	s2.Paths["/api/{domain}/{project}/install-command"].Get.Parameters.GetByInAndName("path", "domain").Schema.Value.MaxLength = &maxLength
+
+	d1, err := diff.Get(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+
+	d1.PathsDiff.Modified["/api/{domain}/{project}/install-command"].OperationsDiff.Modified["GET"].ParametersDiff.Modified["path"]["domain"].SchemaDiff.MaxLengthDiff.To = 13
+
+	require.EqualError(t, d1.Patch(s1), "diff value type mismatch: uint64 vs. \"int\"")
+}

--- a/diff/patch_test.go
+++ b/diff/patch_test.go
@@ -127,14 +127,14 @@ func TestPatch_ValueDiffInt(t *testing.T) {
 	}
 	value := uint64(3)
 	pValue := &value
-	require.EqualError(t, valueDiff.PatchUInt64Ref(&pValue), "diff value type mismatch: *uint64 vs. \"int\"")
+	require.EqualError(t, valueDiff.PatchUInt64Ref(&pValue), "diff value type mismatch: uint64 vs. \"int\"")
 }
 
 func TestPatch_ValueDiff(t *testing.T) {
 	v1 := uint64(3)
 
 	valueDiff := &diff.ValueDiff{
-		To: &v1,
+		To: v1,
 	}
 
 	v2 := uint64(3)

--- a/diff/patch_test.go
+++ b/diff/patch_test.go
@@ -16,7 +16,7 @@ func TestPatch_MethodDescription(t *testing.T) {
 	d1, err := diff.Get(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 
-	d1.Patch(s1)
+	require.NoError(t, d1.Patch(s1))
 
 	d2, err := diff.Get(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
@@ -32,7 +32,7 @@ func TestPatch_ParameterDescription(t *testing.T) {
 	d1, err := diff.Get(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 
-	d1.Patch(s1)
+	require.NoError(t, d1.Patch(s1))
 
 	d2, err := diff.Get(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
@@ -49,7 +49,7 @@ func TestPatch_ParameterSchemaFormat(t *testing.T) {
 	d1, err := diff.Get(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 
-	d1.Patch(s1)
+	require.NoError(t, d1.Patch(s1))
 
 	d2, err := diff.Get(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
@@ -65,7 +65,7 @@ func TestPatch_ParameterSchemaEnum(t *testing.T) {
 	d1, err := diff.Get(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 
-	d1.Patch(s1)
+	require.NoError(t, d1.Patch(s1))
 
 	d2, err := diff.Get(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
@@ -83,7 +83,7 @@ func TestPatch_ParameterSchemaMaxLengthNil(t *testing.T) {
 	d1, err := diff.Get(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 
-	d1.Patch(s1)
+	require.NoError(t, d1.Patch(s1))
 
 	d2, err := diff.Get(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
@@ -100,44 +100,9 @@ func TestPatch_ParameterSchemaMaxLength(t *testing.T) {
 	d1, err := diff.Get(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 
-	d1.Patch(s1)
+	require.NoError(t, d1.Patch(s1))
 
 	d2, err := diff.Get(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	require.False(t, d2.GetSummary().Diff)
-}
-
-func TestPatch_ValueDiffNil(t *testing.T) {
-	valueDiff := &diff.ValueDiff{}
-	value := "reuven"
-	require.EqualError(t, valueDiff.PatchString(&value), "diff value is nil instead of string")
-}
-
-func TestPatch_ValueDiffMismatch(t *testing.T) {
-	valueDiff := &diff.ValueDiff{
-		To: 4,
-	}
-	value := "reuven"
-	require.EqualError(t, valueDiff.PatchString(&value), "diff value type mismatch: string vs. \"int\"")
-}
-
-func TestPatch_ValueDiffInt(t *testing.T) {
-	valueDiff := &diff.ValueDiff{
-		To: 4,
-	}
-	value := uint64(3)
-	pValue := &value
-	require.EqualError(t, valueDiff.PatchUInt64Ref(&pValue), "diff value type mismatch: uint64 vs. \"int\"")
-}
-
-func TestPatch_ValueDiff(t *testing.T) {
-	v1 := uint64(3)
-
-	valueDiff := &diff.ValueDiff{
-		To: v1,
-	}
-
-	v2 := uint64(3)
-	pV2 := &v2
-	require.NoError(t, valueDiff.PatchUInt64Ref(&pV2))
 }

--- a/diff/schema_diff.go
+++ b/diff/schema_diff.go
@@ -123,11 +123,11 @@ func getSchemaDiffInternal(config *Config, schema1, schema2 *openapi3.SchemaRef)
 	result.MaxDiff = getFloat64RefDiff(value1.Max, value2.Max)
 	result.MultipleOfDiff = getFloat64RefDiff(value1.MultipleOf, value2.MultipleOf)
 	result.MinLengthDiff = getValueDiff(value1.MinLength, value2.MinLength)
-	result.MaxLengthDiff = getValueDiff(value1.MaxLength, value2.MaxLength)
+	result.MaxLengthDiff = getUInt64RefDiff(value1.MaxLength, value2.MaxLength)
 	result.PatternDiff = getValueDiff(value1.Pattern, value2.Pattern)
 	// compiledPattern is derived from pattern -> no need to diff
 	result.MinItemsDiff = getValueDiff(value1.MinItems, value2.MinItems)
-	result.MaxItemsDiff = getValueDiff(value1.MaxItems, value2.MaxItems)
+	result.MaxItemsDiff = getUInt64RefDiff(value1.MaxItems, value2.MaxItems)
 	result.ItemsDiff, err = getSchemaDiff(config, value1.Items, value2.Items)
 	if err != nil {
 		return nil, err
@@ -140,7 +140,7 @@ func getSchemaDiffInternal(config *Config, schema1, schema2 *openapi3.SchemaRef)
 	}
 
 	result.MinPropsDiff = getValueDiff(value1.MinProps, value2.MinProps)
-	result.MaxPropsDiff = getValueDiff(value1.MaxProps, value2.MaxProps)
+	result.MaxPropsDiff = getUInt64RefDiff(value1.MaxProps, value2.MaxProps)
 	result.AdditionalPropertiesDiff, err = getSchemaDiff(config, value1.AdditionalProperties, value2.AdditionalProperties)
 	if err != nil {
 		return nil, err

--- a/diff/schema_diff.go
+++ b/diff/schema_diff.go
@@ -205,25 +205,25 @@ func (diff *SchemaDiff) Patch(schema *openapi3.Schema) error {
 		return nil
 	}
 
-	if err := diff.TypeDiff.PatchString(&schema.Type); err != nil {
+	if err := diff.TypeDiff.patchString(&schema.Type); err != nil {
 		return err
 	}
 
-	if err := diff.TitleDiff.PatchString(&schema.Title); err != nil {
+	if err := diff.TitleDiff.patchString(&schema.Title); err != nil {
 		return err
 	}
 
-	if err := diff.FormatDiff.PatchString(&schema.Format); err != nil {
+	if err := diff.FormatDiff.patchString(&schema.Format); err != nil {
 		return err
 	}
 
-	if err := diff.DescriptionDiff.PatchString(&schema.Description); err != nil {
+	if err := diff.DescriptionDiff.patchString(&schema.Description); err != nil {
 		return err
 	}
 
 	diff.EnumDiff.Patch(&schema.Enum)
 
-	if err := diff.MaxLengthDiff.PatchUInt64Ref(&schema.MaxLength); err != nil {
+	if err := diff.MaxLengthDiff.patchUInt64Ref(&schema.MaxLength); err != nil {
 		return err
 	}
 

--- a/diff/value_diff.go
+++ b/diff/value_diff.go
@@ -102,13 +102,13 @@ func (diff *ValueDiff) patchStringCB(cb func(string)) error {
 	return nil
 }
 
-// PatchString applies the patch to a string value
-func (diff *ValueDiff) PatchString(value *string) error {
+// patchString applies the patch to a string value
+func (diff *ValueDiff) patchString(value *string) error {
 	return diff.patchStringCB(func(s string) { *value = s })
 }
 
-// PatchUInt64Ref applies the patch to a *unit64 value
-func (diff *ValueDiff) PatchUInt64Ref(value **uint64) error {
+// patchUInt64Ref applies the patch to a *unit64 value
+func (diff *ValueDiff) patchUInt64Ref(value **uint64) error {
 	if diff.Empty() {
 		return nil
 	}

--- a/diff/value_diff.go
+++ b/diff/value_diff.go
@@ -47,6 +47,10 @@ func getStringRefDiffConditional(exclude bool, valueRef1, valueRef2 *string) *Va
 	return getValueDiffConditional(exclude, derefString(valueRef1), derefString(valueRef2))
 }
 
+func getUInt64RefDiff(valueRef1, valueRef2 *uint64) *ValueDiff {
+	return getValueDiff(derefUInt64(valueRef1), derefUInt64(valueRef2))
+}
+
 func derefString(ref *string) interface{} {
 	if ref == nil {
 		return nil
@@ -64,6 +68,14 @@ func derefBool(ref *bool) interface{} {
 }
 
 func derefFloat64(ref *float64) interface{} {
+	if ref == nil {
+		return nil
+	}
+
+	return *ref
+}
+
+func derefUInt64(ref *uint64) interface{} {
 	if ref == nil {
 		return nil
 	}
@@ -102,14 +114,15 @@ func (diff *ValueDiff) PatchUInt64Ref(value **uint64) error {
 	}
 
 	if diff.To == nil {
-		return fmt.Errorf("diff value is nil instead of *uint64")
+		*value = nil
+		return nil
 	}
 
-	switch diff.To.(type) {
-	case *uint64:
-		*value = diff.To.(*uint64)
+	switch t := diff.To.(type) {
+	case uint64:
+		*value = &t
 	default:
-		return fmt.Errorf("diff value type mismatch: *uint64 vs. %q", reflect.TypeOf(diff.To))
+		return fmt.Errorf("diff value type mismatch: uint64 vs. %q", reflect.TypeOf(diff.To))
 	}
 
 	return nil

--- a/report/report.go
+++ b/report/report.go
@@ -210,7 +210,6 @@ func (r *report) printSchema(d *diff.SchemaDiff) {
 }
 
 func (r *report) printProperties(d *diff.SchemasDiff) {
-
 	if d.Empty() {
 		return
 	}
@@ -220,7 +219,7 @@ func (r *report) printProperties(d *diff.SchemasDiff) {
 	}
 
 	for _, property := range d.Deleted {
-		r.print("Deleted  property:", property)
+		r.print("Deleted property:", property)
 	}
 
 	for property, schemaDiff := range d.Modified {

--- a/report/text_test.go
+++ b/report/text_test.go
@@ -74,3 +74,8 @@ func TestText6(t *testing.T) {
 	textReport := report.GetTextReportAsString(d(t, &diff.Config{}, 1, 5))
 	require.Contains(t, textReport, "Type changed from 'string' to 'object'")
 }
+
+func TestText_DerefUint64(t *testing.T) {
+	textReport := report.GetTextReportAsString(d(t, &diff.Config{}, 1, 3))
+	require.Contains(t, textReport, "MaxLength changed from 29 to 30")
+}


### PR DESCRIPTION
MaxLength, MaxItems and MaxProps are stored as
*uint64 values.

Before being written to the diff report, this properties
must be deferenced. Otherwise the output looks like:

 - MaxLength changed from 0xc00026b500 to 0xc00026ba60
 - MaxItems changed from 0xc00026b4e8 to 0xc00026ba48
 - MaxProps changed from 0xc00026b508 to 0xc00026ba68

With this commit, the output is now:

 - MaxLength changed from 0 to 1
 - MaxItems changed from 0 to 1
 - MaxProps changed from 0 to 1