### PR TITLE
[Feature] Support Wildcard Ignore

### DIFF
--- a/checker/api_change.go
+++ b/checker/api_change.go
@@ -74,6 +74,13 @@ func (c ApiChange) MatchIgnore(ignorePath, ignoreLine string, l Localizer) bool 
 		return false
 	}
 
+	// Check if a wildcard '*' is used to ignore all errors related to this path and operation
+	if strings.Contains(ignoreLine, "*") {
+		// Check if the path matches exactly and the wildcard is used for operation
+		return ignorePath == strings.ToLower(c.Path) && strings.HasPrefix(ignoreLine, strings.ToLower(c.Operation))
+	}
+
+	// Default behavior: match the exact operation and path
 	return ignorePath == strings.ToLower(c.Path) &&
 		strings.Contains(ignoreLine, strings.ToLower(c.Operation+" "+c.Path)) &&
 		strings.Contains(ignoreLine, strings.ToLower(c.GetUncolorizedText(l)))

--- a/checker/api_change_test.go
+++ b/checker/api_change_test.go
@@ -57,6 +57,16 @@ func TestApiChange_MatchIgnore(t *testing.T) {
 	require.True(t, apiChange.MatchIgnore("/test", "error at source, in api get /test this is a breaking change. [change_id]. comment", MockLocalizer))
 }
 
+func TestApiChange_MatchIgnore_Wildcard(t *testing.T) {
+	// Test with wildcard '*', should match on path and operation
+	require.True(t, apiChange.MatchIgnore("/test", "GET *", MockLocalizer))
+}
+
+func TestApiChange_MatchIgnore_NoMatch(t *testing.T) {
+	// Test when ignore does not match, should return false
+	require.False(t, apiChange.MatchIgnore("/different_path", "GET /different_path", MockLocalizer))
+}
+
 func TestApiChange_MultiLineError(t *testing.T) {
 	require.Equal(t, "error\t[change_id] at source\t\n\tin API GET /test\n\t\tThis is a breaking change.\n\t\tcomment", apiChange.MultiLineError(MockLocalizer, checker.ColorNever))
 }


### PR DESCRIPTION
This is a simple feature to support ignoring a specified Method and path in the `--err-ignore` file. If the message is `*` – it will be ignored. This is to solve the issue I created earlier... https://github.com/Tufin/oasdiff/issues/612

:-)