### PR TITLE
Update response property checker

### DIFF
--- a/checker/check-response-property-type-changed.go
+++ b/checker/check-response-property-type-changed.go
@@ -55,9 +55,6 @@ func ResponsePropertyTypeChangedCheck(diffReport *diff.Diff, operationsSources *
 								return
 							}
 
-							if propertyDiff.Revision.Value.ReadOnly {
-								return
-							}
 							schemaDiff := propertyDiff
 							typeDiff := schemaDiff.TypeDiff
 							formatDiff := schemaDiff.FormatDiff


### PR DESCRIPTION
- Since this is the response checker, we shouldn't skip to fail if the item is read-only as it can still break clients when type gets changed