### PR TITLE
chore: add optional checkers to response and request property removal

### DIFF
--- a/checker/check_breaking_test.go
+++ b/checker/check_breaking_test.go
@@ -743,3 +743,83 @@ func TestBreaking_RequestPropertyAllOfRemoved(t *testing.T) {
 	require.Equal(t, checker.WARN, errs[1].GetLevel())
 	require.Equal(t, "removed '#/components/schemas/Breed3' from the '/allOf[#/components/schemas/Dog]/breed' request property 'allOf' list", errs[1].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
+
+// BC: removing an optional field from the request body is breaking (optional)
+func TestBreaking_RequestPropertyRemoved(t *testing.T) {
+	s1, err := open("../data/checker/request_property_removed_base.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/checker/request_property_removed_revision.yaml")
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	checks := allChecksConfig().WithOptionalCheck(checker.RequestPropertyRemovedId)
+	errs := checker.CheckBackwardCompatibility(checks, d, osm)
+
+	require.Len(t, errs, 1)
+
+	require.Equal(t, checker.RequestPropertyRemovedId, errs[0].GetId())
+	require.Equal(t, checker.ERR, errs[0].GetLevel())
+	require.Equal(t, "removed the request property 'breed'", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+
+	d, osm, err = diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	checks = allChecksConfig()
+	errs = checker.CheckBackwardCompatibility(checks, d, osm)
+	require.Len(t, errs, 1)
+	require.Equal(t, checker.WARN, errs[0].GetLevel())
+}
+
+// BC: removing an optional field from the response body is breaking (optional)
+func TestBreaking_ResponsePropertyRemoved(t *testing.T) {
+	s1, err := open("../data/checker/response_property_removed_base.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/checker/response_property_removed_revision.yaml")
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+
+	checks := allChecksConfig().WithOptionalCheck(checker.ResponseOptionalPropertyRemovedId)
+	errs := checker.CheckBackwardCompatibility(checks, d, osm)
+
+	require.Len(t, errs, 1)
+
+	require.Equal(t, checker.ResponseOptionalPropertyRemovedId, errs[0].GetId())
+	require.Equal(t, checker.ERR, errs[0].GetLevel())
+	require.Equal(t, "removed the optional property 'breed' from the response with the '200' status", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+
+	d, osm, err = diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	checks = allChecksConfig()
+	errs = checker.CheckBackwardCompatibility(checks, d, osm)
+	require.Len(t, errs, 1)
+	require.Equal(t, checker.WARN, errs[0].GetLevel())
+}
+
+// BC: removing an optional field from the response body is breaking (optional)
+func TestBreaking_ResponseWriteOnlyPropertyRemoved(t *testing.T) {
+	s1, err := open("../data/checker/response_property_removed_base.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/checker/response_property_removed_revision.yaml")
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+
+	checks := allChecksConfig().WithOptionalCheck(checker.ResponseOptionalWriteOnlyPropertyRemovedId)
+	errs := checker.CheckBackwardCompatibility(checks, d, osm)
+
+	require.Len(t, errs, 2)
+
+	require.Equal(t, checker.ResponseOptionalWriteOnlyPropertyRemovedId, errs[0].GetId())
+	require.Equal(t, checker.ERR, errs[0].GetLevel())
+	require.Equal(t, "removed the optional write-only property 'other' from the response with the '200' status", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+
+	d, osm, err = diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	checks = allChecksConfig()
+	errs = checker.CheckBackwardCompatibility(checks, d, osm)
+	require.Len(t, errs, 1)
+	require.Equal(t, checker.WARN, errs[0].GetLevel())
+}

--- a/checker/rules.go
+++ b/checker/rules.go
@@ -447,6 +447,9 @@ func GetOptionalRules() BackwardCompatibilityRules {
 		newBackwardCompatibilityRule(ResponsePropertyEnumValueRemovedId, INFO, ResponseParameterEnumValueRemovedCheck, DirectionResponse, LocationProperties, ActionRemove),
 		newBackwardCompatibilityRule(ResponseMediaTypeEnumValueRemovedId, INFO, ResponseMediaTypeEnumValueRemovedCheck, DirectionResponse, LocationBody, ActionRemove),
 		newBackwardCompatibilityRule(RequestBodyEnumValueRemovedId, INFO, RequestBodyEnumValueRemovedCheck, DirectionRequest, LocationBody, ActionRemove),
+		newBackwardCompatibilityRule(ResponseOptionalPropertyRemovedId, WARN, ResponseOptionalPropertyUpdatedCheck, DirectionResponse, LocationProperties, ActionRemove),
+		newBackwardCompatibilityRule(ResponseOptionalWriteOnlyPropertyRemovedId, INFO, ResponseOptionalPropertyUpdatedCheck, DirectionResponse, LocationProperties, ActionRemove),
+		newBackwardCompatibilityRule(RequestPropertyRemovedId, WARN, RequestPropertyUpdatedCheck, DirectionRequest, LocationProperties, ActionRemove),
 	}
 }
 

--- a/checker/rules_test.go
+++ b/checker/rules_test.go
@@ -8,5 +8,5 @@ import (
 )
 
 func TestGetOptionalRuleIds(t *testing.T) {
-	require.Len(t, checker.GetOptionalRuleIds(), 7)
+	require.Len(t, checker.GetOptionalRuleIds(), 10)
 }

--- a/data/checker/request_property_removed_base.yaml
+++ b/data/checker/request_property_removed_base.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /pets:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                breed:
+                  type: string
+              required:
+                - name
+      responses:
+        '200':
+          description: Success
+components: {}

--- a/data/checker/request_property_removed_revision.yaml
+++ b/data/checker/request_property_removed_revision.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /pets:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+              required:
+                - name
+      responses:
+        '200':
+          description: Success
+components: {}

--- a/data/checker/response_property_removed_base.yaml
+++ b/data/checker/response_property_removed_base.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  breed:
+                    type: string
+                  other:
+                    type: string
+                    writeOnly: true
+components: {}

--- a/data/checker/response_property_removed_revision.yaml
+++ b/data/checker/response_property_removed_revision.yaml
@@ -1,0 +1,18 @@
+penapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+components: {}

--- a/docs/BREAKING-CHANGES-EXAMPLES.md
+++ b/docs/BREAKING-CHANGES-EXAMPLES.md
@@ -99,6 +99,8 @@ These examples are automatically generated from unit tests.
 [removing an existing required response header is breaking as error](../checker/check_breaking_test.go?plain=1#L207)  
 [removing an existing response with non-successful status is breaking (optional)](../checker/check_breaking_test.go?plain=1#L246)  
 [removing an existing response with successful status is breaking](../checker/check_breaking_test.go?plain=1#L227)  
+[removing an optional field from the request body is breaking (optional)](../checker/check_breaking_test.go?plain=1#L747)  
+[removing an optional field from the response body is breaking (optional)](../checker/check_breaking_test.go?plain=1#L773)  
 [removing an schema object from components is breaking (optional)](../checker/check_breaking_test.go?plain=1#L619)  
 [removing the default value of an optional request parameter is breaking](../checker/check_breaking_test.go?plain=1#L582)  
 [removing the path without a deprecation policy and without specifying sunset date is breaking for endpoints with non draft/alpha stability level](../checker/check_api_removed_test.go?plain=1#L125)  


### PR DESCRIPTION
- Make it possible to configure request/response property as breaking changes since we need that check for our IaC / SDK tools