### PR TITLE
Add optional checker

### DIFF
--- a/BREAKING-CHANGES-EXAMPLES.md
+++ b/BREAKING-CHANGES-EXAMPLES.md
@@ -3,6 +3,7 @@ These examples are automatically generated from unit tests.
 ## Examples of breaking changes
 [Removing a success status is breaking](checker/check-response-status-updated_test.go?plain=1#L92)  
 [adding a new required property in request body is breaking](checker/checker_breaking_property_test.go?plain=1#L352)  
+[adding a path is breaking (optional)](checker/checker_breaking_test.go?plain=1#L617)  
 [adding a pattern to a schema is breaking for recursive properties](checker/checker_breaking_test.go?plain=1#L475)  
 [adding a pattern to a schema is breaking](checker/checker_breaking_test.go?plain=1#L459)  
 [adding a required request body is breaking](checker/checker_breaking_test.go?plain=1#L65)  

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -75,6 +75,7 @@ You can use the `--include-checks` flag to include the following optional checks
 - response-property-enum-value-removed
 - response-mediatype-enum-value-removed
 - request-body-enum-value-removed
+- endpoint-added
 
 For example:
 ```

--- a/checker/check-api-added.go
+++ b/checker/check-api-added.go
@@ -14,7 +14,7 @@ func APIAddedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSour
 	appendErr := func(path, opName string, opConfig *openapi3.Operation) {
 		result = append(result, BackwardCompatibilityError{
 			Id:          "endpoint-added",
-			Level:       INFO,
+			Level:       config.getLogLevel("endpoint-added", INFO),
 			Text:        config.i18n("endpoint-added"),
 			Operation:   opName,
 			OperationId: opConfig.OperationID,

--- a/checker/checker_breaking_test.go
+++ b/checker/checker_breaking_test.go
@@ -613,3 +613,17 @@ func TestBreaking_SchemaRemoved(t *testing.T) {
 	require.Equal(t, "api-schema-removed", errs[1].Id)
 	require.Equal(t, "removed the schema 'rules' from openapi components", errs[1].Text)
 }
+
+// BC: adding a path is breaking (optional)
+func TestBreaking_AddedPath(t *testing.T) {
+	s1 := l(t, 701)
+	s2 := l(t, 1)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(getConfig(), &s1, &s2)
+	require.NoError(t, err)
+	checks := checker.GetChecks(utils.StringList{"endpoint-added"})
+	errs := checker.CheckBackwardCompatibility(checks, d, osm)
+	for _, err := range errs {
+		require.Equal(t, checker.ERR, err.Level)
+	}
+}

--- a/checker/default_checks.go
+++ b/checker/default_checks.go
@@ -46,6 +46,7 @@ var optionalChecks = map[string]BackwardCompatibilityCheck{
 	"response-property-enum-value-removed":  ResponseParameterEnumValueRemovedCheck,
 	"response-mediatype-enum-value-removed": ResponseMediaTypeEnumValueRemovedCheck,
 	"request-body-enum-value-removed":       RequestBodyEnumValueRemovedCheck,
+	"endpoint-added":                        APIAddedCheck,
 }
 
 func GetOptionalChecks() []string {


### PR DESCRIPTION
- We want to be capable to fail on a new endpoint on-demand. 
- Use case here will be to lock a version of the API and not allow any new endpoints.