### PR TITLE
Add support for -include-checks on changelog

### DIFF
--- a/checker/check-api-operation-id-removed.go
+++ b/checker/check-api-operation-id-removed.go
@@ -31,7 +31,7 @@ func APIOperationIdRemovedCheck(diffReport *diff.Diff, operationsSources *diff.O
 
 			result = append(result, BackwardCompatibilityError{
 				Id:          apiOperationRemovedCheckId,
-				Level:       ERR,
+				Level:       config.getLogLevel(apiOperationRemovedCheckId, INFO),
 				Text:        fmt.Sprintf(config.i18n(apiOperationRemovedCheckId), ColorizedValue(operationItem.Base.OperationID), ColorizedValue(operationItem.Revision.OperationID)),
 				Operation:   operation,
 				OperationId: op.OperationID,

--- a/checker/check-api-tag-removed.go
+++ b/checker/check-api-tag-removed.go
@@ -32,7 +32,7 @@ func APITagRemovedCheck(diffReport *diff.Diff, operationsSources *diff.Operation
 			for _, tag := range operationItem.TagsDiff.Deleted {
 				result = append(result, BackwardCompatibilityError{
 					Id:          apiTagRemovedCheckId,
-					Level:       ERR,
+					Level:       config.getLogLevel(apiTagRemovedCheckId, INFO),
 					Text:        fmt.Sprintf(config.i18n(apiTagRemovedCheckId), ColorizedValue(tag)),
 					Operation:   operation,
 					OperationId: op.OperationID,

--- a/checker/check-components-schemas-removed.go
+++ b/checker/check-components-schemas-removed.go
@@ -19,7 +19,7 @@ func APIComponentsSchemaRemovedCheck(diffReport *diff.Diff, operationsSources *d
 	for _, deletedSchema := range diffReport.ComponentsDiff.SchemasDiff.Deleted {
 		result = append(result, BackwardCompatibilityError{
 			Id:        apiSchemasRemovedCheckId,
-			Level:     ERR,
+			Level:     config.getLogLevel(apiSchemasRemovedCheckId, INFO),
 			Text:      fmt.Sprintf(config.i18n(apiSchemasRemovedCheckId), ColorizedValue(deletedSchema)),
 			Operation: "N/A",
 			Path:      "",

--- a/checker/check-request-body-enum-deleted.go
+++ b/checker/check-request-body-enum-deleted.go
@@ -43,7 +43,7 @@ func RequestBodyEnumValueRemovedCheck(diffReport *diff.Diff, operationsSources *
 				for _, enumVal := range enumDiff.Deleted {
 					result = append(result, BackwardCompatibilityError{
 						Id:          requestBodyEnumRemovedId,
-						Level:       ERR,
+						Level:       config.getLogLevel(requestBodyBecameEnumId, INFO),
 						Text:        fmt.Sprintf(config.i18n(requestBodyEnumRemovedId), ColorizedValue(enumVal)),
 						Operation:   operation,
 						OperationId: operationItem.Revision.OperationID,

--- a/checker/check-request-body-enum-deleted.go
+++ b/checker/check-request-body-enum-deleted.go
@@ -43,7 +43,7 @@ func RequestBodyEnumValueRemovedCheck(diffReport *diff.Diff, operationsSources *
 				for _, enumVal := range enumDiff.Deleted {
 					result = append(result, BackwardCompatibilityError{
 						Id:          requestBodyEnumRemovedId,
-						Level:       config.getLogLevel(requestBodyBecameEnumId, INFO),
+						Level:       config.getLogLevel(requestBodyEnumRemovedId, INFO),
 						Text:        fmt.Sprintf(config.i18n(requestBodyEnumRemovedId), ColorizedValue(enumVal)),
 						Operation:   operation,
 						OperationId: operationItem.Revision.OperationID,

--- a/checker/check-response-mediatype-enum-value-removed.go
+++ b/checker/check-response-mediatype-enum-value-removed.go
@@ -46,7 +46,7 @@ func ResponseMediaTypeEnumValueRemovedCheck(diffReport *diff.Diff, operationsSou
 					for _, enumVal := range enumDiff.Deleted {
 						result = append(result, BackwardCompatibilityError{
 							Id:          responseMediatypeEnumValueRemovedId,
-							Level:       ERR,
+							Level:       config.getLogLevel(responseMediatypeEnumValueRemovedId, ERR),
 							Text:        fmt.Sprintf(config.i18n(responseMediatypeEnumValueRemovedId), mediaType, ColorizedValue(enumVal)),
 							Operation:   operation,
 							OperationId: operationItem.Revision.OperationID,

--- a/checker/check-response-property-enum-value-removed.go
+++ b/checker/check-response-property-enum-value-removed.go
@@ -41,7 +41,7 @@ func ResponseParameterEnumValueRemovedCheck(diffReport *diff.Diff, operationsSou
 							for _, enumVal := range enumDiff.Deleted {
 								result = append(result, BackwardCompatibilityError{
 									Id:          responsePropertyEnumValueRemovedId,
-									Level:       ERR,
+									Level:       config.getLogLevel(responsePropertyEnumValueRemovedId, INFO),
 									Text:        fmt.Sprintf(config.i18n(responsePropertyEnumValueRemovedId), enumVal, ColorizedValue(propertyFullName(propertyPath, propertyName)), ColorizedValue(responseStatus)),
 									Operation:   operation,
 									OperationId: operationItem.Revision.OperationID,

--- a/checker/check-response-success-status-removed.go
+++ b/checker/check-response-success-status-removed.go
@@ -12,7 +12,7 @@ func ResponseSuccessStatusRemoved(diffReport *diff.Diff, operationsSources *diff
 		return status >= 200 && status <= 299
 	}
 
-	return ResponseSuccessRemoved(diffReport, operationsSources, config, success, "response-success-status-removed")
+	return ResponseSuccessRemoved(diffReport, operationsSources, config, success, "response-success-status-removed", ERR)
 }
 
 func ResponseNonSuccessStatusRemoved(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config BackwardCompatibilityCheckConfig) []BackwardCompatibilityError {
@@ -20,10 +20,10 @@ func ResponseNonSuccessStatusRemoved(diffReport *diff.Diff, operationsSources *d
 		return status < 200 || status > 299
 	}
 
-	return ResponseSuccessRemoved(diffReport, operationsSources, config, notSuccess, "response-non-success-status-removed")
+	return ResponseSuccessRemoved(diffReport, operationsSources, config, notSuccess, "response-non-success-status-removed", INFO)
 }
 
-func ResponseSuccessRemoved(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config BackwardCompatibilityCheckConfig, filter func(int) bool, id string) []BackwardCompatibilityError {
+func ResponseSuccessRemoved(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config BackwardCompatibilityCheckConfig, filter func(int) bool, id string, defaultLevel Level) []BackwardCompatibilityError {
 	result := make([]BackwardCompatibilityError, 0)
 	if diffReport.PathsDiff == nil {
 		return result
@@ -49,7 +49,7 @@ func ResponseSuccessRemoved(diffReport *diff.Diff, operationsSources *diff.Opera
 				if filter(status) {
 					result = append(result, BackwardCompatibilityError{
 						Id:          id,
-						Level:       config.getLogLevel(id),
+						Level:       config.getLogLevel(id, defaultLevel),
 						Text:        fmt.Sprintf(config.i18n(id), ColorizedValue(responseStatus)),
 						Operation:   operation,
 						OperationId: operationItem.Revision.OperationID,

--- a/checker/check-response-success-status-removed.go
+++ b/checker/check-response-success-status-removed.go
@@ -49,7 +49,7 @@ func ResponseSuccessRemoved(diffReport *diff.Diff, operationsSources *diff.Opera
 				if filter(status) {
 					result = append(result, BackwardCompatibilityError{
 						Id:          id,
-						Level:       ERR,
+						Level:       config.getLogLevel(id),
 						Text:        fmt.Sprintf(config.i18n(id), ColorizedValue(responseStatus)),
 						Operation:   operation,
 						OperationId: operationItem.Revision.OperationID,

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -158,11 +158,11 @@ func (c *BackwardCompatibilityCheckConfig) i18n(messageID string) string {
 	return c.Localizer.Get("messages." + messageID)
 }
 
-func (c *BackwardCompatibilityCheckConfig) getLogLevel(checkerId string) Level {
+func (c *BackwardCompatibilityCheckConfig) getLogLevel(checkerId string, defaultLevel Level) Level {
 	if level, ok := c.OverridenLevels[checkerId]; ok {
 		return level
 	}
-	return INFO
+	return defaultLevel
 }
 
 func CheckBackwardCompatibility(config BackwardCompatibilityCheckConfig, diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap) BackwardCompatibilityErrors {

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -151,10 +151,18 @@ type BackwardCompatibilityCheckConfig struct {
 	MinSunsetBetaDays   int
 	MinSunsetStableDays int
 	Localizer           localizations.Localizer
+	OverridenLevels     map[string]Level
 }
 
 func (c *BackwardCompatibilityCheckConfig) i18n(messageID string) string {
 	return c.Localizer.Get("messages." + messageID)
+}
+
+func (c *BackwardCompatibilityCheckConfig) getLogLevel(checkerId string) Level {
+	if level, ok := c.OverridenLevels[checkerId]; ok {
+		return level
+	}
+	return INFO
 }
 
 func CheckBackwardCompatibility(config BackwardCompatibilityCheckConfig, diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap) BackwardCompatibilityErrors {

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -151,7 +151,7 @@ type BackwardCompatibilityCheckConfig struct {
 	MinSunsetBetaDays   int
 	MinSunsetStableDays int
 	Localizer           localizations.Localizer
-	OverridenLevels     map[string]Level
+	LogLevelOverrides   map[string]Level
 }
 
 func (c *BackwardCompatibilityCheckConfig) i18n(messageID string) string {
@@ -159,7 +159,7 @@ func (c *BackwardCompatibilityCheckConfig) i18n(messageID string) string {
 }
 
 func (c *BackwardCompatibilityCheckConfig) getLogLevel(checkerId string, defaultLevel Level) Level {
-	if level, ok := c.OverridenLevels[checkerId]; ok {
+	if level, ok := c.LogLevelOverrides[checkerId]; ok {
 		return level
 	}
 	return defaultLevel

--- a/checker/default_checks.go
+++ b/checker/default_checks.go
@@ -10,7 +10,7 @@ func GetDefaultChecks() BackwardCompatibilityCheckConfig {
 }
 
 func GetChecks(includeChecks utils.StringList) BackwardCompatibilityCheckConfig {
-	return getBackwardCompatibilityCheckConfig(defaultChecks(), LevelOverrides(includeChecks))
+	return getBackwardCompatibilityCheckConfig(allChecks(), LevelOverrides(includeChecks))
 }
 
 func LevelOverrides(includeChecks utils.StringList) map[string]Level {

--- a/checker/default_checks.go
+++ b/checker/default_checks.go
@@ -28,7 +28,7 @@ func GetAllChecks(includeChecks utils.StringList) BackwardCompatibilityCheckConf
 func getBackwardCompatibilityCheckConfig(checks []BackwardCompatibilityCheck, levelOverrides map[string]Level) BackwardCompatibilityCheckConfig {
 	return BackwardCompatibilityCheckConfig{
 		Checks:              checks,
-		OverridenLevels:     levelOverrides,
+		LogLevelOverrides:   levelOverrides,
 		MinSunsetBetaDays:   31,
 		MinSunsetStableDays: 180,
 		Localizer:           *localizations.New("en", "en"),
@@ -54,14 +54,6 @@ func ValidateIncludeChecks(includeChecks utils.StringList) utils.StringList {
 	}
 
 	return result.Sort()
-}
-
-func includedChecks(includeChecks utils.StringList) []BackwardCompatibilityCheck {
-	result := []BackwardCompatibilityCheck{}
-	for _, s := range includeChecks {
-		result = append(result, optionalChecks[s])
-	}
-	return result
 }
 
 func defaultChecks() []BackwardCompatibilityCheck {

--- a/checker/default_checks.go
+++ b/checker/default_checks.go
@@ -16,6 +16,9 @@ func GetChecks(includeChecks utils.StringList) BackwardCompatibilityCheckConfig 
 func LevelOverrides(includeChecks utils.StringList) map[string]Level {
 	result := map[string]Level{}
 	for _, s := range includeChecks {
+		// if the checker was explicitly included with the `-include-checks`,
+		// it means that it's output is considered a breaking change,
+		// so the returned level should overwritten to ERR.
 		result[s] = ERR
 	}
 	return result

--- a/checker/default_checks.go
+++ b/checker/default_checks.go
@@ -10,16 +10,25 @@ func GetDefaultChecks() BackwardCompatibilityCheckConfig {
 }
 
 func GetChecks(includeChecks utils.StringList) BackwardCompatibilityCheckConfig {
-	return getBackwardCompatibilityCheckConfig(append(defaultChecks(), includedChecks(includeChecks)...))
+	return getBackwardCompatibilityCheckConfig(defaultChecks(), LevelOverrides(includeChecks))
 }
 
-func GetAllChecks() BackwardCompatibilityCheckConfig {
-	return getBackwardCompatibilityCheckConfig(allChecks())
+func LevelOverrides(includeChecks utils.StringList) map[string]Level {
+	result := map[string]Level{}
+	for _, s := range includeChecks {
+		result[s] = ERR
+	}
+	return result
 }
 
-func getBackwardCompatibilityCheckConfig(checks []BackwardCompatibilityCheck) BackwardCompatibilityCheckConfig {
+func GetAllChecks(includeChecks utils.StringList) BackwardCompatibilityCheckConfig {
+	return getBackwardCompatibilityCheckConfig(allChecks(), LevelOverrides(includeChecks))
+}
+
+func getBackwardCompatibilityCheckConfig(checks []BackwardCompatibilityCheck, levelOverrides map[string]Level) BackwardCompatibilityCheckConfig {
 	return BackwardCompatibilityCheckConfig{
 		Checks:              checks,
+		OverridenLevels:     levelOverrides,
 		MinSunsetBetaDays:   31,
 		MinSunsetStableDays: 180,
 		Localizer:           *localizations.New("en", "en"),

--- a/data/run_test/breaking_changes_include_checks_base.yaml
+++ b/data/run_test/breaking_changes_include_checks_base.yaml
@@ -1,0 +1,73 @@
+openapi: 3.0.1
+info:
+  title: Tufin
+  version: "1.0"
+servers:
+- url: https://localhost:9080
+paths:
+  /api/v1.0/groups:
+    post:
+      tags:
+       - Group
+      operationId: createOneGroup
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupView'
+        description: Creates one project.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupView'
+          description: OK
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupView'
+          description: Conflict
+      summary: Create One Project
+  /api/v1.0/groups/{groupId}:
+    get:
+      operationId: returnOneGroup
+      parameters:
+      - $ref: '#/components/parameters/groupId'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupView'
+          description: OK
+      summary: Return One Project
+components:
+  parameters:
+    groupId:
+      in: path
+      name: groupId
+      required: true
+      schema:
+        type: string
+  schemas:
+    GroupView:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            created:
+              type: string
+              format: date-time
+              readOnly: true
+              pattern: "^[a-z]+$"
+            id:
+              type: string
+              readOnly: true
+            name:
+              type: string
+          required:
+            - name

--- a/data/run_test/breaking_changes_include_checks_revision.yaml
+++ b/data/run_test/breaking_changes_include_checks_revision.yaml
@@ -1,0 +1,65 @@
+openapi: 3.0.1
+info:
+  title: Tufin
+  version: "1.0"
+servers:
+- url: https://localhost:9080
+paths:
+  /api/v1.0/groups:
+    post:
+      operationId: createOneGroup
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupView'
+        description: Creates one project.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupView'
+          description: OK
+      summary: Create One Project
+  /api/v1.0/groups/{groupId}:
+    get:
+      operationId: returnOneGroup
+      parameters:
+      - $ref: '#/components/parameters/groupId'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupView'
+          description: OK
+      summary: Return One Project
+components:
+  parameters:
+    groupId:
+      in: path
+      name: groupId
+      required: true
+      schema:
+        type: string
+  schemas:
+    GroupView:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            created:
+              type: string
+              format: date-time
+              readOnly: true
+              pattern: "^[a-z]+$"
+            id:
+              type: string
+              readOnly: true
+            name:
+              type: string
+          required:
+            - name

--- a/data/run_test/changelog_base.yaml
+++ b/data/run_test/changelog_base.yaml
@@ -1,0 +1,55 @@
+openapi: 3.0.1
+info:
+  title: Tufin
+  version: "1.0"
+servers:
+- url: https://localhost:9080
+paths:
+  /api/v1.0/groups:
+    post:
+      operationId: createOneGroup
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupView'
+        description: Creates one project.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupView'
+          description: OK
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupView'
+          description: Conflict  
+      summary: Create One Project
+components:
+  parameters:
+    groupId:
+      in: path
+      name: groupId
+      required: true
+      schema:
+        type: string
+  schemas:
+    GroupView:
+      type: object
+      properties:
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+          pattern: ".*"
+        id:
+          type: string
+          readOnly: true
+        name:
+          type: string
+      required:
+      - name

--- a/data/run_test/changelog_include_checks_base.yaml
+++ b/data/run_test/changelog_include_checks_base.yaml
@@ -1,0 +1,73 @@
+openapi: 3.0.1
+info:
+  title: Tufin
+  version: "1.0"
+servers:
+- url: https://localhost:9080
+paths:
+  /api/v1.0/groups:
+    post:
+      tags:
+       - Group
+      operationId: createOneGroup
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupView'
+        description: Creates one project.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupView'
+          description: OK
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupView'
+          description: Conflict
+      summary: Create One Project
+  /api/v1.0/groups/{groupId}:
+    get:
+      operationId: returnOneGroup
+      parameters:
+      - $ref: '#/components/parameters/groupId'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupView'
+          description: OK
+      summary: Return One Project
+components:
+  parameters:
+    groupId:
+      in: path
+      name: groupId
+      required: true
+      schema:
+        type: string
+  schemas:
+    GroupView:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            created:
+              type: string
+              format: date-time
+              readOnly: true
+              pattern: "^[a-z]+$"
+            id:
+              type: string
+              readOnly: true
+            name:
+              type: string
+          required:
+            - name

--- a/data/run_test/changelog_include_checks_revision.yaml
+++ b/data/run_test/changelog_include_checks_revision.yaml
@@ -1,0 +1,65 @@
+openapi: 3.0.1
+info:
+  title: Tufin
+  version: "1.0"
+servers:
+- url: https://localhost:9080
+paths:
+  /api/v1.0/groups:
+    post:
+      operationId: createOneGroup
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupView'
+        description: Creates one project.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupView'
+          description: OK
+      summary: Create One Project
+  /api/v1.0/groups/{groupId}:
+    get:
+      operationId: returnOneGroup
+      parameters:
+      - $ref: '#/components/parameters/groupId'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupView'
+          description: OK
+      summary: Return One Project
+components:
+  parameters:
+    groupId:
+      in: path
+      name: groupId
+      required: true
+      schema:
+        type: string
+  schemas:
+    GroupView:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            created:
+              type: string
+              format: date-time
+              readOnly: true
+              pattern: "^[a-z]+$"
+            id:
+              type: string
+              readOnly: true
+            name:
+              type: string
+          required:
+            - name

--- a/data/run_test/changelog_revision.yaml
+++ b/data/run_test/changelog_revision.yaml
@@ -1,0 +1,49 @@
+openapi: 3.0.1
+info:
+  title: Tufin
+  version: "1.0"
+servers:
+- url: https://localhost:9080
+paths:
+  /api/v1.0/groups:
+    post:
+      operationId: createOneGroup
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupView'
+        description: Creates one project.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupView'
+          description: OK
+      summary: Create One Project
+components:
+  parameters:
+    groupId:
+      in: path
+      name: groupId
+      required: true
+      schema:
+        type: string
+  schemas:
+    GroupView:
+      type: object
+      properties:
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+          pattern: ".*"
+        id:
+          type: string
+          readOnly: true
+        name:
+          type: string
+      required:
+      - name

--- a/internal/breaking-changes.go
+++ b/internal/breaking-changes.go
@@ -14,7 +14,7 @@ func handleBreakingChanges(stdout io.Writer, diffReport *diff.Diff, operationsSo
 	var level checker.Level
 
 	c = checker.GetAllChecks(inputFlags.includeChecks)
-	// Stablish up to what level to log the changes
+	// establish up to what level to log the changes
 	level = checker.INFO
 	if inputFlags.checkBreaking {
 		level = checker.WARN

--- a/internal/breaking-changes.go
+++ b/internal/breaking-changes.go
@@ -12,12 +12,12 @@ import (
 func handleBreakingChanges(stdout io.Writer, diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, inputFlags *InputFlags) (bool, *ReturnError) {
 	var c checker.BackwardCompatibilityCheckConfig
 	var level checker.Level
+
+	c = checker.GetAllChecks(inputFlags.includeChecks)
+	// Stablish up to what level to log the changes
+	level = checker.INFO
 	if inputFlags.checkBreaking {
-		c = checker.GetChecks(inputFlags.includeChecks)
 		level = checker.WARN
-	} else {
-		c = checker.GetAllChecks()
-		level = checker.INFO
 	}
 
 	c.Localizer = *localizations.New(inputFlags.lang, "en")

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -150,7 +150,7 @@ func validateFlags(inputFlags *InputFlags) *ReturnError {
 		return getErrInvalidFlags(fmt.Errorf("\"check-breaking\" and \"changelog\" cannot be used simultaneously"))
 	}
 
-	if len(inputFlags.includeChecks) > 0 && !inputFlags.checkBreaking {
+	if len(inputFlags.includeChecks) > 0 && !(inputFlags.checkBreaking || inputFlags.changelog) {
 		return getErrInvalidFlags(fmt.Errorf("\"include-checks\" is relevant only with \"-check-breaking\""))
 	}
 

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -151,7 +151,7 @@ func validateFlags(inputFlags *InputFlags) *ReturnError {
 	}
 
 	if len(inputFlags.includeChecks) > 0 && !(inputFlags.checkBreaking || inputFlags.changelog) {
-		return getErrInvalidFlags(fmt.Errorf("\"include-checks\" is relevant only with \"-check-breaking\""))
+		return getErrInvalidFlags(fmt.Errorf("\"include-checks\" is relevant only with \"-check-breaking\" or \"-changelog"))
 	}
 
 	if invalidChecks := checker.ValidateIncludeChecks(inputFlags.includeChecks); len(invalidChecks) > 0 {

--- a/internal/run_test.go
+++ b/internal/run_test.go
@@ -73,6 +73,17 @@ func Test_DiffInvalidFormat(t *testing.T) {
 	require.Equal(t, 108, internal.Run(cmdToArgs("oasdiff -base ../data/openapi-test1.yaml -revision ../data/openapi-test3.yaml -format xxx"), io.Discard, io.Discard))
 }
 
+func Test_BreakingChangesIncludeChecks(t *testing.T) {
+	var stdout bytes.Buffer
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff -base ../data/run_test/breaking_changes_include_checks_base.yaml -revision ../data/run_test/breaking_changes_include_checks_revision.yaml -check-breaking -include-checks response-non-success-status-removed,api-tag-removed -format json"), &stdout, io.Discard))
+	bc := checker.BackwardCompatibilityErrors{}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &bc))
+	require.Len(t, bc, 2)
+	for _, c := range bc {
+		require.Equal(t, c.Level, checker.ERR)
+	}
+}
+
 func Test_BasicBreakingChanges(t *testing.T) {
 	require.Zero(t, internal.Run(cmdToArgs("oasdiff -base ../data/openapi-test1.yaml -revision ../data/openapi-test3.yaml -check-breaking"), io.Discard, io.Discard))
 }
@@ -179,4 +190,23 @@ func Test_DuplicatePathsFail(t *testing.T) {
 
 func Test_DuplicatePathsOK(t *testing.T) {
 	require.Zero(t, internal.Run(cmdToArgs("oasdiff -base ../data/duplicate_endpoints/base.yaml -revision ../data/duplicate_endpoints/revision.yaml -check-breaking -match-path-params"), io.Discard, io.Discard))
+}
+
+func Test_Changelog(t *testing.T) {
+	var stdout bytes.Buffer
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff -base ../data/run_test/changelog_base.yaml -revision ../data/run_test/changelog_revision.yaml -changelog -format json"), &stdout, io.Discard))
+	cl := checker.BackwardCompatibilityErrors{}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &cl))
+	require.Len(t, cl, 1)
+}
+
+func Test_BreakingChangesChangelogOptionalCheckersAreInfoLevel(t *testing.T) {
+	var stdout bytes.Buffer
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff -base ../data/run_test/changelog_include_checks_base.yaml -revision ../data/run_test/changelog_include_checks_revision.yaml -changelog -format json"), &stdout, io.Discard))
+	cl := checker.BackwardCompatibilityErrors{}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &cl))
+	require.Len(t, cl, 2)
+	for _, c := range cl {
+		require.Equal(t, c.Level, checker.INFO)
+	}
 }


### PR DESCRIPTION
Changes description
It's important that the changelog correctly captures what users define as breaking changes through `-include-checks`. In order to do that we need to extend `-include-checks` to `-changelog`. To do that I'm defaulting all checkers to log changes as `INFO`, and store overriden log level in the config.


- Extend all optional checkers to default logs to INFO
- If a checker is described in include-checks and it is classified as optional, then that checker will start logging the changes as errors.
- From now on we can always use `allCheckers` and rely that optional checkers will be at `INFO`level unless `include-checks` is used