### PR TITLE
Parser for circular dependency in OpenAPI 

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Usage of oasdiff:
     	if provided, diff will exclude paths and operations with an OpenAPI Extension matching this regular expression
   -format string
     	output format: yaml, text or html (default "yaml")
+  -max-circular-dep int
+    	maximum allowed number of circular dependencies between objects in OpenAPI specs (default 5)
   -prefix string
     	deprecated. use -prefix-revision instead
   -prefix-base string

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func init() {
 	flag.StringVar(&format, "format", formatYAML, "output format: yaml, text or html")
 	flag.BoolVar(&failOnDiff, "fail-on-diff", false, "fail with exit code 1 if a difference is found")
 	flag.BoolVar(&version, "version", false, "show version and quit")
-	flag.IntVar(&openapi3.CircularReferenceCounter, "max-circular-dep", 5, "Maximum number of circular dependencies between objects that allowed to process OpenAPI file")
+	flag.IntVar(&openapi3.CircularReferenceCounter, "max-circular-dep", 5, "maximum allowed number of circular dependencies between objects in OpenAPI specs")
 }
 
 func validateFlags() bool {

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func init() {
 	flag.StringVar(&format, "format", formatYAML, "output format: yaml, text or html")
 	flag.BoolVar(&failOnDiff, "fail-on-diff", false, "fail with exit code 1 if a difference is found")
 	flag.BoolVar(&version, "version", false, "show version and quit")
-	flag.IntVar(&openapi3.CircularReferenceCounter, "max-circular-dep", 0, "Maximum number of circular dependencies between objects that allowed to process OpenAPI file")
+	flag.IntVar(&openapi3.CircularReferenceCounter, "max-circular-dep", 5, "Maximum number of circular dependencies between objects that allowed to process OpenAPI file")
 }
 
 func validateFlags() bool {

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ func init() {
 	flag.StringVar(&format, "format", formatYAML, "output format: yaml, text or html")
 	flag.BoolVar(&failOnDiff, "fail-on-diff", false, "fail with exit code 1 if a difference is found")
 	flag.BoolVar(&version, "version", false, "show version and quit")
+	flag.IntVar(&openapi3.CircularReferenceCounter, "max-circular-dep", 0, "Maximum number of circular dependencies between objects that allowed to process OpenAPI file")
 }
 
 func validateFlags() bool {


### PR DESCRIPTION
fix: for https://github.com/Tufin/oasdiff/issues/163

## Verification

1. Download api with 2 circular dependencies
```
wget https://gist.githubusercontent.com/wtrocki/2e272375386ddecff69d6228c89d2a05/raw/09c332bdb9edc728054e765f2c75340e2661b55a/scheduler-openapi.yaml
```
2. build binary
```
go build main.go
```

4. Run binary with new argument

```
main -base scheduler-openapi.yaml -revision scheduler-openapi.yaml -max-circular-dep=5
```

4. Run binary without new argument

```
main -base scheduler-openapi.yaml -revision scheduler-openapi.yaml -max-circular-dep=2
```
> failed to load base spec from "scheduler-openapi.yaml" with kin-openapi bug found: circular schema reference not handled - #/components/schemas/OnlineArchiveScheduleView -> #/components/schemas/DefaultScheduleView -> #/components/schemas/OnlineArchiveScheduleView -> #/components/schemas/DailyScheduleView -> #/components/schemas/OnlineArchiveScheduleView
