### PR TITLE
add 'oasdiff checks'

### DIFF
--- a/internal/breaking_changes.go
+++ b/internal/breaking_changes.go
@@ -17,7 +17,7 @@ func getBreakingChangesCmd() *cobra.Command {
 		Short: "Display breaking changes",
 		Long: `Display breaking changes between base and revision specs.
 Base and revision can be a path to a file or a URL.
-In 'composed' mode, base and revision can be a glob and oasdiff will compare mathcing endpoints between the two sets of files.
+In 'composed' mode, base and revision can be a glob and oasdiff will compare matching endpoints between the two sets of files.
 `,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/breaking_changes.go
+++ b/internal/breaking_changes.go
@@ -42,9 +42,16 @@ In 'composed' mode, base and revision can be a glob and oasdiff will compare mat
 		},
 	}
 
+	formatEnum := newEnumValue([]string{FormatYAML, FormatJSON, FormatText}, FormatText, &flags.format)
+	failOnEnum := newEnumValue([]string{LevelErr, LevelWarn}, "", &flags.failOn)
+	langEnum := newEnumValue([]string{LangEn, LangRu}, LangDefault, &flags.lang)
+
+	excludeElementsEnum := newEnumSliceValue(diff.ExcludeDiffOptions, nil, &flags.excludeElements)
+	includeChecksEnum := newEnumSliceValue(checker.GetOptionalChecks(), nil, &flags.includeChecks)
+
 	cmd.PersistentFlags().BoolVarP(&flags.composed, "composed", "c", false, "work in 'composed' mode, compare paths in all specs matching base and revision globs")
-	cmd.PersistentFlags().VarP(newEnumValue([]string{FormatYAML, FormatJSON, FormatText}, FormatText, &flags.format), "format", "f", "output format: yaml, json, or text")
-	cmd.PersistentFlags().VarP(newEnumSliceValue(diff.ExcludeDiffOptions, nil, &flags.excludeElements), "exclude-elements", "e", "comma-separated list of elements to exclude")
+	cmd.PersistentFlags().VarP(formatEnum, "format", "f", "output format: "+formatEnum.listOf())
+	cmd.PersistentFlags().VarP(excludeElementsEnum, "exclude-elements", "e", "comma-separated list of elements to exclude: "+excludeElementsEnum.listOf())
 	cmd.PersistentFlags().StringVarP(&flags.matchPath, "match-path", "p", "", "include only paths that match this regular expression")
 	cmd.PersistentFlags().StringVarP(&flags.filterExtension, "filter-extension", "", "", "exclude paths and operations with an OpenAPI Extension matching this regular expression")
 	cmd.PersistentFlags().IntVarP(&flags.circularReferenceCounter, "max-circular-dep", "", 5, "maximum allowed number of circular dependencies between objects in OpenAPI specs")
@@ -53,11 +60,11 @@ In 'composed' mode, base and revision can be a glob and oasdiff will compare mat
 	cmd.PersistentFlags().StringVarP(&flags.stripPrefixBase, "strip-prefix-base", "", "", "strip this prefix from paths in base-spec before comparison")
 	cmd.PersistentFlags().StringVarP(&flags.stripPrefixRevision, "strip-prefix-revision", "", "", "strip this prefix from paths in revised-spec before comparison")
 	cmd.PersistentFlags().BoolVarP(&flags.includePathParams, "include-path-params", "", false, "include path parameter names in endpoint matching")
-	cmd.PersistentFlags().VarP(newEnumValue([]string{LevelErr, LevelWarn}, "", &flags.failOn), "fail-on", "o", "exit with return code 1 when output includes errors with this level or higher")
-	cmd.PersistentFlags().VarP(newEnumValue([]string{LangEn, LangRu}, LangDefault, &flags.lang), "lang", "l", "language for localized output")
+	cmd.PersistentFlags().VarP(failOnEnum, "fail-on", "o", "exit with return code 1 when output includes errors with this level or higher: "+failOnEnum.listOf())
+	cmd.PersistentFlags().VarP(langEnum, "lang", "l", "language for localized output: "+langEnum.listOf())
 	cmd.PersistentFlags().StringVarP(&flags.errIgnoreFile, "err-ignore", "", "", "configuration file for ignoring errors")
 	cmd.PersistentFlags().StringVarP(&flags.warnIgnoreFile, "warn-ignore", "", "", "configuration file for ignoring warnings")
-	cmd.PersistentFlags().VarP(newEnumSliceValue(checker.GetOptionalChecks(), nil, &flags.includeChecks), "include-checks", "i", "comma-separated list of optional checks")
+	cmd.PersistentFlags().VarP(includeChecksEnum, "include-checks", "i", "comma-separated list of optional checks (see 'oasdiff checks')")
 	cmd.PersistentFlags().IntVarP(&flags.deprecationDaysBeta, "deprecation-days-beta", "", checker.BetaDeprecationDays, "min days required between deprecating a beta resource and removing it")
 	cmd.PersistentFlags().IntVarP(&flags.deprecationDaysStable, "deprecation-days-stable", "", checker.StableDeprecationDays, "min days required between deprecating a stable resource and removing it")
 

--- a/internal/breaking_changes.go
+++ b/internal/breaking_changes.go
@@ -42,16 +42,9 @@ In 'composed' mode, base and revision can be a glob and oasdiff will compare mat
 		},
 	}
 
-	formatEnum := newEnumValue([]string{FormatYAML, FormatJSON, FormatText}, FormatText, &flags.format)
-	failOnEnum := newEnumValue([]string{LevelErr, LevelWarn}, "", &flags.failOn)
-	langEnum := newEnumValue([]string{LangEn, LangRu}, LangDefault, &flags.lang)
-
-	excludeElementsEnum := newEnumSliceValue(diff.ExcludeDiffOptions, nil, &flags.excludeElements)
-	includeChecksEnum := newEnumSliceValue(checker.GetOptionalChecks(), nil, &flags.includeChecks)
-
 	cmd.PersistentFlags().BoolVarP(&flags.composed, "composed", "c", false, "work in 'composed' mode, compare paths in all specs matching base and revision globs")
-	cmd.PersistentFlags().VarP(formatEnum, "format", "f", "output format: "+formatEnum.listOf())
-	cmd.PersistentFlags().VarP(excludeElementsEnum, "exclude-elements", "e", "comma-separated list of elements to exclude: "+excludeElementsEnum.listOf())
+	enumWithOptions(&cmd, newEnumValue([]string{FormatYAML, FormatJSON, FormatText}, FormatText, &flags.format), "format", "f", "output format")
+	enumWithOptions(&cmd, newEnumSliceValue(diff.ExcludeDiffOptions, nil, &flags.excludeElements), "exclude-elements", "e", "comma-separated list of elements to exclude")
 	cmd.PersistentFlags().StringVarP(&flags.matchPath, "match-path", "p", "", "include only paths that match this regular expression")
 	cmd.PersistentFlags().StringVarP(&flags.filterExtension, "filter-extension", "", "", "exclude paths and operations with an OpenAPI Extension matching this regular expression")
 	cmd.PersistentFlags().IntVarP(&flags.circularReferenceCounter, "max-circular-dep", "", 5, "maximum allowed number of circular dependencies between objects in OpenAPI specs")
@@ -60,11 +53,11 @@ In 'composed' mode, base and revision can be a glob and oasdiff will compare mat
 	cmd.PersistentFlags().StringVarP(&flags.stripPrefixBase, "strip-prefix-base", "", "", "strip this prefix from paths in base-spec before comparison")
 	cmd.PersistentFlags().StringVarP(&flags.stripPrefixRevision, "strip-prefix-revision", "", "", "strip this prefix from paths in revised-spec before comparison")
 	cmd.PersistentFlags().BoolVarP(&flags.includePathParams, "include-path-params", "", false, "include path parameter names in endpoint matching")
-	cmd.PersistentFlags().VarP(failOnEnum, "fail-on", "o", "exit with return code 1 when output includes errors with this level or higher: "+failOnEnum.listOf())
-	cmd.PersistentFlags().VarP(langEnum, "lang", "l", "language for localized output: "+langEnum.listOf())
+	enumWithOptions(&cmd, newEnumValue([]string{LevelErr, LevelWarn}, "", &flags.failOn), "fail-on", "o", "exit with return code 1 when output includes errors with this level or higher")
+	enumWithOptions(&cmd, newEnumValue([]string{LangEn, LangRu}, LangDefault, &flags.lang), "lang", "l", "language for localized output")
 	cmd.PersistentFlags().StringVarP(&flags.errIgnoreFile, "err-ignore", "", "", "configuration file for ignoring errors")
 	cmd.PersistentFlags().StringVarP(&flags.warnIgnoreFile, "warn-ignore", "", "", "configuration file for ignoring warnings")
-	cmd.PersistentFlags().VarP(includeChecksEnum, "include-checks", "i", "comma-separated list of optional checks (see 'oasdiff checks')")
+	enumWithOptions(&cmd, newEnumSliceValue(checker.GetOptionalChecks(), nil, &flags.includeChecks), "include-checks", "i", "comma-separated list of optional checks (run 'oasdiff checks' to see options)")
 	cmd.PersistentFlags().IntVarP(&flags.deprecationDaysBeta, "deprecation-days-beta", "", checker.BetaDeprecationDays, "min days required between deprecating a beta resource and removing it")
 	cmd.PersistentFlags().IntVarP(&flags.deprecationDaysStable, "deprecation-days-stable", "", checker.StableDeprecationDays, "min days required between deprecating a stable resource and removing it")
 

--- a/internal/changelog.go
+++ b/internal/changelog.go
@@ -44,9 +44,15 @@ In 'composed' mode, base and revision can be a glob and oasdiff will compare mat
 		},
 	}
 
+	formatEnum := newEnumValue([]string{FormatYAML, FormatJSON, FormatText}, FormatText, &flags.format)
+	langEnum := newEnumValue([]string{LangEn, LangRu}, LangDefault, &flags.lang)
+
+	excludeElementsEnum := newEnumSliceValue(diff.ExcludeDiffOptions, nil, &flags.excludeElements)
+	includeChecksEnum := newEnumSliceValue(checker.GetOptionalChecks(), nil, &flags.includeChecks)
+
 	cmd.PersistentFlags().BoolVarP(&flags.composed, "composed", "c", false, "work in 'composed' mode, compare paths in all specs matching base and revision globs")
-	cmd.PersistentFlags().VarP(newEnumValue([]string{FormatYAML, FormatJSON, FormatText}, FormatText, &flags.format), "format", "f", "output format: yaml, json, or text")
-	cmd.PersistentFlags().VarP(newEnumSliceValue(diff.ExcludeDiffOptions, nil, &flags.excludeElements), "exclude-elements", "e", "comma-separated list of elements to exclude")
+	cmd.PersistentFlags().VarP(formatEnum, "format", "f", "output format: "+formatEnum.listOf())
+	cmd.PersistentFlags().VarP(excludeElementsEnum, "exclude-elements", "e", "comma-separated list of elements to exclude: "+excludeElementsEnum.listOf())
 	cmd.PersistentFlags().StringVarP(&flags.matchPath, "match-path", "p", "", "include only paths that match this regular expression")
 	cmd.PersistentFlags().StringVarP(&flags.filterExtension, "filter-extension", "", "", "exclude paths and operations with an OpenAPI Extension matching this regular expression")
 	cmd.PersistentFlags().IntVarP(&flags.circularReferenceCounter, "max-circular-dep", "", 5, "maximum allowed number of circular dependencies between objects in OpenAPI specs")
@@ -55,12 +61,13 @@ In 'composed' mode, base and revision can be a glob and oasdiff will compare mat
 	cmd.PersistentFlags().StringVarP(&flags.stripPrefixBase, "strip-prefix-base", "", "", "strip this prefix from paths in base-spec before comparison")
 	cmd.PersistentFlags().StringVarP(&flags.stripPrefixRevision, "strip-prefix-revision", "", "", "strip this prefix from paths in revised-spec before comparison")
 	cmd.PersistentFlags().BoolVarP(&flags.includePathParams, "include-path-params", "", false, "include path parameter names in endpoint matching")
-	cmd.PersistentFlags().VarP(newEnumValue([]string{LangEn, LangRu}, LangDefault, &flags.lang), "lang", "l", "language for localized output")
+	cmd.PersistentFlags().VarP(langEnum, "lang", "l", "language for localized output: "+langEnum.listOf())
 	cmd.PersistentFlags().StringVarP(&flags.errIgnoreFile, "err-ignore", "", "", "configuration file for ignoring errors")
 	cmd.PersistentFlags().StringVarP(&flags.warnIgnoreFile, "warn-ignore", "", "", "configuration file for ignoring warnings")
-	cmd.PersistentFlags().VarP(newEnumSliceValue(checker.GetOptionalChecks(), nil, &flags.includeChecks), "include-checks", "i", "comma-separated list of optional checks")
+	cmd.PersistentFlags().VarP(includeChecksEnum, "include-checks", "i", "comma-separated list of optional checks (see 'oasdiff checks')")
 	cmd.PersistentFlags().IntVarP(&flags.deprecationDaysBeta, "deprecation-days-beta", "", checker.BetaDeprecationDays, "min days required between deprecating a beta resource and removing it")
 	cmd.PersistentFlags().IntVarP(&flags.deprecationDaysStable, "deprecation-days-stable", "", checker.StableDeprecationDays, "min days required between deprecating a stable resource and removing it")
+
 	return &cmd
 }
 

--- a/internal/changelog.go
+++ b/internal/changelog.go
@@ -44,15 +44,9 @@ In 'composed' mode, base and revision can be a glob and oasdiff will compare mat
 		},
 	}
 
-	formatEnum := newEnumValue([]string{FormatYAML, FormatJSON, FormatText}, FormatText, &flags.format)
-	langEnum := newEnumValue([]string{LangEn, LangRu}, LangDefault, &flags.lang)
-
-	excludeElementsEnum := newEnumSliceValue(diff.ExcludeDiffOptions, nil, &flags.excludeElements)
-	includeChecksEnum := newEnumSliceValue(checker.GetOptionalChecks(), nil, &flags.includeChecks)
-
 	cmd.PersistentFlags().BoolVarP(&flags.composed, "composed", "c", false, "work in 'composed' mode, compare paths in all specs matching base and revision globs")
-	cmd.PersistentFlags().VarP(formatEnum, "format", "f", "output format: "+formatEnum.listOf())
-	cmd.PersistentFlags().VarP(excludeElementsEnum, "exclude-elements", "e", "comma-separated list of elements to exclude: "+excludeElementsEnum.listOf())
+	varWithOptions(&cmd, newEnumValue([]string{FormatYAML, FormatJSON, FormatText}, FormatText, &flags.format), "format", "f", "output format")
+	varWithOptions(&cmd, newEnumSliceValue(diff.ExcludeDiffOptions, nil, &flags.excludeElements), "exclude-elements", "e", "comma-separated list of elements to exclude")
 	cmd.PersistentFlags().StringVarP(&flags.matchPath, "match-path", "p", "", "include only paths that match this regular expression")
 	cmd.PersistentFlags().StringVarP(&flags.filterExtension, "filter-extension", "", "", "exclude paths and operations with an OpenAPI Extension matching this regular expression")
 	cmd.PersistentFlags().IntVarP(&flags.circularReferenceCounter, "max-circular-dep", "", 5, "maximum allowed number of circular dependencies between objects in OpenAPI specs")
@@ -61,14 +55,18 @@ In 'composed' mode, base and revision can be a glob and oasdiff will compare mat
 	cmd.PersistentFlags().StringVarP(&flags.stripPrefixBase, "strip-prefix-base", "", "", "strip this prefix from paths in base-spec before comparison")
 	cmd.PersistentFlags().StringVarP(&flags.stripPrefixRevision, "strip-prefix-revision", "", "", "strip this prefix from paths in revised-spec before comparison")
 	cmd.PersistentFlags().BoolVarP(&flags.includePathParams, "include-path-params", "", false, "include path parameter names in endpoint matching")
-	cmd.PersistentFlags().VarP(langEnum, "lang", "l", "language for localized output: "+langEnum.listOf())
+	varWithOptions(&cmd, newEnumValue([]string{LangEn, LangRu}, LangDefault, &flags.lang), "lang", "l", "language for localized output")
 	cmd.PersistentFlags().StringVarP(&flags.errIgnoreFile, "err-ignore", "", "", "configuration file for ignoring errors")
 	cmd.PersistentFlags().StringVarP(&flags.warnIgnoreFile, "warn-ignore", "", "", "configuration file for ignoring warnings")
-	cmd.PersistentFlags().VarP(includeChecksEnum, "include-checks", "i", "comma-separated list of optional checks (see 'oasdiff checks')")
+	varWithOptions(&cmd, newEnumSliceValue(checker.GetOptionalChecks(), nil, &flags.includeChecks), "include-checks", "i", "comma-separated list of optional checks (see 'oasdiff checks')")
 	cmd.PersistentFlags().IntVarP(&flags.deprecationDaysBeta, "deprecation-days-beta", "", checker.BetaDeprecationDays, "min days required between deprecating a beta resource and removing it")
 	cmd.PersistentFlags().IntVarP(&flags.deprecationDaysStable, "deprecation-days-stable", "", checker.StableDeprecationDays, "min days required between deprecating a stable resource and removing it")
 
 	return &cmd
+}
+
+func varWithOptions(cmd *cobra.Command, value enumVal, name, shorthand, usage string) {
+	cmd.PersistentFlags().VarP(value, name, shorthand, usage+": "+value.listOf())
 }
 
 func runChangelog(flags *ChangelogFlags, stdout io.Writer) (bool, *ReturnError) {

--- a/internal/changelog.go
+++ b/internal/changelog.go
@@ -45,8 +45,8 @@ In 'composed' mode, base and revision can be a glob and oasdiff will compare mat
 	}
 
 	cmd.PersistentFlags().BoolVarP(&flags.composed, "composed", "c", false, "work in 'composed' mode, compare paths in all specs matching base and revision globs")
-	varWithOptions(&cmd, newEnumValue([]string{FormatYAML, FormatJSON, FormatText}, FormatText, &flags.format), "format", "f", "output format")
-	varWithOptions(&cmd, newEnumSliceValue(diff.ExcludeDiffOptions, nil, &flags.excludeElements), "exclude-elements", "e", "comma-separated list of elements to exclude")
+	enumWithOptions(&cmd, newEnumValue([]string{FormatYAML, FormatJSON, FormatText}, FormatText, &flags.format), "format", "f", "output format")
+	enumWithOptions(&cmd, newEnumSliceValue(diff.ExcludeDiffOptions, nil, &flags.excludeElements), "exclude-elements", "e", "comma-separated list of elements to exclude")
 	cmd.PersistentFlags().StringVarP(&flags.matchPath, "match-path", "p", "", "include only paths that match this regular expression")
 	cmd.PersistentFlags().StringVarP(&flags.filterExtension, "filter-extension", "", "", "exclude paths and operations with an OpenAPI Extension matching this regular expression")
 	cmd.PersistentFlags().IntVarP(&flags.circularReferenceCounter, "max-circular-dep", "", 5, "maximum allowed number of circular dependencies between objects in OpenAPI specs")
@@ -55,17 +55,17 @@ In 'composed' mode, base and revision can be a glob and oasdiff will compare mat
 	cmd.PersistentFlags().StringVarP(&flags.stripPrefixBase, "strip-prefix-base", "", "", "strip this prefix from paths in base-spec before comparison")
 	cmd.PersistentFlags().StringVarP(&flags.stripPrefixRevision, "strip-prefix-revision", "", "", "strip this prefix from paths in revised-spec before comparison")
 	cmd.PersistentFlags().BoolVarP(&flags.includePathParams, "include-path-params", "", false, "include path parameter names in endpoint matching")
-	varWithOptions(&cmd, newEnumValue([]string{LangEn, LangRu}, LangDefault, &flags.lang), "lang", "l", "language for localized output")
+	enumWithOptions(&cmd, newEnumValue([]string{LangEn, LangRu}, LangDefault, &flags.lang), "lang", "l", "language for localized output")
 	cmd.PersistentFlags().StringVarP(&flags.errIgnoreFile, "err-ignore", "", "", "configuration file for ignoring errors")
 	cmd.PersistentFlags().StringVarP(&flags.warnIgnoreFile, "warn-ignore", "", "", "configuration file for ignoring warnings")
-	varWithOptions(&cmd, newEnumSliceValue(checker.GetOptionalChecks(), nil, &flags.includeChecks), "include-checks", "i", "comma-separated list of optional checks (see 'oasdiff checks')")
+	cmd.PersistentFlags().VarP(newEnumSliceValue(checker.GetOptionalChecks(), nil, &flags.includeChecks), "include-checks", "i", "comma-separated list of optional checks (run 'oasdiff checks' to see options)")
 	cmd.PersistentFlags().IntVarP(&flags.deprecationDaysBeta, "deprecation-days-beta", "", checker.BetaDeprecationDays, "min days required between deprecating a beta resource and removing it")
 	cmd.PersistentFlags().IntVarP(&flags.deprecationDaysStable, "deprecation-days-stable", "", checker.StableDeprecationDays, "min days required between deprecating a stable resource and removing it")
 
 	return &cmd
 }
 
-func varWithOptions(cmd *cobra.Command, value enumVal, name, shorthand, usage string) {
+func enumWithOptions(cmd *cobra.Command, value enumVal, name, shorthand, usage string) {
 	cmd.PersistentFlags().VarP(value, name, shorthand, usage+": "+value.listOf())
 }
 

--- a/internal/checks.go
+++ b/internal/checks.go
@@ -34,7 +34,7 @@ func getChecksCmd() *cobra.Command {
 
 func runChecks(stdout io.Writer) *ReturnError {
 	if err := printYAML(stdout, checker.GetOptionalChecks()); err != nil {
-		return getErrFailedPrint("optional breaking changes checks", err)
+		return getErrFailedPrint("optional checks YAML", err)
 	}
 	return nil
 }

--- a/internal/checks.go
+++ b/internal/checks.go
@@ -1,0 +1,33 @@
+package internal
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+	"github.com/tufin/oasdiff/checker"
+)
+
+func getChecksCmd() *cobra.Command {
+
+	cmd := cobra.Command{
+		Use:   "checks [flags]",
+		Short: "Display optional breaking changes checks",
+		Long:  `Display optional breaking changes checks`,
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			// by now flags have been parsed successfully so we don't need to show usage on any errors
+			cmd.Root().SilenceUsage = true
+
+			runChecks(cmd.OutOrStdout())
+
+			return nil
+		},
+	}
+
+	return &cmd
+}
+
+func runChecks(stdout io.Writer) {
+	printYAML(stdout, checker.GetOptionalChecks())
+}

--- a/internal/checks.go
+++ b/internal/checks.go
@@ -19,7 +19,10 @@ func getChecksCmd() *cobra.Command {
 			// by now flags have been parsed successfully so we don't need to show usage on any errors
 			cmd.Root().SilenceUsage = true
 
-			runChecks(cmd.OutOrStdout())
+			if err := runChecks(cmd.OutOrStdout()); err != nil {
+				setReturnValue(cmd, err.Code)
+				return err
+			}
 
 			return nil
 		},
@@ -28,6 +31,9 @@ func getChecksCmd() *cobra.Command {
 	return &cmd
 }
 
-func runChecks(stdout io.Writer) {
-	printYAML(stdout, checker.GetOptionalChecks())
+func runChecks(stdout io.Writer) *ReturnError {
+	if err := printYAML(stdout, checker.GetOptionalChecks()); err != nil {
+		return getErrFailedPrint("optional breaking changes checks", err)
+	}
+	return nil
 }

--- a/internal/checks.go
+++ b/internal/checks.go
@@ -11,8 +11,8 @@ func getChecksCmd() *cobra.Command {
 
 	cmd := cobra.Command{
 		Use:   "checks [flags]",
-		Short: "Display optional breaking changes checks",
-		Long:  `Display optional breaking changes checks`,
+		Short: "Display optional checks",
+		Long:  `Display optional checks`,
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 

--- a/internal/checks.go
+++ b/internal/checks.go
@@ -10,10 +10,11 @@ import (
 func getChecksCmd() *cobra.Command {
 
 	cmd := cobra.Command{
-		Use:   "checks [flags]",
-		Short: "Display optional checks",
-		Long:  `Display optional checks`,
-		Args:  cobra.ExactArgs(0),
+		Use:               "checks [flags]",
+		Short:             "Display optional checks",
+		Long:              `Display optional checks that can be passed to 'breaking' and 'changelog' with the 'include-checks' flag`,
+		Args:              cobra.NoArgs,
+		ValidArgsFunction: cobra.NoFileCompletions, // see https://github.com/spf13/cobra/issues/1969
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			// by now flags have been parsed successfully so we don't need to show usage on any errors

--- a/internal/diff.go
+++ b/internal/diff.go
@@ -45,10 +45,8 @@ In 'composed' mode, base and revision can be a glob and oasdiff will compare mat
 		},
 	}
 
-	formatEnum := newEnumValue([]string{FormatYAML, FormatJSON, FormatText, FormatHTML}, FormatYAML, &flags.format)
-
 	cmd.PersistentFlags().BoolVarP(&flags.composed, "composed", "c", false, "work in 'composed' mode, compare paths in all specs matching base and revision globs")
-	cmd.PersistentFlags().VarP(formatEnum, "format", "f", "output format: "+formatEnum.listOf())
+	enumWithOptions(&cmd, newEnumValue([]string{FormatYAML, FormatJSON, FormatText, FormatHTML}, FormatYAML, &flags.format), "format", "f", "output format")
 	cmd.PersistentFlags().VarP(newEnumSliceValue(diff.ExcludeDiffOptions, nil, &flags.excludeElements), "exclude-elements", "e", "comma-separated list of elements to exclude")
 	cmd.PersistentFlags().StringVarP(&flags.matchPath, "match-path", "p", "", "include only paths that match this regular expression")
 	cmd.PersistentFlags().StringVarP(&flags.filterExtension, "filter-extension", "", "", "exclude paths and operations with an OpenAPI Extension matching this regular expression")

--- a/internal/diff.go
+++ b/internal/diff.go
@@ -45,8 +45,10 @@ In 'composed' mode, base and revision can be a glob and oasdiff will compare mat
 		},
 	}
 
+	formatEnum := newEnumValue([]string{FormatYAML, FormatJSON, FormatText, FormatHTML}, FormatYAML, &flags.format)
+
 	cmd.PersistentFlags().BoolVarP(&flags.composed, "composed", "c", false, "work in 'composed' mode, compare paths in all specs matching base and revision globs")
-	cmd.PersistentFlags().VarP(newEnumValue([]string{FormatYAML, FormatJSON, FormatText, FormatHTML}, FormatYAML, &flags.format), "format", "f", "output format: yaml, json, text or html")
+	cmd.PersistentFlags().VarP(formatEnum, "format", "f", "output format: "+formatEnum.listOf())
 	cmd.PersistentFlags().VarP(newEnumSliceValue(diff.ExcludeDiffOptions, nil, &flags.excludeElements), "exclude-elements", "e", "comma-separated list of elements to exclude")
 	cmd.PersistentFlags().StringVarP(&flags.matchPath, "match-path", "p", "", "include only paths that match this regular expression")
 	cmd.PersistentFlags().StringVarP(&flags.filterExtension, "filter-extension", "", "", "exclude paths and operations with an OpenAPI Extension matching this regular expression")

--- a/internal/diff.go
+++ b/internal/diff.go
@@ -20,7 +20,7 @@ func getDiffCmd() *cobra.Command {
 		Short: "Generate a diff report",
 		Long: `Generate a diff report between base and revision specs.
 Base and revision can be a path to a file or a URL.
-In 'composed' mode, base and revision can be a glob and oasdiff will compare mathcing endpoints between the two sets of files.
+In 'composed' mode, base and revision can be a glob and oasdiff will compare matching endpoints between the two sets of files.
 `,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/enum.go
+++ b/internal/enum.go
@@ -32,24 +32,24 @@ func (v *enumValue) Set(s string) error {
 		*v.value = s
 		return nil
 	}
-	return fmt.Errorf("must be %s", listOf(v.allowedValues))
+	return fmt.Errorf("%s is not one of the allowed values: %s", s, v.listOf())
 }
 
-func listOf(options []string) string {
-	l := len(options)
-	if l == 0 {
-		return "empty"
+func (v *enumValue) listOf() string {
+	l := len(v.allowedValues)
+	switch l {
+	case 0:
+		return "no options available"
+	case 1:
+		return v.allowedValues[0]
+	case 2:
+		return v.allowedValues[0] + " or " + v.allowedValues[1]
+	default:
+		return strings.Join(v.allowedValues[:l-1], ", ") + ", or " + v.allowedValues[l-1]
 	}
-	if l == 1 {
-		return options[0]
-	}
-	if l == 2 {
-		return options[0] + " or " + options[1]
-	}
-	return strings.Join(options[:l-1], ", ") + ", or " + options[l-1]
 }
 
 // Type is only used in help text
-func (f *enumValue) Type() string {
+func (v *enumValue) Type() string {
 	return "string"
 }

--- a/internal/enum.go
+++ b/internal/enum.go
@@ -7,6 +7,13 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+type enumVal interface {
+	Set(s string) error
+	String() string
+	Type() string
+	listOf() string
+}
+
 // enumValue is like stringValue with allowed values
 type enumValue struct {
 	value         *string

--- a/internal/run.go
+++ b/internal/run.go
@@ -28,6 +28,7 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 		getSummaryCmd(),
 		getBreakingChangesCmd(),
 		getChangelogCmd(),
+		getChecksCmd(),
 	)
 
 	return strategy()(rootCmd)

--- a/internal/summary.go
+++ b/internal/summary.go
@@ -41,10 +41,8 @@ In 'composed' mode, base and revision can be a glob and oasdiff will compare mat
 		},
 	}
 
-	formatEnum := newEnumValue([]string{FormatYAML, FormatJSON}, FormatYAML, &flags.format)
-
 	cmd.PersistentFlags().BoolVarP(&flags.composed, "composed", "c", false, "work in 'composed' mode, compare paths in all specs matching base and revision globs")
-	cmd.PersistentFlags().VarP(formatEnum, "format", "f", "output format: "+formatEnum.listOf())
+	enumWithOptions(&cmd, newEnumValue([]string{FormatYAML, FormatJSON}, FormatYAML, &flags.format), "format", "f", "output format")
 	cmd.PersistentFlags().VarP(newEnumSliceValue(diff.ExcludeDiffOptions, nil, &flags.excludeElements), "exclude-elements", "e", "comma-separated list of elements to exclude")
 	cmd.PersistentFlags().StringVarP(&flags.matchPath, "match-path", "p", "", "include only paths that match this regular expression")
 	cmd.PersistentFlags().StringVarP(&flags.filterExtension, "filter-extension", "", "", "exclude paths and operations with an OpenAPI Extension matching this regular expression")

--- a/internal/summary.go
+++ b/internal/summary.go
@@ -41,8 +41,10 @@ In 'composed' mode, base and revision can be a glob and oasdiff will compare mat
 		},
 	}
 
+	formatEnum := newEnumValue([]string{FormatYAML, FormatJSON}, FormatYAML, &flags.format)
+
 	cmd.PersistentFlags().BoolVarP(&flags.composed, "composed", "c", false, "work in 'composed' mode, compare paths in all specs matching base and revision globs")
-	cmd.PersistentFlags().VarP(newEnumValue([]string{FormatYAML, FormatJSON}, FormatYAML, &flags.format), "format", "f", "output format: yaml or json")
+	cmd.PersistentFlags().VarP(formatEnum, "format", "f", "output format: "+formatEnum.listOf())
 	cmd.PersistentFlags().VarP(newEnumSliceValue(diff.ExcludeDiffOptions, nil, &flags.excludeElements), "exclude-elements", "e", "comma-separated list of elements to exclude")
 	cmd.PersistentFlags().StringVarP(&flags.matchPath, "match-path", "p", "", "include only paths that match this regular expression")
 	cmd.PersistentFlags().StringVarP(&flags.filterExtension, "filter-extension", "", "", "exclude paths and operations with an OpenAPI Extension matching this regular expression")
@@ -89,5 +91,4 @@ func outputSummary(stdout io.Writer, diffReport *diff.Diff, format string) *Retu
 	}
 
 	return nil
-
 }

--- a/internal/summary.go
+++ b/internal/summary.go
@@ -16,7 +16,7 @@ func getSummaryCmd() *cobra.Command {
 		Short: "Generate a diff summary",
 		Long: `Display a summary of changes between base and revision specs.
 Base and revision can be a path to a file or a URL.
-In 'composed' mode, base and revision can be a glob and oasdiff will compare mathcing endpoints between the two sets of files.
+In 'composed' mode, base and revision can be a glob and oasdiff will compare matching endpoints between the two sets of files.
 `,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Improve cmd-line help for enum values.
Before this PR users needed to guess the possible values for enum flags like:
- exclude-elements
- fail-on
- format
- include-checks
- lang

This PR adds the possible values to the cmd-line help, like this:
```
  -e, --exclude-elements csv           comma-separated list of elements to exclude: examples, description, endpoints, title, or summary
```

In the case of `--include-checks` there are many possible values so instead of adding it to the help, I added a new command `oasdiff checks` to display optional breaking-changes checks.
