### PR TITLE
Add support for multiple media types inside content component

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,39 +63,40 @@ Add the `-format` flag to generate other formats (text or html).
 docker run --rm -t tufin/oasdiff -help
 ```
 
-## Output example - Text
+## Output example - Text/Markdown
+```./oasdiff -base data/openapi-test1.yaml -revision data/openapi-test5.yaml -format text```
 
-### New Endpoints
------------------
+### New Endpoints: None
+-----------------------
 
-### Deleted Endpoints
----------------------
-POST /subscribe  
-POST /register  
+### Deleted Endpoints: 2
+------------------------
+POST /register
+POST /subscribe
 
-### Modified Endpoints
-----------------------
+### Modified Endpoints: 2
+-------------------------
 GET /api/{domain}/{project}/badges/security-score
-* Modified query param: filter
+- Modified query param: filter
   - Content changed
     - Modified media type: application/json
       - Schema changed
         - Required changed
-* Modified query param: image
-* Modified query param: token
+- Modified query param: image
+- Modified query param: token
   - Schema changed
-    - MaxLength changed from 29 to 30
-* Modified header param: user
+    - MaxLength changed from 29 to <nil>
+- Modified header param: user
   - Schema changed
     - Schema added
   - Content changed
     - Deleted media type: application/json
-* Modified cookie param: test
+- Modified cookie param: test
   - Content changed
     - Modified media type: application/json
       - Schema changed
         - Type changed from 'object' to 'string'
-* Responses changed
+- Responses changed
   - New response: default
   - Deleted response: 200
   - Modified response: 201
@@ -105,14 +106,15 @@ GET /api/{domain}/{project}/badges/security-score
           - Type changed from 'string' to 'object'
 
 GET /api/{domain}/{project}/install-command
-* Deleted header param: network-policies
-* Responses changed
+- Deleted header param: network-policies
+- Responses changed
   - Modified response: default
     - Description changed from 'Tufin1' to 'Tufin'
     - Headers changed
       - Deleted header: X-RateLimit-Limit
 
 ## Output example - YAML
+```./oasdiff -base data/openapi-test1.yaml -revision data/openapi-test5.yaml -format yaml```
 
 ```yaml
 info:
@@ -215,9 +217,9 @@ paths:
 endpoints:
   deleted:
     - method: POST
-      path: /subscribe
-    - method: POST
       path: /register
+    - method: POST
+      path: /subscribe
   modified:
     ? method: GET
       path: /api/{domain}/{project}/badges/security-score
@@ -251,15 +253,15 @@ endpoints:
                       required:
                         added:
                           - type
-          image:
-            examples:
-              deleted:
-                - "0"
-          token:
-            schema:
-              maxLength:
-                from: 29
-                to: null
+            image:
+              examples:
+                deleted:
+                  - "0"
+            token:
+              schema:
+                maxLength:
+                  from: 29
+                  to: null
       responses:
         added:
           - default

--- a/README.md
+++ b/README.md
@@ -75,33 +75,43 @@ POST /register
 
 ### Modified Endpoints
 ----------------------
-GET /api/{domain}/{project}/badges/security-score  
+GET /api/{domain}/{project}/badges/security-score
 * Modified query param: filter
   - Content changed
-    - Schema changed
+    - Modified media type: application/json
+      - Schema changed
+        - Required changed
 * Modified query param: image
+* Modified query param: token
+  - Schema changed
+    - MaxLength changed from 29 to 30
 * Modified header param: user
   - Schema changed
     - Schema added
   - Content changed
+    - Deleted media type: application/json
 * Modified cookie param: test
   - Content changed
-* Response changed
+    - Modified media type: application/json
+      - Schema changed
+        - Type changed from 'object' to 'string'
+* Responses changed
   - New response: default
   - Deleted response: 200
   - Modified response: 201
     - Content changed
-      - Schema changed
-        - Type changed from 'string' to 'object'
+      - Modified media type: application/xml
+        - Schema changed
+          - Type changed from 'string' to 'object'
 
 GET /api/{domain}/{project}/install-command
 * Deleted header param: network-policies
-* Response changed
+* Responses changed
   - Modified response: default
     - Description changed from 'Tufin1' to 'Tufin'
     - Headers changed
       - Deleted header: X-RateLimit-Limit
-        
+
 ## Output example - YAML
 
 ```yaml
@@ -133,20 +143,37 @@ paths:
                 cookie:
                   test:
                     content:
-                      mediaType: true
+                      mediaTypeModified:
+                        application/json:
+                          schema:
+                            type:
+                              from: object
+                              to: string
                 header:
                   user:
                     schema:
                       schemaAdded: true
                     content:
-                      mediaTypeDeleted: true
+                      mediaTypeDeleted:
+                        - application/json
                 query:
                   filter:
                     content:
-                      schema:
-                        required:
-                          added:
-                            - type
+                      mediaTypeModified:
+                        application/json:
+                          schema:
+                            required:
+                              added:
+                                - type
+                  image:
+                    examples:
+                      deleted:
+                        - "0"
+                  token:
+                    schema:
+                      maxLength:
+                        from: 29
+                        to: null
             responses:
               added:
                 - default
@@ -155,10 +182,12 @@ paths:
               modified:
                 "201":
                   content:
-                    schema:
-                      type:
-                        from: string
-                        to: object
+                    mediaTypeModified:
+                      application/xml:
+                        schema:
+                          type:
+                            from: string
+                            to: object
       parameters:
         deleted:
           path:
@@ -200,20 +229,37 @@ endpoints:
           cookie:
             test:
               content:
-                mediaType: true
+                mediaTypeModified:
+                  application/json:
+                    schema:
+                      type:
+                        from: object
+                        to: string
           header:
             user:
               schema:
                 schemaAdded: true
               content:
-                mediaTypeDeleted: true
+                mediaTypeDeleted:
+                  - application/json
           query:
             filter:
               content:
-                schema:
-                  required:
-                    added:
-                      - type
+                mediaTypeModified:
+                  application/json:
+                    schema:
+                      required:
+                        added:
+                          - type
+          image:
+            examples:
+              deleted:
+                - "0"
+          token:
+            schema:
+              maxLength:
+                from: 29
+                to: null
       responses:
         added:
           - default
@@ -222,10 +268,12 @@ endpoints:
         modified:
           "201":
             content:
-              schema:
-                type:
-                  from: string
-                  to: object
+              mediaTypeModified:
+                application/xml:
+                  schema:
+                    type:
+                      from: string
+                      to: object
     ? method: GET
       path: /api/{domain}/{project}/install-command
     : parameters:
@@ -284,10 +332,12 @@ components:
             to: false
       testc:
         content:
-          schema:
-            type:
-              from: object
-              to: string
+          mediaTypeModified:
+            application/json:
+              schema:
+                type:
+                  from: object
+                  to: string
   requestBodies:
     deleted:
       - reuven

--- a/data/openapi-test5.yaml
+++ b/data/openapi-test5.yaml
@@ -31,9 +31,9 @@ paths:
       - in: cookie
         name: test
         content:
-          application/xml:
+          application/json:
             schema:
-              type: object
+              type: string
       - in: query
         name: image
         schema:

--- a/diff/content_diff.go
+++ b/diff/content_diff.go
@@ -4,7 +4,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
-// ContentDiff describes the changes between content objects each containing media type objects: https://swagger.io/specification/#media-type-object
+// ContentDiff describes the changes between content properties each containing media type objects: https://swagger.io/specification/#media-type-object
 type ContentDiff struct {
 	MediaTypeAdded    StringList         `json:"mediaTypeAdded,omitempty" yaml:"mediaTypeAdded,omitempty"`
 	MediaTypeDeleted  StringList         `json:"mediaTypeDeleted,omitempty" yaml:"mediaTypeDeleted,omitempty"`

--- a/diff/content_diff.go
+++ b/diff/content_diff.go
@@ -1,30 +1,36 @@
 package diff
 
 import (
-	"fmt"
-
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
-// ContentDiff describes the changes between a pair of content objects each containing a media type object: https://swagger.io/specification/#media-type-object
+// ContentDiff describes the changes between content objects each containing media type objects: https://swagger.io/specification/#media-type-object
 type ContentDiff struct {
-	MediaTypeAdded   bool            `json:"mediaTypeAdded,omitempty" yaml:"mediaTypeAdded,omitempty"`
-	MediaTypeDeleted bool            `json:"mediaTypeDeleted,omitempty" yaml:"mediaTypeDeleted,omitempty"`
-	MediaTypeDiff    bool            `json:"mediaType,omitempty" yaml:"mediaType,omitempty"`
-	ExtensionsDiff   *ExtensionsDiff `json:"extensions,omitempty" yaml:"extensions,omitempty"`
-	SchemaDiff       *SchemaDiff     `json:"schema,omitempty" yaml:"schema,omitempty"`
-	ExampleDiff      *ValueDiff      `json:"example,omitempty" yaml:"example,omitempty"`
-	ExamplesDiff     *ExamplesDiff   `json:"examples,omitempty" yaml:"examples,omitempty"`
-	EncodingsDiff    *EncodingsDiff  `json:"encoding,omitempty" yaml:"encoding,omitempty"`
+	MediaTypeAdded    StringList         `json:"mediaTypeAdded,omitempty" yaml:"mediaTypeAdded,omitempty"`
+	MediaTypeDeleted  StringList         `json:"mediaTypeDeleted,omitempty" yaml:"mediaTypeDeleted,omitempty"`
+	MediaTypeModified ModifiedMediaTypes `json:"mediaTypeModified,omitempty" yaml:"mediaTypeModified,omitempty"`
 }
 
+// ModifiedMediaTypes is map of media type names to their respective diffs
+type ModifiedMediaTypes map[string]*MediaTypeDiff
+
 func newContentDiff() *ContentDiff {
-	return &ContentDiff{}
+	return &ContentDiff{
+		MediaTypeAdded:    StringList{},
+		MediaTypeDeleted:  StringList{},
+		MediaTypeModified: ModifiedMediaTypes{},
+	}
 }
 
 // Empty indicates whether a change was found in this element
-func (contentDiff *ContentDiff) Empty() bool {
-	return contentDiff == nil || *contentDiff == ContentDiff{}
+func (diff *ContentDiff) Empty() bool {
+	if diff == nil {
+		return true
+	}
+
+	return len(diff.MediaTypeAdded) == 0 &&
+		len(diff.MediaTypeDeleted) == 0 &&
+		len(diff.MediaTypeModified) == 0
 }
 
 func getContentDiff(config *Config, content1, content2 openapi3.Content) (*ContentDiff, error) {
@@ -41,76 +47,28 @@ func getContentDiff(config *Config, content1, content2 openapi3.Content) (*Conte
 
 func getContentDiffInternal(config *Config, content1, content2 openapi3.Content) (*ContentDiff, error) {
 
-	if len(content1) == 0 && len(content2) == 0 {
-		return nil, nil
-	}
-
 	result := newContentDiff()
 
-	if len(content1) == 0 && len(content2) != 0 {
-		result.MediaTypeAdded = true
-		return result, nil
+	for name1, media1 := range content1 {
+		if media2, ok := content2[name1]; ok {
+			diff, err := getMediaTypeDiff(config, media1, media2)
+			if err != nil {
+				return nil, err
+			}
+
+			if !diff.Empty() {
+				result.MediaTypeModified[name1] = diff
+			}
+		} else {
+			result.MediaTypeDeleted = append(result.MediaTypeDeleted, name1)
+		}
 	}
 
-	if len(content1) != 0 && len(content2) == 0 {
-		result.MediaTypeDeleted = true
-		return result, nil
-	}
-
-	mediaType1, mediaTypeValue1, err := getMediaType(content1)
-	if err != nil {
-		return nil, err
-	}
-
-	mediaType2, mediaTypeValue2, err := getMediaType(content2)
-	if err != nil {
-		return nil, err
-	}
-
-	if mediaTypeValue1 == nil || mediaTypeValue2 == nil {
-		return nil, fmt.Errorf("media type is nil")
-	}
-
-	if mediaType1 != mediaType2 {
-		result.MediaTypeDiff = true
-		return result, nil
-	}
-
-	result.ExtensionsDiff = getExtensionsDiff(config, mediaTypeValue1.ExtensionProps, mediaTypeValue2.ExtensionProps)
-	result.SchemaDiff, err = getSchemaDiff(config, mediaTypeValue1.Schema, mediaTypeValue2.Schema)
-	if err != nil {
-		return nil, err
-	}
-
-	result.ExampleDiff = getValueDiffConditional(config.ExcludeExamples, mediaTypeValue1.Example, mediaTypeValue1.Example)
-
-	result.EncodingsDiff, err = getEncodingsDiff(config, mediaTypeValue1.Encoding, mediaTypeValue2.Encoding)
-	if err != nil {
-		return nil, err
-	}
-
-	result.ExamplesDiff, err = getExamplesDiff(config, mediaTypeValue1.Examples, mediaTypeValue2.Examples)
-	if err != nil {
-		return nil, err
+	for name2 := range content2 {
+		if _, ok := content1[name2]; !ok {
+			result.MediaTypeAdded = append(result.MediaTypeDeleted, name2)
+		}
 	}
 
 	return result, nil
-}
-
-// getMediaType returns the single MediaType entry in the content map
-func getMediaType(content openapi3.Content) (string, *openapi3.MediaType, error) {
-
-	var mediaType string
-	var mediaTypeValue *openapi3.MediaType
-
-	if len(content) != 1 {
-		return "", nil, fmt.Errorf("content map has more than one value")
-	}
-
-	for k, v := range content {
-		mediaType = k
-		mediaTypeValue = v
-	}
-
-	return mediaType, mediaTypeValue, nil
 }

--- a/diff/diff_error_test.go
+++ b/diff/diff_error_test.go
@@ -266,17 +266,6 @@ func TestDiff_ComponentCallbacksNil(t *testing.T) {
 	require.EqualError(t, err, "callback reference is nil")
 }
 
-func TestSchemaDiff_MediaInvalidMultiEntries(t *testing.T) {
-
-	s5 := l(t, 5)
-	s5.Paths[securityScorePath].Get.Parameters.GetByInAndName(openapi3.ParameterInCookie, "test").Content["second/invalid"] = openapi3.NewMediaType()
-
-	s1 := l(t, 1)
-
-	_, err := diff.Get(diff.NewConfig(), s5, s1)
-	require.EqualError(t, err, "content map has more than one value")
-}
-
 func TestFilterByRegex_Invalid(t *testing.T) {
 	_, err := diff.Get(&diff.Config{PathFilter: "["}, l(t, 1), l(t, 2))
 	require.EqualError(t, err, "failed to compile filter regex \"[\" with error parsing regexp: missing closing ]: `[`")

--- a/diff/media_type_diff.go
+++ b/diff/media_type_diff.go
@@ -1,0 +1,59 @@
+package diff
+
+import (
+	"fmt"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// MediaTypeDiff describes the changes between a pair of media type objects
+type MediaTypeDiff struct {
+	ExtensionsDiff *ExtensionsDiff `json:"extensions,omitempty" yaml:"extensions,omitempty"`
+	SchemaDiff     *SchemaDiff     `json:"schema,omitempty" yaml:"schema,omitempty"`
+	ExampleDiff    *ValueDiff      `json:"example,omitempty" yaml:"example,omitempty"`
+	ExamplesDiff   *ExamplesDiff   `json:"examples,omitempty" yaml:"examples,omitempty"`
+	EncodingsDiff  *EncodingsDiff  `json:"encoding,omitempty" yaml:"encoding,omitempty"`
+}
+
+// Empty indicates whether a change was found in this element
+func (diff *MediaTypeDiff) Empty() bool {
+	return diff == nil || *diff == MediaTypeDiff{}
+}
+
+func getMediaTypeDiff(config *Config, mediaType1 *openapi3.MediaType, mediaType2 *openapi3.MediaType) (*MediaTypeDiff, error) {
+	diff, err := getMediaTypeDiffInternal(config, mediaType1, mediaType2)
+	if err != nil {
+		return nil, err
+	}
+
+	if diff.Empty() {
+		return nil, nil
+	}
+	return diff, nil
+}
+
+func getMediaTypeDiffInternal(config *Config, mediaType1 *openapi3.MediaType, mediaType2 *openapi3.MediaType) (*MediaTypeDiff, error) {
+	result := MediaTypeDiff{}
+	var err error
+
+	if mediaType1 == nil || mediaType2 == nil {
+		return nil, fmt.Errorf("media type is nil")
+	}
+
+	result.ExtensionsDiff = getExtensionsDiff(config, mediaType1.ExtensionProps, mediaType2.ExtensionProps)
+	result.SchemaDiff, err = getSchemaDiff(config, mediaType1.Schema, mediaType2.Schema)
+	if err != nil {
+		return nil, err
+	}
+	result.ExampleDiff = getValueDiffConditional(config.ExcludeExamples, mediaType1.Example, mediaType2.Example)
+	result.EncodingsDiff, err = getEncodingsDiff(config, mediaType1.Encoding, mediaType2.Encoding)
+	if err != nil {
+		return nil, err
+	}
+	result.ExamplesDiff, err = getExamplesDiff(config, mediaType1.Examples, mediaType2.Examples)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}

--- a/report/report.go
+++ b/report/report.go
@@ -290,6 +290,25 @@ func (r *report) printContent(d *diff.ContentDiff) {
 		return
 	}
 
+	for _, name := range d.MediaTypeAdded {
+		r.print("New media type:", name)
+	}
+
+	for _, name := range d.MediaTypeDeleted {
+		r.print("Deleted media type:", name)
+	}
+
+	for name, d := range d.MediaTypeModified {
+		r.print("Modified media type:", name)
+		r.indent().printMediaType(d)
+	}
+}
+
+func (r *report) printMediaType(d *diff.MediaTypeDiff) {
+	if d.Empty() {
+		return
+	}
+
 	if !d.SchemaDiff.Empty() {
 		r.print("Schema changed")
 		r.indent().printSchema(d.SchemaDiff)


### PR DESCRIPTION
Added support for diff changes when there are multiple
media types inside a content component.

The diff changes include: added, deleted and modified
media types.

All modified media types are now indexed by the media type
name. This adds one extra element to the component hierarchy.

Updated README.md file and unit test accordingly.