### PR TITLE
flatten command - fix wrong Title and Description values

### DIFF
--- a/ALLOF.md
+++ b/ALLOF.md
@@ -32,7 +32,6 @@ oasdiff flatten data/allof/simple.yaml
 
 The following schema fields are not merged:
 - Extensions
-- Default
 - Example
 - ExternalDocs
 - AllowEmptyValue

--- a/flatten/merge_allof.go
+++ b/flatten/merge_allof.go
@@ -299,8 +299,8 @@ func flattenSchemas(state *state, result *openapi3.SchemaRef, schemas []*openapi
 	collection := collect(schemas)
 	var err error
 
-	result.Value.Title = collection.Title[0]
-	result.Value.Description = collection.Description[0]
+	result.Value.Title = firstNonEmptyString(collection.Title)
+	result.Value.Description = firstNonEmptyString(collection.Description)
 	result.Value = resolveNumberRange(result.Value, &collection)
 	result.Value.MinLength = findMaxValue(collection.MinLength)
 	result.Value.MaxLength = findMinValue(collection.MaxLength)
@@ -1056,4 +1056,14 @@ func resolveDefault(collection *SchemaCollection) (interface{}, error) {
 		}
 	}
 	return first, nil
+}
+
+func firstNonEmptyString(values []string) string {
+	if len(values) == 1 {
+		return values[0]
+	}
+	if len(values[0]) > 0 {
+		return values[0]
+	}
+	return values[1]
 }

--- a/flatten/merge_allof.go
+++ b/flatten/merge_allof.go
@@ -299,8 +299,8 @@ func flattenSchemas(state *state, result *openapi3.SchemaRef, schemas []*openapi
 	collection := collect(schemas)
 	var err error
 
-	result.Value.Title = firstNonEmptyString(collection.Title)
-	result.Value.Description = firstNonEmptyString(collection.Description)
+	result.Value.Title = firstOrSecondNonEmpty(collection.Title)
+	result.Value.Description = firstOrSecondNonEmpty(collection.Description)
 	result.Value = resolveNumberRange(result.Value, &collection)
 	result.Value.MinLength = findMaxValue(collection.MinLength)
 	result.Value.MaxLength = findMinValue(collection.MaxLength)
@@ -1058,11 +1058,16 @@ func resolveDefault(collection *SchemaCollection) (interface{}, error) {
 	return first, nil
 }
 
-func firstNonEmptyString(values []string) string {
+// FirstOrSecondNonEmpty returns the first non-empty string from the first two elements of a slice.
+// If both are empty or the slice is empty, it returns an empty string.
+func firstOrSecondNonEmpty(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
 	if len(values) == 1 {
 		return values[0]
 	}
-	if len(values[0]) > 0 {
+	if values[0] != "" {
 		return values[0]
 	}
 	return values[1]

--- a/flatten/merge_allof_test.go
+++ b/flatten/merge_allof_test.go
@@ -1172,6 +1172,27 @@ func TestMerge_Description(t *testing.T) {
 			}})
 	require.NoError(t, err)
 	require.Equal(t, "desc0", merged.Description)
+
+	merged, err = flatten.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{
+						Value: &openapi3.Schema{
+							Type:        "object",
+							Description: "desc1",
+						},
+					},
+					&openapi3.SchemaRef{
+						Value: &openapi3.Schema{
+							Type:        "object",
+							Description: "desc2",
+						},
+					},
+				},
+			}})
+	require.NoError(t, err)
+	require.Equal(t, "desc1", merged.Description)
 }
 
 // non-conflicting types are merged successfully
@@ -1253,6 +1274,27 @@ func TestMerge_Title(t *testing.T) {
 			}})
 	require.NoError(t, err)
 	require.Equal(t, "base schema", merged.Title)
+
+	merged, err = flatten.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{
+						Value: &openapi3.Schema{
+							Type:  "object",
+							Title: "first",
+						},
+					},
+					&openapi3.SchemaRef{
+						Value: &openapi3.Schema{
+							Type:  "object",
+							Title: "second",
+						},
+					},
+				},
+			}})
+	require.NoError(t, err)
+	require.Equal(t, "first", merged.Title)
 }
 
 // merge conflicting integer formats


### PR DESCRIPTION
fix for the problem mentioned in: #463 

flattening of Title and Description:

The Title and Description fields are set to the value specified in the base schema. 
If the base schema does not contain any values, the first value from the 'allOf' property is used instead.