### PR TITLE
option to wrap changes in object

### DIFF
--- a/formatters/format_json.go
+++ b/formatters/format_json.go
@@ -30,7 +30,7 @@ func (f JSONFormatter) RenderSummary(diff *diff.Diff, opts RenderOpts) ([]byte, 
 }
 
 func (f JSONFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts, specInfoPair *load.SpecInfoPair) ([]byte, error) {
-	return printJSON(NewChanges(changes, f.Localizer))
+	return printJSON(adaptStructure(NewChanges(changes, f.Localizer), opts.WrapInObject))
 }
 
 func (f JSONFormatter) RenderChecks(checks Checks, opts RenderOpts) ([]byte, error) {
@@ -56,4 +56,12 @@ func printJSON(output interface{}) ([]byte, error) {
 	}
 
 	return bytes, nil
+}
+
+func adaptStructure(output any, wrapInObject bool) any {
+	if wrapInObject {
+		output = map[string]any{"changes": output}
+	}
+
+	return output
 }

--- a/formatters/format_yaml.go
+++ b/formatters/format_yaml.go
@@ -30,7 +30,7 @@ func (f YAMLFormatter) RenderSummary(diff *diff.Diff, opts RenderOpts) ([]byte, 
 }
 
 func (f YAMLFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts, specInfoPair *load.SpecInfoPair) ([]byte, error) {
-	return printYAML(NewChanges(changes, f.Localizer))
+	return printYAML(adaptStructure(NewChanges(changes, f.Localizer), opts.WrapInObject))
 }
 
 func (f YAMLFormatter) RenderChecks(checks Checks, opts RenderOpts) ([]byte, error) {

--- a/formatters/format_yaml_test.go
+++ b/formatters/format_yaml_test.go
@@ -1,6 +1,7 @@
 package formatters_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/oasdiff/oasdiff/checker"
@@ -29,6 +30,19 @@ func TestYamlFormatter_RenderChangelog(t *testing.T) {
 	out, err := yamlFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), nil)
 	require.NoError(t, err)
 	require.Equal(t, "- id: change_id\n  text: This is a breaking change.\n  level: 3\n  section: components\n", string(out))
+}
+
+func TestYamlFormatter_RenderChangelogWithWrapInObject(t *testing.T) {
+	testChanges := checker.Changes{
+		checker.ComponentChange{
+			Id:    "change_id",
+			Level: checker.ERR,
+		},
+	}
+
+	out, err := yamlFormatter.RenderChangelog(testChanges, formatters.RenderOpts{WrapInObject: true}, nil)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(string(out), "changes:"))
 }
 
 func TestYamlFormatter_RenderChecks(t *testing.T) {

--- a/formatters/types.go
+++ b/formatters/types.go
@@ -39,7 +39,8 @@ type FormatterOpts struct {
 
 // RenderOpts can be used to pass properties to the renderer method
 type RenderOpts struct {
-	ColorMode checker.ColorMode
+	ColorMode    checker.ColorMode
+	WrapInObject bool // wrap the output in a JSON object with the key "changes"
 }
 
 func NewRenderOpts() RenderOpts {


### PR DESCRIPTION
Add an option to wrap breaking-changes and changelog in a json/yaml object rather than returning a list.
This is useful for the oasdiff-service that needs to return this format.