### PR TITLE
[Add] Include severity changelog template for MD

### DIFF
--- a/formatters/changes_by_endpoint.go
+++ b/formatters/changes_by_endpoint.go
@@ -21,11 +21,13 @@ func GroupChanges(changes checker.Changes, l checker.Localizer) ChangesByEndpoin
 				*c = append(*c, Change{
 					IsBreaking: change.IsBreaking(),
 					Text:       change.GetUncolorizedText(l),
+					Level:      change.GetLevel(),
 				})
 			} else {
 				apiChanges[ep] = &Changes{Change{
 					IsBreaking: change.IsBreaking(),
 					Text:       change.GetUncolorizedText(l),
+					Level:      change.GetLevel(),
 				}}
 			}
 		}

--- a/formatters/templates/changelog.md
+++ b/formatters/templates/changelog.md
@@ -1,6 +1,9 @@
 # API Changelog {{ .BaseVersion }}{{ if ne .BaseVersion .RevisionVersion }} vs. {{ .RevisionVersion }}{{ end }}
+
 {{ range $endpoint, $changes := .APIChanges }}
 ## {{ $endpoint.Operation }} {{ $endpoint.Path }}
-{{ range $changes }}- {{ if .IsBreaking }}:warning:{{ end }} {{ .Text }}
+
+{{ range $changes }}
+- **{{ .Level }}**: {{ .Text }}
 {{ end }}
 {{ end }}

--- a/formatters/templates/changelog.md
+++ b/formatters/templates/changelog.md
@@ -4,6 +4,6 @@
 ## {{ $endpoint.Operation }} {{ $endpoint.Path }}
 
 {{ range $changes }}
-- **{{ .Level }}**: {{ .Text }}
+- {{ if .IsBreaking }}**{{ .Level }}**:{{ end }} {{ .Text }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
### Summary
This PR introduces a severity classification to the API changelog markdown.

### Changes made
- Updated `GroupChanges` function in `formatters/changes_by_endpoint.go`
- Updated `changelog.md` template in `formatters/templates/changelog.md`.

### Reason for change
- The update was made to improve the clarity of the changelog and better structure the changes based on severity and impact.
-  This ensures that the breaking changes are highlighted and that the changelog displays the changes in a more consistent format.

### Tests
- All existing tests have been run to ensure that no functionality has been affected by this change.
- Requests are added correctly without being removed, and existing functionality remains intact.

### Reviewers
- Please review the changes and provide feedback on the removal of the feature.
