### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ deps:  ## Download go module dependencies
 	go mod download
 	go mod tidy
 
-
 .PHONY: lint
 lint: ## Run linter
 	golangci-lint run

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ deps:  ## Download go module dependencies
 .PHONY: lint
 lint: ## Run linter
 	golangci-lint run
+	
+.PHONY: localize
+localize: ## Run localizer
+	go generate go-localize -input localizations_src -output localizations 
 
 .PHONY: devtools
 devtools:  ## Install dev tools

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 VERSION=$(shell git describe --always --tags | cut -d "v" -f 2)
 LINKER_FLAGS=-s -w -X github.com/tufin/oasdiff/build.Version=${VERSION}
-GOLANGCI_VERSION=v1.50.1
+GOLANGCILINT_VERSION=v1.52.2
 
 .PHONY: test
 test:
@@ -30,4 +30,4 @@ localize: ## Run localizer
 .PHONY: devtools
 devtools:  ## Install dev tools
 	@echo "==> Installing dev tools..."
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin $(GOLANGCI_VERSION)
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin $(GOLANGCILINT_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,30 @@
+# A Self-Documenting Makefile: http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+
+VERSION=$(shell git describe --always --tags | cut -d "v" -f 2)
+LINKER_FLAGS=-s -w -X github.com/tufin/oasdiff/build.Version=${VERSION}
+GOLANGCI_VERSION=v1.50.1
+
+.PHONY: test
 test:
 	scripts/test.sh
+
+.PHONY: build
+build:
+	@echo "==> Building oasdiff binary"
+	go build -ldflags "$(LINKER_FLAGS)" -o ./bin/oasdiff $(MCLI_SOURCE_FILES)
+
+.PHONY: deps
+deps:  ## Download go module dependencies
+	@echo "==> Installing go.mod dependencies..."
+	go mod download
+	go mod tidy
+
+
+.PHONY: lint
+lint: ## Run linter
+	golangci-lint run
+
+.PHONY: devtools
+devtools:  ## Install dev tools
+	@echo "==> Installing dev tools..."
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin $(GOLANGCI_VERSION)


### PR DESCRIPTION
**Description:**
This PR adds functionalities to install deps/builds and run lint in the Makefile.

Example:

```bash
make build                                                                                                                                                       1.20.3  16.18.0 bazel 5.4.0
==> Building oasdiff binary
go build -ldflags "-s -w -X github.com/tufin/oasdiff/build.Version=1.5.12-11-g211f1f3" -o ./bin/oasdiff

./bin/oasdiff -version                                                                                                                                           1.20.3  16.18.0 bazel 5.4.0
oasdiff version: 1.5.12-11-g211f1f3
```

```
make deps                                                                                                                                                        1.20.3  16.18.0 bazel 5.4.0
==> Installing go.mod dependencies...
go mod download
go mod tidy
```

```bash
make devtools                                                                                                                                                    1.20.3  16.18.0 bazel 5.4.0
==> Installing dev tools...
curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /Users/andrea.angiolillo/go/bin v1.50.1
golangci/golangci-lint info checking GitHub for tag 'v1.50.1'
golangci/golangci-lint info found version: 1.50.1 for v1.50.1/darwin/arm64
golangci/golangci-lint info installed /Users/andrea.angiolillo/go/bin/golangci-lint
```


**Additional Info:**
- It seems to me that the repo does not use `golangci-lint`. Happy to remove it if there is no plan to use it in the future