### PR TITLE
revert unneeded WithExcludeExtensions from tests

### DIFF
--- a/checker/composed_test.go
+++ b/checker/composed_test.go
@@ -29,7 +29,7 @@ func TestComposed_Empty(t *testing.T) {
 		loadFrom(t, "../data/composed/base/", 1),
 	}
 
-	diffReport, _, err := diff.GetPathsDiff(diff.NewConfig().WithExcludeExtensions(), s1, s2)
+	diffReport, _, err := diff.GetPathsDiff(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	require.Nil(t, diffReport)
 }
@@ -69,7 +69,7 @@ func TestComposed_CompareMostRecent(t *testing.T) {
 		loadFrom(t, "../data/composed/revision/", 2),
 	}
 
-	diffReport, _, err := diff.GetPathsDiff(diff.NewConfig().WithExcludeExtensions(), s1, s2)
+	diffReport, _, err := diff.GetPathsDiff(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	require.Nil(t, diffReport)
 }

--- a/diff/diff_common_params_test.go
+++ b/diff/diff_common_params_test.go
@@ -32,7 +32,7 @@ func TestDiff_CommonParamsMoved(t *testing.T) {
 	s2, err := load.NewSpecInfo(loader, load.NewSource("../data/common-params/params_in_op.yaml"), load.WithFlattenParams())
 	require.NoError(t, err)
 
-	d, _, err := diff.GetWithOperationsSourcesMap(diff.NewConfig().WithExcludeExtensions(), s1, s2)
+	d, _, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	require.Empty(t, d)
 }

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -32,7 +32,7 @@ func d(t *testing.T, config *diff.Config, v1, v2 int) *diff.Diff {
 }
 
 func TestDiff_Same(t *testing.T) {
-	require.Nil(t, d(t, diff.NewConfig().WithExcludeExtensions(), 1, 1))
+	require.Nil(t, d(t, diff.NewConfig(), 1, 1))
 }
 
 func TestDiff_Empty(t *testing.T) {
@@ -823,7 +823,7 @@ func TestDiff_DifferentComponentSameSchema(t *testing.T) {
 	s1, err := load.NewSpecInfo(openapi3.NewLoader(), load.NewSource("../data/different_component_same_schema.yaml"))
 	require.NoError(t, err)
 
-	d, _, err := diff.GetWithOperationsSourcesMap(diff.NewConfig().WithExcludeExtensions(), s1, s1)
+	d, _, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s1)
 	require.NoError(t, err)
 	require.Empty(t, d)
 }

--- a/diff/patch_test.go
+++ b/diff/patch_test.go
@@ -18,7 +18,7 @@ func TestPatch_MethodDescription(t *testing.T) {
 
 	require.NoError(t, d1.Patch(s1))
 
-	d2, err := diff.Get(diff.NewConfig().WithExcludeExtensions(), s1, s2)
+	d2, err := diff.Get(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	require.False(t, d2.GetSummary().Diff)
 }
@@ -34,7 +34,7 @@ func TestPatch_ParameterDescription(t *testing.T) {
 
 	require.NoError(t, d1.Patch(s1))
 
-	d2, err := diff.Get(diff.NewConfig().WithExcludeExtensions(), s1, s2)
+	d2, err := diff.Get(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	require.False(t, d2.GetSummary().Diff)
 }
@@ -51,7 +51,7 @@ func TestPatch_ParameterSchemaFormat(t *testing.T) {
 
 	require.NoError(t, d1.Patch(s1))
 
-	d2, err := diff.Get(diff.NewConfig().WithExcludeExtensions(), s1, s2)
+	d2, err := diff.Get(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	require.False(t, d2.GetSummary().Diff)
 }
@@ -67,7 +67,7 @@ func TestPatch_ParameterSchemaEnum(t *testing.T) {
 
 	require.NoError(t, d1.Patch(s1))
 
-	d2, err := diff.Get(diff.NewConfig().WithExcludeExtensions(), s1, s2)
+	d2, err := diff.Get(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	require.False(t, d2.GetSummary().Diff)
 }
@@ -85,7 +85,7 @@ func TestPatch_ParameterSchemaMaxLengthNil(t *testing.T) {
 
 	require.NoError(t, d1.Patch(s1))
 
-	d2, err := diff.Get(diff.NewConfig().WithExcludeExtensions(), s1, s2)
+	d2, err := diff.Get(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	require.False(t, d2.GetSummary().Diff)
 }
@@ -102,7 +102,7 @@ func TestPatch_ParameterSchemaMaxLength(t *testing.T) {
 
 	require.NoError(t, d1.Patch(s1))
 
-	d2, err := diff.Get(diff.NewConfig().WithExcludeExtensions(), s1, s2)
+	d2, err := diff.Get(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	require.False(t, d2.GetSummary().Diff)
 }

--- a/report/text_test.go
+++ b/report/text_test.go
@@ -28,7 +28,7 @@ func d(t *testing.T, config *diff.Config, v1, v2 int) *diff.Diff {
 }
 
 func Test_NoChanges(t *testing.T) {
-	require.Equal(t, report.GetTextReportAsString(d(t, diff.NewConfig().WithExcludeExtensions(), 3, 3)), "No changes\n")
+	require.Equal(t, report.GetTextReportAsString(d(t, diff.NewConfig(), 3, 3)), "No changes\n")
 }
 
 func Test_NoEndpointChanges(t *testing.T) {


### PR DESCRIPTION
As part of https://github.com/Tufin/oasdiff/pull/515 I added some calls to WithExcludeExtensions() in the unit tests to make them pass.
The failing tests were actually correct and were catching [this bug](https://github.com/Tufin/oasdiff/issues/519) which I overlooked.
This PR reverts these unneeded changes to the unit tests.