### PR TITLE
lower-min-go-ver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tufin/oasdiff
 
-go 1.21.5
+go 1.21.4
 
 require (
 	cloud.google.com/go v0.111.0


### PR DESCRIPTION
Tried to remove patch from go version in go. mod but apparently one of our dependancies requires 1.21.4 which means we can't go lower :-(