### PR TITLE
Issue 430

### DIFF
--- a/flatten/merge_allof.go
+++ b/flatten/merge_allof.go
@@ -98,15 +98,12 @@ func Merge(schema openapi3.SchemaRef) (*openapi3.Schema, error) {
 
 // remove fields while maintaining an equivalent schema.
 func pruneFields(schema *openapi3.SchemaRef) {
-
-	prunedOneOf := openapi3.SchemaRefs{}
-	for _, sref := range schema.Value.OneOf {
-		if sref.Value != schema.Value {
-			prunedOneOf = append(prunedOneOf, sref)
-		}
+	if len(schema.Value.OneOf) == 1 && schema.Value.OneOf[0].Value == schema.Value {
+		schema.Value.OneOf = nil
 	}
-
-	schema.Value.OneOf = prunedOneOf
+	if len(schema.Value.AnyOf) == 1 && schema.Value.AnyOf[0].Value == schema.Value {
+		schema.Value.AnyOf = nil
+	}
 }
 
 func mergeCircularAllOf(state *state, baseSchemaRef *openapi3.SchemaRef) error {

--- a/flatten/merge_allof.go
+++ b/flatten/merge_allof.go
@@ -90,9 +90,23 @@ func Merge(schema openapi3.SchemaRef) (*openapi3.Schema, error) {
 		if err != nil {
 			return nil, err
 		}
+		pruneFields(schema)
 	}
 
 	return result.Value, nil
+}
+
+// remove fields while maintaining an equivalent schema.
+func pruneFields(schema *openapi3.SchemaRef) {
+
+	prunedOneOf := openapi3.SchemaRefs{}
+	for _, sref := range schema.Value.OneOf {
+		if sref.Value != schema.Value {
+			prunedOneOf = append(prunedOneOf, sref)
+		}
+	}
+
+	schema.Value.OneOf = prunedOneOf
 }
 
 func mergeCircularAllOf(state *state, baseSchemaRef *openapi3.SchemaRef) error {

--- a/flatten/merge_allof.go
+++ b/flatten/merge_allof.go
@@ -630,8 +630,20 @@ func resolveEnum(values [][]interface{}) ([]interface{}, error) {
 }
 
 func resolvePattern(values []string) string {
+	patterns := []string{}
+	for _, v := range values {
+		if len(v) > 0 {
+			patterns = append(patterns, v)
+		}
+	}
+	if len(patterns) == 0 {
+		return ""
+	}
+	if len(patterns) == 1 {
+		return patterns[0]
+	}
 	var pattern strings.Builder
-	for _, p := range values {
+	for _, p := range patterns {
 		if len(p) > 0 {
 			if !isPatternResolved(p) {
 				pattern.WriteString(fmt.Sprintf("(?=%s)", p))

--- a/flatten/merge_allof_test.go
+++ b/flatten/merge_allof_test.go
@@ -1800,9 +1800,7 @@ func TestMerge_CircularAllOf(t *testing.T) {
 	merged, err := flatten.Merge(*doc.Components.Schemas["AWSEnvironmentSettings"])
 	require.NoError(t, err)
 	require.Empty(t, merged.AllOf)
-
-	require.Equal(t, "#/components/schemas/AWSEnvironmentSettings", merged.OneOf[0].Ref)
-	require.Equal(t, &merged, &merged.OneOf[0].Value)
+	require.Empty(t, merged.OneOf)
 
 	require.Equal(t, "string", merged.Properties["serviceEndpoints"].Value.Type)
 	require.Equal(t, "string", merged.Properties["region"].Value.Type)

--- a/flatten/merge_allof_test.go
+++ b/flatten/merge_allof_test.go
@@ -1806,15 +1806,40 @@ func TestMerge_CircularAllOf(t *testing.T) {
 	require.Equal(t, "string", merged.Properties["region"].Value.Type)
 }
 
-func TestMerge_PruneOneOf(t *testing.T) {
+// A single OneOf field is pruned if it references it's parent schema
+func TestMerge_OneOfIsPruned(t *testing.T) {
 	doc := loadSpec(t, "testdata/circular2.yaml")
-	merged, err := flatten.Merge(*doc.Components.Schemas["AWSEnvironmentSettings"])
+	merged, err := flatten.Merge(*doc.Components.Schemas["OneOf_Is_Pruned_B"])
+	require.NoError(t, err)
+	require.Empty(t, merged.AllOf)
+	require.Empty(t, merged.OneOf)
+}
+
+// A single OneOf field is not pruned if it does not reference it's parent schema
+func TestMerge_OneOfIsNotPruned(t *testing.T) {
+	doc := loadSpec(t, "testdata/circular2.yaml")
+	merged, err := flatten.Merge(*doc.Components.Schemas["OneOf_Is_Not_Pruned_B"])
 	require.NoError(t, err)
 	require.Empty(t, merged.AllOf)
 	require.NotEmpty(t, merged.OneOf)
-	require.Equal(t, "string", merged.OneOf[0].Value.Properties["prop1"].Value.Type)
-	require.Equal(t, "string", merged.Properties["serviceEndpoints"].Value.Type)
-	require.Equal(t, "string", merged.Properties["region"].Value.Type)
+}
+
+// A single AnyOf field is pruned if it references it's parent schema
+func TestMerge_AnyOfIsPruned(t *testing.T) {
+	doc := loadSpec(t, "testdata/circular2.yaml")
+	merged, err := flatten.Merge(*doc.Components.Schemas["AnyOf_Is_Pruned_B"])
+	require.NoError(t, err)
+	require.Empty(t, merged.AllOf)
+	require.Empty(t, merged.AnyOf)
+}
+
+// A single AnyOf field is not pruned if it does not reference it's parent schema
+func TestMerge_AnyOfIsNotPruned(t *testing.T) {
+	doc := loadSpec(t, "testdata/circular2.yaml")
+	merged, err := flatten.Merge(*doc.Components.Schemas["AnyOf_Is_Not_Pruned_B"])
+	require.NoError(t, err)
+	require.Empty(t, merged.AllOf)
+	require.NotEmpty(t, merged.AnyOf)
 }
 
 func loadSpec(t *testing.T, path string) *openapi3.T {

--- a/flatten/merge_allof_test.go
+++ b/flatten/merge_allof_test.go
@@ -1715,8 +1715,30 @@ func TestMerge_AdditionalProperties_True(t *testing.T) {
 }
 
 func TestMergeAllOf_Pattern(t *testing.T) {
-
 	merged, err := flatten.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				Pattern: "abc",
+			}})
+	require.NoError(t, err)
+	require.Equal(t, "abc", merged.Pattern)
+
+	merged, err = flatten.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{
+						Value: &openapi3.Schema{
+							Type:    "object",
+							Pattern: "abc",
+						},
+					},
+				},
+			}})
+	require.NoError(t, err)
+	require.Equal(t, "abc", merged.Pattern)
+
+	merged, err = flatten.Merge(
 		openapi3.SchemaRef{
 			Value: &openapi3.Schema{
 				AllOf: openapi3.SchemaRefs{

--- a/flatten/merge_allof_test.go
+++ b/flatten/merge_allof_test.go
@@ -1806,6 +1806,17 @@ func TestMerge_CircularAllOf(t *testing.T) {
 	require.Equal(t, "string", merged.Properties["region"].Value.Type)
 }
 
+func TestMerge_PruneOneOf(t *testing.T) {
+	doc := loadSpec(t, "testdata/circular2.yaml")
+	merged, err := flatten.Merge(*doc.Components.Schemas["AWSEnvironmentSettings"])
+	require.NoError(t, err)
+	require.Empty(t, merged.AllOf)
+	require.NotEmpty(t, merged.OneOf)
+	require.Equal(t, "string", merged.OneOf[0].Value.Properties["prop1"].Value.Type)
+	require.Equal(t, "string", merged.Properties["serviceEndpoints"].Value.Type)
+	require.Equal(t, "string", merged.Properties["region"].Value.Type)
+}
+
 func loadSpec(t *testing.T, path string) *openapi3.T {
 	ctx := context.Background()
 	sl := openapi3.NewLoader()

--- a/flatten/testdata/circular2.yaml
+++ b/flatten/testdata/circular2.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.0
+info:
+  title: Circular Reference Example
+  version: 1.0.0
+paths:
+  /sample:
+    put:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CloudEnvironmentSettings'
+      responses:
+        '200':
+          description: Ok
+          
+components:
+  schemas:
+    CloudEnvironmentSettings:
+      type: object
+      oneOf:
+        - type: object
+          properties:
+            prop1:
+              type: string
+      properties:
+        serviceEndpoints:
+          type: string
+      description: a
+
+    AWSEnvironmentSettings:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/CloudEnvironmentSettings'
+        - type: object
+          properties:
+            region:
+              type: string
+      description: b

--- a/flatten/testdata/circular2.yaml
+++ b/flatten/testdata/circular2.yaml
@@ -10,31 +10,49 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CloudEnvironmentSettings'
+              $ref: '#/components/schemas/OneOf_Is_Pruned_A'
       responses:
         '200':
           description: Ok
           
 components:
   schemas:
-    CloudEnvironmentSettings:
+    OneOf_Is_Pruned_A:
       type: object
-      oneOf:
-        - type: object
-          properties:
-            prop1:
-              type: string
-      properties:
-        serviceEndpoints:
-          type: string
-      description: a
-
-    AWSEnvironmentSettings:
+      oneOf: 
+        - $ref: '#/components/schemas/OneOf_Is_Pruned_B'
+    
+    OneOf_Is_Pruned_B:
       type: object
       allOf:
-        - $ref: '#/components/schemas/CloudEnvironmentSettings'
+        - $ref: '#/components/schemas/OneOf_Is_Pruned_A'
+
+    OneOf_Is_Not_Pruned_A:
+      type: object
+      oneOf: 
         - type: object
-          properties:
-            region:
-              type: string
-      description: b
+    
+    OneOf_Is_Not_Pruned_B:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/OneOf_Is_Not_Pruned_A'  
+
+    AnyOf_Is_Pruned_A:
+      type: object
+      anyOf: 
+        - $ref: '#/components/schemas/AnyOf_Is_Pruned_B'
+    
+    AnyOf_Is_Pruned_B:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/AnyOf_Is_Pruned_A'
+
+    AnyOf_Is_Not_Pruned_A:
+      type: object
+      anyOf: 
+        - type: object
+    
+    AnyOf_Is_Not_Pruned_B:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/AnyOf_Is_Not_Pruned_A'        


### PR DESCRIPTION
issue: #430

- fix flattening of Pattern field
- If the schema contains a single OneOf or AnyOf field that references itself, then that field is removed

this PR fixes the issue of wrongly detecting changes, except for when BaseClass gets deleted. It's focused on dealing with specific situations involving AnyOf or OneOf fields that can be removed while maintaining an equivalent schema.
If you encounter similar problems with flattened circular schemas, please open an issue about it. 


The output of running the diff command after the fix:
```
components:
    schemas:
        deleted:
            - BaseClass
```