### PR TITLE
fix external refs in non-composed mode

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -379,12 +379,14 @@ func (diffBC *BCDiff) AddRequestPropertiesDiff(path string, operation string, me
 // LoadOpenAPISpecInfoFromFile loads a LoadOpenAPISpecInfoFromFile from a local file path
 func LoadOpenAPISpecInfoFromFile(location string) (*load.OpenAPISpecInfo, error) {
 	loader := openapi3.NewLoader()
+	loader.IsExternalRefsAllowed = true
 	s, err := loader.LoadFromFile(location)
 	return &load.OpenAPISpecInfo{Spec: s, Url: location}, err
 }
 
 func LoadOpenAPISpecInfo(location string) (*load.OpenAPISpecInfo, error) {
 	loader := openapi3.NewLoader()
+	loader.IsExternalRefsAllowed = true
 	s, err := load.From(loader, location)
 	return &load.OpenAPISpecInfo{Spec: s, Url: location}, err
 }


### PR DESCRIPTION
The OpenAPI loader created in `internal/run.go` is configured with `IsExternalRefsAllowed = true`, which allows specifications to use external references. This loader is only used with `-composed` however, without this flag another loader is created elsewhere in the code.

The less confusing solution would be for the same loader to be used everywhere, regardless of mode the tool is working in, but that is a bigger refactor. This change will at least make the tool behave consistently both with and without `-composed`.