### PR TITLE
(feature) Add json output option to check-breaking flag

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -89,7 +89,7 @@ func IsPipedOutput() bool {
 	return *pipedOutput
 }
 
-func (r *BackwardCompatibilityError) PrettyError(l localizations.Localizer) string {
+func (r *BackwardCompatibilityError) PrettyErrorText(l localizations.Localizer) string {
 	if IsPipedOutput() {
 		return r.LocalizedError(l)
 	}

--- a/diff/example_test.go
+++ b/diff/example_test.go
@@ -113,7 +113,7 @@ func ExampleGetPathsDiff() {
 	if len(errs) > 0 {
 		fmt.Printf(c.Localizer.Get("messages.total-errors"), len(errs))
 		for _, bcerr := range errs {
-			fmt.Printf("%s\n\n", bcerr.PrettyError(c.Localizer))
+			fmt.Printf("%s\n\n", bcerr.PrettyErrorText(c.Localizer))
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -202,19 +202,32 @@ func main() {
 				os.Exit(122)
 			}
 		}
-
-		// pretty output
-		if len(errs) > 0 {
-			fmt.Printf(c.Localizer.Get("messages.total-errors"), len(errs))
-		}
-
 		countWarns := 0
-		for _, bcerr := range errs {
-			if bcerr.Level == checker.WARN {
-				countWarns++
+
+		if format == formatJSON {
+			if err = printJSON(errs); err != nil {
+				fmt.Fprintf(os.Stderr, "failed to print diff JSON with %v\n", err)
+				os.Exit(106)
 			}
-			fmt.Printf("%s\n\n", bcerr.PrettyError(c.Localizer))
+			for _, bcerr := range errs {
+				if bcerr.Level == checker.WARN {
+					countWarns++
+				}
+			}
+		} else {
+			// pretty output
+			if len(errs) > 0 {
+				fmt.Printf(c.Localizer.Get("messages.total-errors"), len(errs))
+			}
+
+			for _, bcerr := range errs {
+				if bcerr.Level == checker.WARN {
+					countWarns++
+				}
+				fmt.Printf("%s\n\n", bcerr.PrettyErrorText(c.Localizer))
+			}
 		}
+
 		countErrs := len(errs) - countWarns
 
 		diffEmpty := countErrs == 0


### PR DESCRIPTION
This PR adds support to the `--format json` flag.

## New checker output 

Output without json flag

```shell
Backward compatibility errors (1):
error at ChangeHttpVerbTest-base.yaml, in API GET /api/v2/changeHttpVerbTest api removed without deprecation [api-removed-without-deprecation]. 
```

Output with json flag en

```json
[
  {
    "id": "api-removed-without-deprecation",
    "text": "api removed without deprecation",
    "level": 0,
    "operation": "GET",
    "path": "/api/v2/changeHttpVerbTest",
    "source": "ChangeHttpVerbTest-base.yaml"
  }
]
```
Output with json flag ru

```json

[
  {
    "id": "api-removed-without-deprecation",
    "text": "API удалён без deprecation",
    "level": 0,
    "operation": "GET",
    "path": "/api/v2/changeHttpVerbTest",
    "source": "ChangeHttpVerbTest-base.yaml"
  }
]
```


#### List of changes

- Add logic to support json format but keep default checker logic to use text


Note: please let me know if there is any further tests I can run to validate my PR.