### PR TITLE
refactor get operation

### DIFF
--- a/checker/check_api_added.go
+++ b/checker/check_api_added.go
@@ -35,7 +35,7 @@ func APIAddedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSour
 
 	for path, pathDiff := range diffReport.PathsDiff.Modified {
 		for opName, op := range pathDiff.Revision.Operations() {
-			if _, foundInBase := pathDiff.Base.Operations()[opName]; foundInBase {
+			if baseOp := pathDiff.Base.GetOperation(opName); baseOp != nil {
 				continue
 			}
 			appendErr(path, opName, op)

--- a/checker/check_api_deprecation.go
+++ b/checker/check_api_deprecation.go
@@ -28,7 +28,7 @@ func APIDeprecationCheck(diffReport *diff.Diff, operationsSources *diff.Operatio
 			continue
 		}
 		for operation, operationDiff := range pathItem.OperationsDiff.Modified {
-			op := pathItem.Revision.Operations()[operation]
+			op := pathItem.Revision.GetOperation(operation)
 			source := (*operationsSources)[op]
 
 			if operationDiff.DeprecatedDiff == nil {

--- a/checker/check_api_operation_id_updated.go
+++ b/checker/check_api_operation_id_updated.go
@@ -26,14 +26,14 @@ func APIOperationIdUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.O
 				continue
 			}
 
-			op := pathItem.Base.Operations()[operation]
+			op := pathItem.Base.GetOperation(operation)
 			source := (*operationsSources)[op]
 
 			id := APIOperationIdRemovedId
 			args := []any{operationItem.Base.OperationID, operationItem.Revision.OperationID}
 			if operationItem.OperationIDDiff.From == nil || operationItem.OperationIDDiff.From == "" {
 				id = APIOperationIdAddId
-				op = pathItem.Revision.Operations()[operation]
+				op = pathItem.Revision.GetOperation(operation)
 				args = []any{operationItem.Revision.OperationID}
 			}
 

--- a/checker/check_api_removed.go
+++ b/checker/check_api_removed.go
@@ -24,9 +24,10 @@ func APIRemovedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSo
 	}
 
 	for _, path := range diffReport.PathsDiff.Deleted {
-		if diffReport.PathsDiff.Base.Value(path) == nil || diffReport.PathsDiff.Base.Value(path).Operations() == nil {
+		if diffReport.PathsDiff.Base.Value(path) == nil {
 			continue
 		}
+
 		for operation := range diffReport.PathsDiff.Base.Value(path).Operations() {
 			op := diffReport.PathsDiff.Base.Value(path).GetOperation(operation)
 			if change := checkAPIRemoval(APIPathRemovedWithoutDeprecationId, APIPathRemovedBeforeSunsetId, op, operationsSources, operation, path); change != nil {

--- a/checker/check_api_removed.go
+++ b/checker/check_api_removed.go
@@ -28,7 +28,7 @@ func APIRemovedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSo
 			continue
 		}
 		for operation := range diffReport.PathsDiff.Base.Value(path).Operations() {
-			op := diffReport.PathsDiff.Base.Value(path).Operations()[operation]
+			op := diffReport.PathsDiff.Base.Value(path).GetOperation(operation)
 			if change := checkAPIRemoval(APIPathRemovedWithoutDeprecationId, APIPathRemovedBeforeSunsetId, op, operationsSources, operation, path); change != nil {
 				result = append(result, change)
 			}
@@ -40,7 +40,7 @@ func APIRemovedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSo
 			continue
 		}
 		for _, operation := range pathItem.OperationsDiff.Deleted {
-			op := pathItem.Base.Operations()[operation]
+			op := pathItem.Base.GetOperation(operation)
 			if change := checkAPIRemoval(APIRemovedWithoutDeprecationId, APIRemovedBeforeSunsetId, op, operationsSources, operation, path); change != nil {
 				result = append(result, change)
 			}

--- a/checker/check_api_sunset_changed.go
+++ b/checker/check_api_sunset_changed.go
@@ -25,8 +25,8 @@ func APISunsetChangedCheck(diffReport *diff.Diff, operationsSources *diff.Operat
 			continue
 		}
 		for operation, operationDiff := range pathItem.OperationsDiff.Modified {
-			opRevision := pathItem.Revision.Operations()[operation]
-			opBase := pathItem.Base.Operations()[operation]
+			opRevision := pathItem.Revision.GetOperation(operation)
+			opBase := pathItem.Base.GetOperation(operation)
 
 			if !opRevision.Deprecated {
 				continue

--- a/checker/check_api_tag_updated.go
+++ b/checker/check_api_tag_updated.go
@@ -22,7 +22,7 @@ func APITagUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.Operation
 		}
 
 		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			op := pathItem.Base.Operations()[operation]
+			op := pathItem.Base.GetOperation(operation)
 			source := (*operationsSources)[op]
 
 			if operationItem.TagsDiff == nil {

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -57,7 +57,7 @@ func removeDraftAndAlphaOperationsDiffs(config *Config, diffReport *diff.Diff, r
 		ignore := true
 		pathDiff := diffReport.PathsDiff
 		for operation, operationItem := range pathDiff.Base.Value(path).Operations() {
-			baseStability, err := getStabilityLevel(pathDiff.Base.Value(path).Operations()[operation].Extensions)
+			baseStability, err := getStabilityLevel(pathDiff.Base.Value(path).GetOperation(operation).Extensions)
 			if err != nil {
 				result = append(result, getAPIInvalidStabilityLevel(operationItem, operationsSources, operation, path, err))
 				continue
@@ -82,7 +82,7 @@ func removeDraftAndAlphaOperationsDiffs(config *Config, diffReport *diff.Diff, r
 		// remove draft and alpha operations diffs deleted
 		iOperation := 0
 		for _, operation := range pathDiff.OperationsDiff.Deleted {
-			operationItem := pathDiff.Base.Operations()[operation]
+			operationItem := pathDiff.Base.GetOperation(operation)
 			baseStability, err := getStabilityLevel(operationItem.Extensions)
 			if err != nil {
 				result = append(result, getAPIInvalidStabilityLevel(operationItem, operationsSources, operation, path, err))
@@ -97,12 +97,12 @@ func removeDraftAndAlphaOperationsDiffs(config *Config, diffReport *diff.Diff, r
 
 		// remove draft and alpha operations diffs modified
 		for operation, operationItem := range pathDiff.OperationsDiff.Modified {
-			baseStability, err := getStabilityLevel(pathDiff.Base.Operations()[operation].Extensions)
+			baseStability, err := getStabilityLevel(pathDiff.Base.GetOperation(operation).Extensions)
 			if err != nil {
 				result = append(result, getAPIInvalidStabilityLevel(operationItem.Base, operationsSources, operation, path, err))
 				continue
 			}
-			revisionStability, err := getStabilityLevel(pathDiff.Revision.Operations()[operation].Extensions)
+			revisionStability, err := getStabilityLevel(pathDiff.Revision.GetOperation(operation).Extensions)
 			if err != nil {
 				result = append(result, getAPIInvalidStabilityLevel(operationItem.Revision, operationsSources, operation, path, err))
 				continue
@@ -111,7 +111,7 @@ func removeDraftAndAlphaOperationsDiffs(config *Config, diffReport *diff.Diff, r
 				baseStability == STABILITY_BETA && revisionStability != STABILITY_BETA && revisionStability != STABILITY_STABLE ||
 				baseStability == STABILITY_ALPHA && revisionStability != STABILITY_ALPHA && revisionStability != STABILITY_BETA && revisionStability != STABILITY_STABLE ||
 				revisionStability == "" && baseStability != "" {
-				source := (*operationsSources)[pathDiff.Revision.Operations()[operation]]
+				source := (*operationsSources)[pathDiff.Revision.GetOperation(operation)]
 				result = append(result, ApiChange{
 					Id:          APIStabilityDecreasedId,
 					Args:        []any{baseStability, revisionStability},


### PR DESCRIPTION
Replace `Operations()[operation]` by `GetOperation(operation)` which is cheaper.
