### PR TITLE
Change sample sunset date to self-explain that it's YYYY-MM-DD format

### DIFF
--- a/API-DEPRECATION.md
+++ b/API-DEPRECATION.md
@@ -11,7 +11,7 @@ Oasdiff allows you to gracefully remove a resource without getting a breaking ch
    /api/test:
     get:
      deprecated: true
-     x-sunset: "2022-08-10"
+     x-sunset: "2022-12-31"
    ```
 2. At the sunset date or anytime later, the resource can be removed without triggering a breaking change error. An earlier removal will be considered a breaking change.
 


### PR DESCRIPTION
Minor change to make it obvious which part is the month and which is a day, took me a while to dig into this by finding out how it's parsed and what format `civil` uses, this way it should be obvious at first glance.