### PR TITLE
add deprecation days support for beta and stable levels

### DIFF
--- a/API-DEPRECATION.md
+++ b/API-DEPRECATION.md
@@ -15,11 +15,11 @@ oasdiff allows you to gracefully remove a resource without getting the ```breaki
    ```
 2. At the sunset date or anytime later, the resource can be removed without triggering a ```breaking-change``` warning. An earlier removal will be considered a breaking change.
 
-In addition, oasdiff also allows you to control the minimal number of days required between deprecating a resource and removing it with the ```--deprecation-days``` flag.  
+In addition, oasdiff also allows you to control the minimal number of days required between deprecating a resource and removing it with the `--deprecation-days-beta` and `--deprecation-days-stable` flags, specifying the deprecation days for each [API stability level](https://github.com/Tufin/oasdiff/blob/main/BREAKING-CHANGES.md#api-stability-levels).  
 For example, the following command requires any deprecation to be accompanied by an ```x-sunset``` extension with a date which is at least 30 days away, otherwise the deprecation itself will be considered a breaking change:
 ```
-oasdiff breaking data/deprecation/base.yaml data/deprecation/deprecated-past.yaml --deprecation-days=30 
+oasdiff breaking data/deprecation/base.yaml data/deprecation/deprecated-past.yaml --deprecation-days-stable=30
 ```
 
-Setting deprecation-days to 0 is equivalent to the default which allows non-breaking deprecation regardless of the sunset date.  
+By default, `--deprecation-days-beta` and `--deprecation-days-stable` are set to 31 and 180, respectively. Setting deprecation-days to 0 allows for non-breaking deprecation, regardless of the sunset date.  
 Note: this is a Beta feature. Please report issues.

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -22,7 +22,7 @@ You can specify the `--format` flag to output breaking-changes in json or yaml.
 
 ### API Stability Levels
 When a new API is introduced, you may want to allow developers to change its behavior without triggering a breaking-change error.  
-The new Breaking Changes method provides this feature through the `x-stability-level` extension.  
+oasdiff provides this feature through the `x-stability-level` extension.  
 There are four stability levels: `draft`->`alpha`->`beta`->`stable`.  
 APIs with the levels `draft` or `alpha` can be changed freely without triggering a breaking-change error.  
 Stability level may be increased, but not decreased, like this: `draft`->`alpha`->`beta`->`stable`.  
@@ -64,7 +64,7 @@ In most cases the `x-extensible-enum` is similar to enum values, except it allow
 If you don't use the `x-extensible-enum` in your OpenAPI specifications, nothing changes for you, but if you do, oasdiff will identify breaking changes related to `x-extensible-enum` parameters and properties.
 
 ### Deprecating APIs
-OASDiff allows you to [deprecate APIs gracefully](API-DEPRECATION.md) without triggering a breaking-change error.
+oasdiff allows you to [deprecate APIs gracefully](API-DEPRECATION.md) without triggering a breaking-change error.
 
 ### Optional Breaking-Changes Checks
 You can use the `--include-checks` flag to include the following optional checks:

--- a/checker/default_checks.go
+++ b/checker/default_checks.go
@@ -10,7 +10,7 @@ func GetDefaultChecks() Config {
 }
 
 func GetChecks(includeChecks utils.StringList) Config {
-	return getBackwardCompatibilityCheckConfig(allChecks(), LevelOverrides(includeChecks))
+	return getBackwardCompatibilityCheckConfig(allChecks(), LevelOverrides(includeChecks), BetaDeprecationDays, StableDeprecationDays)
 }
 
 func LevelOverrides(includeChecks utils.StringList) map[string]Level {
@@ -24,16 +24,16 @@ func LevelOverrides(includeChecks utils.StringList) map[string]Level {
 	return result
 }
 
-func GetAllChecks(includeChecks utils.StringList) Config {
-	return getBackwardCompatibilityCheckConfig(allChecks(), LevelOverrides(includeChecks))
+func GetAllChecks(includeChecks utils.StringList, deprecationDaysBeta int, deprecationDaysStable int) Config {
+	return getBackwardCompatibilityCheckConfig(allChecks(), LevelOverrides(includeChecks), deprecationDaysBeta, deprecationDaysStable)
 }
 
-func getBackwardCompatibilityCheckConfig(checks []BackwardCompatibilityCheck, levelOverrides map[string]Level) Config {
+func getBackwardCompatibilityCheckConfig(checks []BackwardCompatibilityCheck, levelOverrides map[string]Level, minSunsetBetaDays int, minSunsetStableDays int) Config {
 	return Config{
 		Checks:              checks,
 		LogLevelOverrides:   levelOverrides,
-		MinSunsetBetaDays:   31,
-		MinSunsetStableDays: 180,
+		MinSunsetBetaDays:   minSunsetBetaDays,
+		MinSunsetStableDays: minSunsetStableDays,
 		Localizer:           *localizations.New("en", "en"),
 	}
 }

--- a/checker/deprecation.go
+++ b/checker/deprecation.go
@@ -9,6 +9,11 @@ import (
 	"github.com/tufin/oasdiff/diff"
 )
 
+const (
+	BetaDeprecationDays   = 31
+	StableDeprecationDays = 180
+)
+
 func getSunsetDate(Extensions map[string]interface{}) (string, civil.Date, error) {
 	sunset, ok := Extensions[diff.SunsetExtension].(string)
 	if !ok {

--- a/diff/config.go
+++ b/diff/config.go
@@ -13,7 +13,6 @@ type Config struct {
 	PathPrefixRevision      string
 	PathStripPrefixBase     string
 	PathStripPrefixRevision string
-	DeprecationDays         int
 	ExcludeElements         utils.StringSet
 	IncludePathParams       bool
 }

--- a/internal/breaking_changes.go
+++ b/internal/breaking_changes.go
@@ -59,8 +59,8 @@ In 'composed' mode, base and revision can be a glob and oasdiff will compare mat
 	cmd.PersistentFlags().StringVarP(&flags.errIgnoreFile, "err-ignore", "", "", "configuration file for ignoring errors")
 	cmd.PersistentFlags().StringVarP(&flags.warnIgnoreFile, "warn-ignore", "", "", "configuration file for ignoring warnings")
 	cmd.PersistentFlags().VarP(newEnumSliceValue(checker.GetOptionalChecks(), nil, &flags.includeChecks), "include-checks", "i", "comma-separated list of optional checks")
-	cmd.PersistentFlags().IntVarP(&flags.deprecationDaysBeta, "deprecation-days-beta", "", checker.BetaDeprecationDays, "minimal number of days required between deprecating a resource and removing it - stability level: beta")
-	cmd.PersistentFlags().IntVarP(&flags.deprecationDaysStable, "deprecation-days-stable", "", checker.StableDeprecationDays, "minimal number of days required between deprecating a resource and removing it - stability level: stable")
+	cmd.PersistentFlags().IntVarP(&flags.deprecationDaysBeta, "deprecation-days-beta", "", checker.BetaDeprecationDays, "min days required between deprecating a beta resource and removing it")
+	cmd.PersistentFlags().IntVarP(&flags.deprecationDaysStable, "deprecation-days-stable", "", checker.StableDeprecationDays, "min days required between deprecating a stable resource and removing it")
 
 	return &cmd
 }

--- a/internal/breaking_changes.go
+++ b/internal/breaking_changes.go
@@ -59,7 +59,8 @@ In 'composed' mode, base and revision can be a glob and oasdiff will compare mat
 	cmd.PersistentFlags().StringVarP(&flags.errIgnoreFile, "err-ignore", "", "", "configuration file for ignoring errors")
 	cmd.PersistentFlags().StringVarP(&flags.warnIgnoreFile, "warn-ignore", "", "", "configuration file for ignoring warnings")
 	cmd.PersistentFlags().VarP(newEnumSliceValue(checker.GetOptionalChecks(), nil, &flags.includeChecks), "include-checks", "i", "comma-separated list of optional checks")
-	cmd.PersistentFlags().IntVarP(&flags.deprecationDays, "deprecation-days", "d", 0, "minimal number of days required between deprecating a resource and removing it")
+	cmd.PersistentFlags().IntVarP(&flags.deprecationDaysBeta, "deprecation-days-beta", "", checker.BetaDeprecationDays, "minimal number of days required between deprecating a resource and removing it - stability level: beta")
+	cmd.PersistentFlags().IntVarP(&flags.deprecationDaysStable, "deprecation-days-stable", "", checker.StableDeprecationDays, "minimal number of days required between deprecating a resource and removing it - stability level: stable")
 
 	return &cmd
 }

--- a/internal/changelog.go
+++ b/internal/changelog.go
@@ -60,8 +60,8 @@ In 'composed' mode, base and revision can be a glob and oasdiff will compare mat
 	cmd.PersistentFlags().StringVarP(&flags.errIgnoreFile, "err-ignore", "", "", "configuration file for ignoring errors")
 	cmd.PersistentFlags().StringVarP(&flags.warnIgnoreFile, "warn-ignore", "", "", "configuration file for ignoring warnings")
 	cmd.PersistentFlags().VarP(newEnumSliceValue(checker.GetOptionalChecks(), nil, &flags.includeChecks), "include-checks", "i", "comma-separated list of optional checks")
-	cmd.PersistentFlags().IntVarP(&flags.deprecationDays, "deprecation-days", "d", 0, "minimal number of days required between deprecating a resource and removing it")
-
+	cmd.PersistentFlags().IntVarP(&flags.deprecationDaysBeta, "deprecation-days-beta", "", checker.BetaDeprecationDays, "minimal number of days required between deprecating a resource and removing it - stability level: beta")
+	cmd.PersistentFlags().IntVarP(&flags.deprecationDaysStable, "deprecation-days-stable", "", checker.StableDeprecationDays, "minimal number of days required between deprecating a resource and removing it - stability level: stable")
 	return &cmd
 }
 
@@ -78,7 +78,7 @@ func getChangelog(flags *ChangelogFlags, stdout io.Writer, level checker.Level, 
 		return false, err
 	}
 
-	bcConfig := checker.GetAllChecks(flags.includeChecks)
+	bcConfig := checker.GetAllChecks(flags.includeChecks, flags.deprecationDaysBeta, flags.deprecationDaysStable)
 	bcConfig.Localizer = *localizations.New(flags.lang, LangDefault)
 
 	errs, returnErr := filterIgnored(

--- a/internal/changelog.go
+++ b/internal/changelog.go
@@ -60,8 +60,8 @@ In 'composed' mode, base and revision can be a glob and oasdiff will compare mat
 	cmd.PersistentFlags().StringVarP(&flags.errIgnoreFile, "err-ignore", "", "", "configuration file for ignoring errors")
 	cmd.PersistentFlags().StringVarP(&flags.warnIgnoreFile, "warn-ignore", "", "", "configuration file for ignoring warnings")
 	cmd.PersistentFlags().VarP(newEnumSliceValue(checker.GetOptionalChecks(), nil, &flags.includeChecks), "include-checks", "i", "comma-separated list of optional checks")
-	cmd.PersistentFlags().IntVarP(&flags.deprecationDaysBeta, "deprecation-days-beta", "", checker.BetaDeprecationDays, "minimal number of days required between deprecating a resource and removing it - stability level: beta")
-	cmd.PersistentFlags().IntVarP(&flags.deprecationDaysStable, "deprecation-days-stable", "", checker.StableDeprecationDays, "minimal number of days required between deprecating a resource and removing it - stability level: stable")
+	cmd.PersistentFlags().IntVarP(&flags.deprecationDaysBeta, "deprecation-days-beta", "", checker.BetaDeprecationDays, "min days required between deprecating a beta resource and removing it")
+	cmd.PersistentFlags().IntVarP(&flags.deprecationDaysStable, "deprecation-days-stable", "", checker.StableDeprecationDays, "min days required between deprecating a stable resource and removing it")
 	return &cmd
 }
 

--- a/internal/changelog_flags.go
+++ b/internal/changelog_flags.go
@@ -23,7 +23,6 @@ type ChangelogFlags struct {
 	lang                     string
 	errIgnoreFile            string
 	warnIgnoreFile           string
-	deprecationDays          int
 	deprecationDaysBeta      int
 	deprecationDaysStable    int
 }
@@ -37,7 +36,6 @@ func (flags *ChangelogFlags) toConfig() *diff.Config {
 	config.PathStripPrefixBase = flags.stripPrefixBase
 	config.PathStripPrefixRevision = flags.stripPrefixRevision
 	config.IncludePathParams = flags.includePathParams
-	config.DeprecationDays = flags.deprecationDays
 
 	return config
 }

--- a/internal/changelog_flags.go
+++ b/internal/changelog_flags.go
@@ -24,6 +24,8 @@ type ChangelogFlags struct {
 	errIgnoreFile            string
 	warnIgnoreFile           string
 	deprecationDays          int
+	deprecationDaysBeta      int
+	deprecationDaysStable    int
 }
 
 func (flags *ChangelogFlags) toConfig() *diff.Config {


### PR DESCRIPTION
closes #283

- the changelog and breaking command now include deprecation-days flags for both beta and stable versions.
- updated ChangelogFlags with new deprecation days flags
- removed hardcoded deprecation days values
- removed unused DeprecationDays field from ChangelogFlags  and diff.Config
