### PR TITLE
Improve handling of x-sunset, which can mashalled as string or a date in RFC3339 format

### DIFF
--- a/checker/checker_deprecation_test.go
+++ b/checker/checker_deprecation_test.go
@@ -265,7 +265,7 @@ func TestBreaking_DeprecationPathMixed(t *testing.T) {
 	require.Equal(t, "api-path-removed-before-sunset", errs[0].Id)
 }
 
-// BC: deleting a path with some operations having sunset date in the future is breaking
+// test sunset date without double quotes, see https://github.com/Tufin/oasdiff/pull/198/files
 func TestBreaking_DeprecationPathMixed_RFC3339_Sunset(t *testing.T) {
 
 	s1, err := checker.LoadOpenAPISpecInfoFromFile(getDeprecationFile("deprecated-path-mixed-rfc3339-sunset.yaml"))

--- a/checker/checker_deprecation_test.go
+++ b/checker/checker_deprecation_test.go
@@ -264,3 +264,20 @@ func TestBreaking_DeprecationPathMixed(t *testing.T) {
 	require.Len(t, errs, 1)
 	require.Equal(t, "api-path-removed-before-sunset", errs[0].Id)
 }
+
+// BC: deleting a path with some operations having sunset date in the future is breaking
+func TestBreaking_DeprecationPathMixed_RFC3339_Sunset(t *testing.T) {
+
+	s1, err := checker.LoadOpenAPISpecInfoFromFile(getDeprecationFile("deprecated-path-mixed-rfc3339-sunset.yaml"))
+	require.NoError(t, err)
+
+	s2, err := checker.LoadOpenAPISpecInfoFromFile(getDeprecationFile("sunset-path.yaml"))
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(&diff.Config{}, s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibility(checker.DefaultChecks(), d, osm)
+	require.NotEmpty(t, errs)
+	require.Len(t, errs, 1)
+	require.Equal(t, "api-path-removed-before-sunset", errs[0].Id)
+}

--- a/checker/checker_deprecation_test.go
+++ b/checker/checker_deprecation_test.go
@@ -276,7 +276,7 @@ func TestBreaking_DeprecationPathMixed_RFC3339_Sunset(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(&diff.Config{}, s1, s2)
 	require.NoError(t, err)
-	errs := checker.CheckBackwardCompatibility(checker.DefaultChecks(), d, osm)
+	errs := checker.CheckBackwardCompatibility(checker.GetDefaultChecks(), d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
 	require.Equal(t, "api-path-removed-before-sunset", errs[0].Id)

--- a/data/deprecation/deprecated-path-mixed-rfc3339-sunset.yaml
+++ b/data/deprecation/deprecated-path-mixed-rfc3339-sunset.yaml
@@ -1,0 +1,24 @@
+info:
+  title: Tufin
+  version: 1.0.0
+openapi: 3.0.3
+paths:
+  /api/placeholder:
+    get:
+      responses:
+        200:
+          description: OK
+  /api/test:
+    get:
+      deprecated: true
+      # kin-openapi will unmarshall x-sunset as "2022-08-10T00:00:00Z"
+      x-sunset: 2022-08-10
+      responses:
+        200:
+          description: OK
+    post:
+      deprecated: true
+      x-sunset: "9999-08-10"
+      responses:
+        201:
+          description: OK

--- a/diff/deprecation.go
+++ b/diff/deprecation.go
@@ -22,12 +22,13 @@ func GetSunsetDate(Extensions map[string]interface{}) (civil.Date, error) {
 		}
 	}
 
-	date, err := civil.ParseDate(sunset)
-	if err != nil {
-		return civil.Date{}, errors.New("failed to parse time")
+	if date, err := civil.ParseDate(sunset); err == nil {
+		return date, nil
+	} else if date, err := time.Parse(time.RFC3339, sunset); err == nil {
+		return civil.DateOf(date), nil
 	}
 
-	return date, nil
+	return civil.Date{}, errors.New("failed to parse time")
 }
 
 // SunsetAllowed checks if an element can be deleted after deprecation period


### PR DESCRIPTION
When generating the spec in yaml format, depending on the yaml lib, the x-sunset can be marshalled in either one of these options:
1.  x-sunset: "2023-03-21"
2. x-sunset: 2023-03-21

The second option will then be unmarshalled by kin-openapi as "2023-03-21T00:00:00Z" which is incompatible with civil.ParseDate.

This PR is to add support for both formats when parsing the x-sunset extension.