### PR TITLE
fix: eliminate false positive diffs on identical files (issue #806)

### DIFF
--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -2,6 +2,7 @@ package diff_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -177,6 +178,29 @@ func TestSchemaDiff_EnumDiff(t *testing.T) {
 			Deleted: diff.EnumValues{},
 		},
 		d(t, diff.NewConfig(), 1, 3).PathsDiff.Modified[installCommandPath].OperationsDiff.Modified["GET"].ParametersDiff.Modified[openapi3.ParameterInPath]["project"].SchemaDiff.EnumDiff)
+}
+
+// Regression test: identical files loaded from different paths must produce an empty diff.
+// Without the fix, __origin__ (source-location metadata) leaks into the MediaType.Encoding map as a
+// real entry, causing false positive diffs when file paths differ (issue #806).
+func TestDiff_IdenticalFilesNoDiff(t *testing.T) {
+	loader := openapi3.NewLoader()
+	s1, err := loader.LoadFromFile("../data/openapi-test1.yaml")
+	require.NoError(t, err)
+	// Copy the same file to a temp location to get a different path.
+	tmp, err := os.CreateTemp("", "openapi-test-*.yaml")
+	require.NoError(t, err)
+	defer os.Remove(tmp.Name())
+	src, err := os.ReadFile("../data/openapi-test1.yaml")
+	require.NoError(t, err)
+	_, err = tmp.Write(src)
+	require.NoError(t, err)
+	require.NoError(t, tmp.Close())
+	s2, err := loader.LoadFromFile(tmp.Name())
+	require.NoError(t, err)
+	d, err := diff.Get(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	require.Nil(t, d)
 }
 
 // Regression test: object-valued enum entries must not produce a false diff due to __origin__ metadata.

--- a/go.mod
+++ b/go.mod
@@ -51,4 +51,4 @@ require (
 	github.com/wI2L/jsondiff v0.7.0
 )
 
-replace github.com/getkin/kin-openapi => github.com/oasdiff/kin-openapi v0.0.0-20260316152142-c8b2b9040385
+replace github.com/getkin/kin-openapi => github.com/oasdiff/kin-openapi v0.0.0-20260316155013-a09d176e52ca

--- a/go.mod
+++ b/go.mod
@@ -50,3 +50,5 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/wI2L/jsondiff v0.7.0
 )
+
+replace github.com/getkin/kin-openapi => github.com/oasdiff/kin-openapi v0.0.0-20260316152142-c8b2b9040385

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/mailru/easyjson v0.9.2 h1:dX8U45hQsZpxd80nLvDGihsQ/OxlvTkVUXH2r/8cb2M
 github.com/mailru/easyjson v0.9.2/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
-github.com/oasdiff/kin-openapi v0.0.0-20260316152142-c8b2b9040385 h1:SrWPu4juBj4SCjQktnqW9iQKx4R8XT9j3s1/Ht/Vf7Q=
-github.com/oasdiff/kin-openapi v0.0.0-20260316152142-c8b2b9040385/go.mod h1:wK6ZLG/VgoETO9pcLJ/VmAtIcl/DNlMayNTb716EUxE=
+github.com/oasdiff/kin-openapi v0.0.0-20260316155013-a09d176e52ca h1:B3wKS9Spr4Yg9jt6nlTvpTbwCLItYgsMbBkL6AOWqVI=
+github.com/oasdiff/kin-openapi v0.0.0-20260316155013-a09d176e52ca/go.mod h1:wK6ZLG/VgoETO9pcLJ/VmAtIcl/DNlMayNTb716EUxE=
 github.com/oasdiff/yaml v0.0.0-20260313112342-a3ea61cb4d4c h1:7ACFcSaQsrWtrH4WHHfUqE1C+f8r2uv8KGaW0jTNjus=
 github.com/oasdiff/yaml v0.0.0-20260313112342-a3ea61cb4d4c/go.mod h1:JKox4Gszkxt57kj27u7rvi7IFoIULvCZHUsBTUmQM/s=
 github.com/oasdiff/yaml3 v0.0.0-20260224194419-61cd415a242b h1:vivRhVUAa9t1q0Db4ZmezBP8pWQWnXHFokZj0AOea2g=

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,6 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
-github.com/getkin/kin-openapi v0.134.0 h1:/L5+1+kfe6dXh8Ot/wqiTgUkjOIEJiC0bbYVziHB8rU=
-github.com/getkin/kin-openapi v0.134.0/go.mod h1:wK6ZLG/VgoETO9pcLJ/VmAtIcl/DNlMayNTb716EUxE=
 github.com/go-openapi/jsonpointer v0.22.5 h1:8on/0Yp4uTb9f4XvTrM2+1CPrV05QPZXu+rvu2o9jcA=
 github.com/go-openapi/jsonpointer v0.22.5/go.mod h1:gyUR3sCvGSWchA2sUBJGluYMbe1zazrYWIkWPjjMUY0=
 github.com/go-openapi/swag/jsonname v0.25.5 h1:8p150i44rv/Drip4vWI3kGi9+4W9TdI3US3uUYSFhSo=
@@ -39,6 +37,8 @@ github.com/mailru/easyjson v0.9.2 h1:dX8U45hQsZpxd80nLvDGihsQ/OxlvTkVUXH2r/8cb2M
 github.com/mailru/easyjson v0.9.2/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
+github.com/oasdiff/kin-openapi v0.0.0-20260316152142-c8b2b9040385 h1:SrWPu4juBj4SCjQktnqW9iQKx4R8XT9j3s1/Ht/Vf7Q=
+github.com/oasdiff/kin-openapi v0.0.0-20260316152142-c8b2b9040385/go.mod h1:wK6ZLG/VgoETO9pcLJ/VmAtIcl/DNlMayNTb716EUxE=
 github.com/oasdiff/yaml v0.0.0-20260313112342-a3ea61cb4d4c h1:7ACFcSaQsrWtrH4WHHfUqE1C+f8r2uv8KGaW0jTNjus=
 github.com/oasdiff/yaml v0.0.0-20260313112342-a3ea61cb4d4c/go.mod h1:JKox4Gszkxt57kj27u7rvi7IFoIULvCZHUsBTUmQM/s=
 github.com/oasdiff/yaml3 v0.0.0-20260224194419-61cd415a242b h1:vivRhVUAa9t1q0Db4ZmezBP8pWQWnXHFokZj0AOea2g=


### PR DESCRIPTION
## Summary

- Fixes #806: oasdiff reports spurious diffs when comparing byte-identical YAML files loaded from different paths
- Root cause: the origin-tracking YAML loader injects \`__origin__\` metadata as a real key into typed Go maps (\`map[string]*Encoding\`, \`map[string]*ServerVariable\`), which contains the file path. When files are at different paths, this entry differs.
- Fix applied in \`oasdiff/kin-openapi\` fork (\`fix/issue-806\` branch): introduce named types \`Encodings\` and \`ServerVariables\` with their own \`UnmarshalJSON\` using \`unmarshalStringMapP\`, consistent with how \`Content\`, \`Schemas\`, \`Headers\`, etc. already handle origin stripping

## Affected maps (3 total)

| Map | Fix |
|-----|-----|
| \`MediaType.Encoding map[string]*Encoding\` | new \`Encodings\` type with \`unmarshalStringMapP[Encoding]\` |
| \`Server.Variables map[string]*ServerVariable\` | new \`ServerVariables\` type with \`unmarshalStringMapP[ServerVariable]\` |
| \`T.Webhooks map[string]*PathItem\` (OpenAPI 3.1) | fixed in \`feat/openapi-3.1-support\` fork branch |

All other component maps (\`Content\`, \`Schemas\`, \`Headers\`, \`Links\`, etc.) were already handled via \`unmarshalStringMapP\`/\`popOrigin\` or \`maplike.go\`.

## Test plan

- [ ] \`TestDiff_IdenticalFilesNoDiff\`: new regression test that loads \`openapi-test1.yaml\` twice from different paths and asserts the diff is nil
- [ ] All existing tests pass: \`go test ./...\`
- [ ] Manual verification: \`oasdiff diff /tmp/test1.yaml /tmp/test2.yaml\` (identical files at different paths) now produces empty output

🤖 Generated with [Claude Code](https://claude.com/claude-code)