### PR TITLE
flatten command - prune oneOf field on circular references

### DIFF
--- a/flatten/merge_allof.go
+++ b/flatten/merge_allof.go
@@ -117,12 +117,13 @@ func pruneAnyOf(schema *openapi3.SchemaRef) {
 	}
 }
 
-func pruneOneOf(state *state, merged *openapi3.SchemaRef, allOf openapi3.SchemaRefs) {
-	if len(merged.Value.OneOf) == 1 && merged.Value.OneOf[0].Value == merged.Value {
-		merged.Value.OneOf = nil
-		return
-	}
-
+// pruneCircularOneOfInHierarchy prunes the 'oneOf' field from a merged schema when specific conditions are met.
+// Pruning criteria:
+// - The unmerged schema is a child of another parent schema, through the oneOf field.
+// - The unmerged schema contains an 'allOf' field with a circular reference to the parent schema.
+// - The merged parent and the merged child schemas contain an identical oneOf field.
+// - The merged parent schema contains a non-empty propertyName discriminator field.
+func pruneCircularOneOfInHierarchy(state *state, merged *openapi3.SchemaRef, allOf openapi3.SchemaRefs) {
 	for _, allOfSchema := range allOf {
 		isCircular := state.refs[allOfSchema.Ref]
 		if !isCircular {
@@ -141,6 +142,14 @@ func pruneOneOf(state *state, merged *openapi3.SchemaRef, allOf openapi3.SchemaR
 			continue
 		}
 
+		if allOfSchema.Value.Discriminator == nil || allOfSchema.Value.Discriminator.PropertyName == "" {
+			continue
+		}
+
+		if len(allOfSchema.Value.OneOf) != len(merged.Value.OneOf) {
+			continue
+		}
+
 		// check if oneOf field of allOfSchema matches the oneOf field of merged
 		mismatchFound := false
 		for i, of := range allOfSchema.Value.OneOf {
@@ -155,6 +164,14 @@ func pruneOneOf(state *state, merged *openapi3.SchemaRef, allOf openapi3.SchemaR
 			break
 		}
 	}
+}
+
+func pruneOneOf(state *state, merged *openapi3.SchemaRef, allOf openapi3.SchemaRefs) {
+	if len(merged.Value.OneOf) == 1 && merged.Value.OneOf[0].Value == merged.Value {
+		merged.Value.OneOf = nil
+		return
+	}
+	pruneCircularOneOfInHierarchy(state, merged, allOf)
 }
 
 // Merge replaces objects under AllOf with a flattened equivalent
@@ -191,6 +208,7 @@ func mergeInternal(state *state, base *openapi3.SchemaRef) (*openapi3.SchemaRef,
 	result.Value.MultipleOf = base.Value.MultipleOf
 	result.Value.MinLength = base.Value.MinLength
 	result.Value.Default = base.Value.Default
+	result.Value.Discriminator = base.Value.Discriminator
 	if base.Value.MaxLength != nil {
 		result.Value.MaxLength = openapi3.Uint64Ptr(*base.Value.MaxLength)
 	}

--- a/flatten/merge_allof_test.go
+++ b/flatten/merge_allof_test.go
@@ -1860,6 +1860,11 @@ func TestMerge_ComplexOneOfIsNotPruned(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, merged.OneOf)
 	require.Len(t, merged.OneOf, 2)
+
+	merged, err = flatten.Merge(*doc.Components.Schemas["SchemaWithOneOf"])
+	require.NoError(t, err)
+	require.NotEmpty(t, merged.OneOf)
+	require.Len(t, merged.OneOf, 2)
 }
 
 func loadSpec(t *testing.T, path string) *openapi3.T {

--- a/flatten/merge_allof_test.go
+++ b/flatten/merge_allof_test.go
@@ -1842,6 +1842,26 @@ func TestMerge_AnyOfIsNotPruned(t *testing.T) {
 	require.NotEmpty(t, merged.AnyOf)
 }
 
+func TestMerge_ComplexOneOfIsPruned(t *testing.T) {
+	doc := loadSpec(t, "testdata/prune-oneof.yaml")
+	merged, err := flatten.Merge(*doc.Components.Schemas["SchemaWithWithoutOneOf"])
+	require.NoError(t, err)
+	require.Empty(t, merged.OneOf)
+}
+
+func TestMerge_ComplexOneOfIsNotPruned(t *testing.T) {
+	doc := loadSpec(t, "testdata/prune-oneof.yaml")
+	merged, err := flatten.Merge(*doc.Components.Schemas["ThirdSchema"])
+	require.NoError(t, err)
+	require.NotEmpty(t, merged.OneOf)
+	require.Len(t, merged.OneOf, 2)
+
+	merged, err = flatten.Merge(*doc.Components.Schemas["ComplexSchema"])
+	require.NoError(t, err)
+	require.NotEmpty(t, merged.OneOf)
+	require.Len(t, merged.OneOf, 2)
+}
+
 func loadSpec(t *testing.T, path string) *openapi3.T {
 	ctx := context.Background()
 	sl := openapi3.NewLoader()

--- a/flatten/testdata/prune-oneof.yaml
+++ b/flatten/testdata/prune-oneof.yaml
@@ -1,0 +1,76 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 1.0.0
+paths: {}
+
+components:
+  schemas:
+    # BaseSchema is the parent of SchemaWithWithoutOneOf
+    # the flattened version of SchemaWithWithoutOneOf does not contain oneOf field 
+    BaseSchema:
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/SchemaWithWithoutOneOf'
+        - type: object
+          properties:
+            inlineProperty:
+              type: string                  
+
+    SchemaWithWithoutOneOf:
+      allOf:
+        - $ref: '#/components/schemas/BaseSchema'
+        - type: object
+          properties:
+            additionalProperty:
+              type: string
+
+    # FirstSchema is not a parent of ThirdSchema
+    # the flattened version of ThirdSchema contains oneOf
+    FirstSchema:
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/SecondSchema'
+        - type: object
+          properties:
+            prop1:
+              type: string
+
+    SecondSchema:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/ThirdSchema'
+
+    ThirdSchema:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/FirstSchema'
+        - type: object
+          properties:
+            thirdProperty:
+              type: string
+
+    # Base is a parent of ComplexSchema
+    # the flattened version of ComplexSchema contains the oneOf of NestedSchema
+    Base:
+      type: object
+      allOf: 
+        - $ref: '#/components/schemas/ComplexSchema'
+      
+    ComplexSchema:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Base'
+        - $ref: '#/components/schemas/NestedSchema'
+
+    NestedSchema:
+      type: object
+      oneOf:
+        - type: object
+          properties:
+            nestedProperty:
+              type: string
+        - type: object
+          properties:
+            anotherNestedProperty:
+              type: number

--- a/flatten/testdata/prune-oneof.yaml
+++ b/flatten/testdata/prune-oneof.yaml
@@ -15,11 +15,32 @@ components:
         - type: object
           properties:
             inlineProperty:
-              type: string                  
+              type: string
+      discriminator:
+        propertyName: test
 
     SchemaWithWithoutOneOf:
       allOf:
         - $ref: '#/components/schemas/BaseSchema'
+        - type: object
+          properties:
+            additionalProperty:
+              type: string
+
+    # BaseSchema is the parent of SchemaWithWithOneOf
+    # the flattened version of SchemaWithWithoutOneOf contains oneOf field, because BaseSchema does not have the discriminator field
+    BaseSchemaNoDiscriminator:
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/SchemaWithOneOf'
+        - type: object
+          properties:
+            inlineProperty:
+              type: string
+
+    SchemaWithOneOf:
+      allOf:
+        - $ref: '#/components/schemas/BaseSchemaNoDiscriminator'
         - type: object
           properties:
             additionalProperty:
@@ -35,6 +56,8 @@ components:
           properties:
             prop1:
               type: string
+      discriminator:
+        propertyName: test              
 
     SecondSchema:
       type: object
@@ -56,6 +79,8 @@ components:
       type: object
       allOf: 
         - $ref: '#/components/schemas/ComplexSchema'
+      discriminator:
+        propertyName: test        
       
     ComplexSchema:
       type: object


### PR DESCRIPTION
issue: #465 

Conditions for pruning the 'oneOf' field:

-    The schema being merged is a child of another schema, through the oneOf field.
-    In the unmerged schema, the parent schema is nested within the 'allOf' array, creating a circular reference
-    The 'oneOf' field in both the parent and child schemas is identical.
-    The parent schema contains a non-empty propertyName discriminator field

