### PR TITLE
fix: remove replace directive, use github.com/oasdiff/kin-openapi v0.136.0 (#810)

### DIFF
--- a/checker/api_change.go
+++ b/checker/api_change.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/TwiN/go-color"
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/oasdiff/oasdiff/load"
 )

--- a/checker/check_api_added.go
+++ b/checker/check_api_added.go
@@ -1,7 +1,7 @@
 package checker
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 )
 

--- a/checker/check_api_deprecation_test.go
+++ b/checker/check_api_deprecation_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/civil"
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/oasdiff/oasdiff/load"

--- a/checker/check_api_removed_test.go
+++ b/checker/check_api_removed_test.go
@@ -3,7 +3,7 @@ package checker_test
 import (
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/stretchr/testify/require"

--- a/checker/check_breaking_min_max_test.go
+++ b/checker/check_breaking_min_max_test.go
@@ -3,7 +3,7 @@ package checker_test
 import (
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/stretchr/testify/require"

--- a/checker/check_breaking_property_test.go
+++ b/checker/check_breaking_property_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/oasdiff/oasdiff/load"

--- a/checker/check_breaking_request_type_changed_test.go
+++ b/checker/check_breaking_request_type_changed_test.go
@@ -3,7 +3,7 @@ package checker_test
 import (
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/stretchr/testify/require"

--- a/checker/check_breaking_response_type_changed_test.go
+++ b/checker/check_breaking_response_type_changed_test.go
@@ -3,7 +3,7 @@ package checker_test
 import (
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/stretchr/testify/require"

--- a/checker/check_breaking_test.go
+++ b/checker/check_breaking_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/oasdiff/oasdiff/load"

--- a/checker/check_new_requried_request_header_property.go
+++ b/checker/check_new_requried_request_header_property.go
@@ -1,7 +1,7 @@
 package checker
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 	"slices"
 )

--- a/checker/check_not_breaking_test.go
+++ b/checker/check_not_breaking_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/civil"
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/stretchr/testify/require"

--- a/checker/check_request_parameter_deprecation.go
+++ b/checker/check_request_parameter_deprecation.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/civil"
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 )
 

--- a/checker/check_request_parameter_removed.go
+++ b/checker/check_request_parameter_removed.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/civil"
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 )
 

--- a/checker/check_request_parameter_required_value_updated_test.go
+++ b/checker/check_request_parameter_required_value_updated_test.go
@@ -3,7 +3,7 @@ package checker_test
 import (
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/oasdiff/oasdiff/load"

--- a/checker/check_request_parameters_max_items_updated_test.go
+++ b/checker/check_request_parameters_max_items_updated_test.go
@@ -3,7 +3,7 @@ package checker_test
 import (
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/oasdiff/oasdiff/load"

--- a/checker/check_request_parameters_type_changed_test.go
+++ b/checker/check_request_parameters_type_changed_test.go
@@ -3,7 +3,7 @@ package checker_test
 import (
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/oasdiff/oasdiff/load"

--- a/checker/check_request_property_type_changed_test.go
+++ b/checker/check_request_property_type_changed_test.go
@@ -3,7 +3,7 @@ package checker_test
 import (
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/oasdiff/oasdiff/load"

--- a/checker/check_request_property_updated.go
+++ b/checker/check_request_property_updated.go
@@ -1,7 +1,7 @@
 package checker
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 	"slices"
 )

--- a/checker/check_response_optional_property_updated.go
+++ b/checker/check_response_optional_property_updated.go
@@ -1,7 +1,7 @@
 package checker
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 	"slices"
 )

--- a/checker/check_response_property_type_changed_test.go
+++ b/checker/check_response_property_type_changed_test.go
@@ -3,7 +3,7 @@ package checker_test
 import (
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/oasdiff/oasdiff/load"

--- a/checker/check_response_required_property_updated.go
+++ b/checker/check_response_required_property_updated.go
@@ -1,7 +1,7 @@
 package checker
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 	"slices"
 )

--- a/checker/check_response_status_updated.go
+++ b/checker/check_response_status_updated.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 )
 

--- a/checker/check_types.go
+++ b/checker/check_types.go
@@ -3,7 +3,7 @@ package checker
 import (
 	"strings"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 )
 

--- a/checker/check_types_test.go
+++ b/checker/check_types_test.go
@@ -3,7 +3,7 @@ package checker
 import (
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/stretchr/testify/require"
 )

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 )
 

--- a/checker/checks-utils.go
+++ b/checker/checks-utils.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 )
 

--- a/checker/composed_test.go
+++ b/checker/composed_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/oasdiff/oasdiff/load"
 	"github.com/stretchr/testify/require"

--- a/checker/example_test.go
+++ b/checker/example_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/oasdiff/oasdiff/load"

--- a/checker/list_of_types_core.go
+++ b/checker/list_of_types_core.go
@@ -1,7 +1,7 @@
 package checker
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 )
 

--- a/checker/list_of_types_core_test.go
+++ b/checker/list_of_types_core_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/oasdiff/oasdiff/load"

--- a/checker/op_info.go
+++ b/checker/op_info.go
@@ -1,7 +1,7 @@
 package checker
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 )
 

--- a/checker/source.go
+++ b/checker/source.go
@@ -1,7 +1,7 @@
 package checker
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/oasdiff/oasdiff/load"
 )

--- a/checker/source_test.go
+++ b/checker/source_test.go
@@ -3,7 +3,7 @@ package checker_test
 import (
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/oasdiff/oasdiff/load"

--- a/diff/callbacks_diff.go
+++ b/diff/callbacks_diff.go
@@ -3,7 +3,7 @@ package diff
 import (
 	"fmt"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // CallbacksDiff describes the changes between a pair of callback objects: https://swagger.io/specification/#callback-object

--- a/diff/components_diff.go
+++ b/diff/components_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // ComponentsDiff describes the changes between a pair of component objects: https://swagger.io/specification/#components-object

--- a/diff/contact.go
+++ b/diff/contact.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // ContactDiff describes the changes between a pair of contact objects: https://swagger.io/specification/#contact-object

--- a/diff/content_diff.go
+++ b/diff/content_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // ContentDiff describes the changes between content properties each containing media type objects: https://swagger.io/specification/#media-type-object

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -7,7 +7,7 @@ import (
 	"maps"
 
 	"cloud.google.com/go/civil"
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/load"
 )
 
@@ -48,7 +48,7 @@ Get calculates the diff between a pair of OpenAPI objects.
 
 Note that Get expects OpenAPI References (https://swagger.io/docs/specification/using-ref/) to be resolved.
 References are normally resolved automatically when you load the spec.
-In other cases you can resolve refs using https://pkg.go.dev/github.com/getkin/kin-openapi/openapi3#Loader.ResolveRefsIn.
+In other cases you can resolve refs using https://pkg.go.dev/github.com/oasdiff/kin-openapi/openapi3#Loader.ResolveRefsIn.
 */
 func Get(config *Config, s1, s2 *openapi3.T) (*Diff, error) {
 	diff, err := getDiff(config, newState(), s1, s2)
@@ -63,7 +63,7 @@ GetWithOperationsSourcesMap calculates the diff between a pair of OpenAPI object
 
 Note that GetWithOperationsSourcesMap expects OpenAPI References (https://swagger.io/docs/specification/using-ref/) to be resolved.
 References are normally resolved automatically when you load the spec.
-In other cases you can resolve refs using https://pkg.go.dev/github.com/getkin/kin-openapi/openapi3#Loader.ResolveRefsIn.
+In other cases you can resolve refs using https://pkg.go.dev/github.com/oasdiff/kin-openapi/openapi3#Loader.ResolveRefsIn.
 */
 func GetWithOperationsSourcesMap(config *Config, s1, s2 *load.SpecInfo) (*Diff, *OperationsSourcesMap, error) {
 	diff, err := getDiff(config, newState(), s1.Spec, s2.Spec)
@@ -97,7 +97,7 @@ The format of the x-since-date is the RFC3339 full-date format
 
 Note that Get expects OpenAPI References (https://swagger.io/docs/specification/using-ref/) to be resolved.
 References are normally resolved automatically when you load the spec.
-In other cases you can resolve refs using https://pkg.go.dev/github.com/getkin/kin-openapi/openapi3#Loader.ResolveRefsIn.
+In other cases you can resolve refs using https://pkg.go.dev/github.com/oasdiff/kin-openapi/openapi3#Loader.ResolveRefsIn.
 */
 func GetPathsDiff(config *Config, s1, s2 []*load.SpecInfo) (*Diff, *OperationsSourcesMap, error) {
 	state := newState()

--- a/diff/diff_common_params_test.go
+++ b/diff/diff_common_params_test.go
@@ -3,7 +3,7 @@ package diff_test
 import (
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/oasdiff/oasdiff/load"
 	"github.com/stretchr/testify/require"

--- a/diff/diff_error_test.go
+++ b/diff/diff_error_test.go
@@ -3,7 +3,7 @@ package diff_test
 import (
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/stretchr/testify/require"
 )

--- a/diff/diff_prefix_test.go
+++ b/diff/diff_prefix_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/stretchr/testify/require"
 )

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/oasdiff/oasdiff/load"
 	"github.com/stretchr/testify/require"

--- a/diff/diff_x_of_test.go
+++ b/diff/diff_x_of_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/stretchr/testify/require"
 )

--- a/diff/diff_x_of_titles_test.go
+++ b/diff/diff_x_of_titles_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/stretchr/testify/require"
 )

--- a/diff/directional_schema_diff_cache.go
+++ b/diff/directional_schema_diff_cache.go
@@ -1,6 +1,6 @@
 package diff
 
-import "github.com/getkin/kin-openapi/openapi3"
+import "github.com/oasdiff/kin-openapi/openapi3"
 
 type directionalSchemaDiffCache struct {
 	requestCache  schemaDiffCache

--- a/diff/discriminator_diff.go
+++ b/diff/discriminator_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // DiscriminatorDiff describes the changes between a pair of discriminator objects: https://swagger.io/specification/#discriminator-object

--- a/diff/encoding_diff.go
+++ b/diff/encoding_diff.go
@@ -3,7 +3,7 @@ package diff
 import (
 	"fmt"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // EncodingDiff describes the changes between a pair of encoding objects: https://swagger.io/specification/#encoding-object

--- a/diff/encodings_diff.go
+++ b/diff/encodings_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // EncodingsDiff describes the changes between a pair of sets of encoding objects: https://swagger.io/specification/#encoding-object

--- a/diff/endpoints_diff.go
+++ b/diff/endpoints_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 /*

--- a/diff/example_diff.go
+++ b/diff/example_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // ExampleDiff describes the changes between a pair of example objects: https://swagger.io/specification/#example-object

--- a/diff/example_test.go
+++ b/diff/example_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 	"go.yaml.in/yaml/v3"
 )

--- a/diff/examples_diff.go
+++ b/diff/examples_diff.go
@@ -3,7 +3,7 @@ package diff
 import (
 	"fmt"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // ExamplesDiff describes the changes between a pair of sets of example objects: https://swagger.io/specification/#example-object

--- a/diff/external_docs_diff.go
+++ b/diff/external_docs_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // ExternalDocsDiff describes the changes between a pair of external documentation objects: https://swagger.io/specification/#external-documentation-object

--- a/diff/header_diff.go
+++ b/diff/header_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // HeaderDiff describes the changes between a pair of header objects: https://swagger.io/specification/#header-object

--- a/diff/headers_diff.go
+++ b/diff/headers_diff.go
@@ -3,7 +3,7 @@ package diff
 import (
 	"fmt"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // HeadersDiff describes the changes between a pair of sets of header objects: https://swagger.io/specification/#header-object

--- a/diff/info_diff.go
+++ b/diff/info_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // InfoDiff describes the changes between a pair of info objects: https://swagger.io/specification/#info-object

--- a/diff/license_diff.go
+++ b/diff/license_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // LicenseDiff describes the changes between a pair of license objects: https://swagger.io/specification/#license-object

--- a/diff/link_diff.go
+++ b/diff/link_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // LinkDiff describes the changes between a pair of link objects: https://swagger.io/specification/#link-object

--- a/diff/links_diff.go
+++ b/diff/links_diff.go
@@ -3,7 +3,7 @@ package diff
 import (
 	"fmt"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // LinksDiff describes the changes between a pair of sets of link objects: https://swagger.io/specification/#link-object

--- a/diff/list_of_types_diff.go
+++ b/diff/list_of_types_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // ListOfTypesDiff represents changes in the "list-of-types" design pattern.

--- a/diff/list_of_types_diff_test.go
+++ b/diff/list_of_types_diff_test.go
@@ -3,7 +3,7 @@ package diff_test
 import (
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/stretchr/testify/require"
 )

--- a/diff/media_type_diff.go
+++ b/diff/media_type_diff.go
@@ -3,7 +3,7 @@ package diff
 import (
 	"fmt"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // MediaTypeDiff describes the changes between a pair of media type objects: https://swagger.io/specification/#media-type-object

--- a/diff/media_type_name_diff_test.go
+++ b/diff/media_type_name_diff_test.go
@@ -3,7 +3,7 @@ package diff_test
 import (
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/oasdiff/oasdiff/load"
 	"github.com/stretchr/testify/require"

--- a/diff/method_diff.go
+++ b/diff/method_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // MethodDiff describes the changes between a pair of operation objects: https://swagger.io/specification/#operation-object

--- a/diff/modified_subschemas.go
+++ b/diff/modified_subschemas.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // ModifiedSubschemas is list of modified subschemas with their diffs

--- a/diff/oauth_flow.go
+++ b/diff/oauth_flow.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // OAuthFlowDiff describes the changes between a pair of oauth flow objects: https://swagger.io/specification/#oauth-flow-object

--- a/diff/oauth_flows.go
+++ b/diff/oauth_flows.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // OAuthFlowsDiff describes the changes between a pair of oauth flows objects: https://swagger.io/specification/#oauth-flows-object

--- a/diff/operations_diff.go
+++ b/diff/operations_diff.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"regexp"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // OperationsDiff describes the changes between a pair of operation objects (https://swagger.io/specification/#operation-object) of two path item objects

--- a/diff/parameter_diff.go
+++ b/diff/parameter_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // ParameterDiff describes the changes between a pair of parameter objects: https://swagger.io/specification/#parameter-object

--- a/diff/parameters_diff.go
+++ b/diff/parameters_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // ParametersDiff describes the changes between a pair of lists of parameter objects: https://swagger.io/specification/#parameter-object

--- a/diff/parameters_diff_by_location.go
+++ b/diff/parameters_diff_by_location.go
@@ -3,7 +3,7 @@ package diff
 import (
 	"fmt"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // ParametersDiffByLocation describes the changes, grouped by param location, between a pair of lists of parameter objects: https://swagger.io/specification/#parameter-object

--- a/diff/parameters_diff_by_location_test.go
+++ b/diff/parameters_diff_by_location_test.go
@@ -3,7 +3,7 @@ package diff_test
 import (
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/oasdiff/oasdiff/load"
 	"github.com/stretchr/testify/require"

--- a/diff/path_diff.go
+++ b/diff/path_diff.go
@@ -3,7 +3,7 @@ package diff
 import (
 	"fmt"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // PathDiff describes the changes between a pair of path item objects: https://swagger.io/specification/#path-item-object

--- a/diff/path_items_diff.go
+++ b/diff/path_items_diff.go
@@ -3,7 +3,7 @@ package diff
 import (
 	"strings"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 type pathItemPair struct {

--- a/diff/paths_diff.go
+++ b/diff/paths_diff.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // PathsDiff describes the changes between a pair of Paths objects: https://swagger.io/specification/#paths-object

--- a/diff/request_bodies_diff.go
+++ b/diff/request_bodies_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // RequestBodiesDiff describes the changes between a pair of sets of request body objects: https://swagger.io/specification/#request-body-object

--- a/diff/request_body_diff.go
+++ b/diff/request_body_diff.go
@@ -3,7 +3,7 @@ package diff
 import (
 	"fmt"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // RequestBodyDiff describes the changes between a pair of request body objects: https://swagger.io/specification/#request-body-object

--- a/diff/required_diff.go
+++ b/diff/required_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // RequiredPropertiesDiff describes the changes between a pair of lists of required properties

--- a/diff/response_diff.go
+++ b/diff/response_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // ResponseDiff describes the changes between a pair of response objects: https://swagger.io/specification/#response-object

--- a/diff/responses_diff.go
+++ b/diff/responses_diff.go
@@ -3,7 +3,7 @@ package diff
 import (
 	"fmt"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // ResponsesDiff describes the changes between a pair of sets of response objects: https://swagger.io/specification/#responses-object

--- a/diff/schema_circular_refs.go
+++ b/diff/schema_circular_refs.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 type circularRefStatus int

--- a/diff/schema_diff.go
+++ b/diff/schema_diff.go
@@ -3,7 +3,7 @@ package diff
 import (
 	"errors"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // SchemaDiff describes the changes between a pair of schema objects: https://swagger.io/specification/#schema-object

--- a/diff/schema_diff_cache.go
+++ b/diff/schema_diff_cache.go
@@ -1,6 +1,6 @@
 package diff
 
-import "github.com/getkin/kin-openapi/openapi3"
+import "github.com/oasdiff/kin-openapi/openapi3"
 
 type schemaPair struct {
 	Schema1 *openapi3.SchemaRef

--- a/diff/schema_ref_map.go
+++ b/diff/schema_ref_map.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 type ref struct {

--- a/diff/schemas_diff.go
+++ b/diff/schemas_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // SchemasDiff describes the changes between a pair of maps of schema objects like the components.schemas object

--- a/diff/security_requirements_diff.go
+++ b/diff/security_requirements_diff.go
@@ -5,7 +5,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/utils"
 )
 

--- a/diff/security_scheme.go
+++ b/diff/security_scheme.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // SecuritySchemeDiff describes the changes between a pair of security scheme objects: https://swagger.io/specification/#security-scheme-object

--- a/diff/security_schemes.go
+++ b/diff/security_schemes.go
@@ -3,7 +3,7 @@ package diff
 import (
 	"fmt"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // SecuritySchemesDiff describes the changes between a pair of sets of security scheme objects: https://swagger.io/specification/#security-scheme-object

--- a/diff/security_scopes_diff.go
+++ b/diff/security_scopes_diff.go
@@ -1,6 +1,6 @@
 package diff
 
-import "github.com/getkin/kin-openapi/openapi3"
+import "github.com/oasdiff/kin-openapi/openapi3"
 
 // SecurityScopesDiff is a map of security schemes to their respective scope diffs
 type SecurityScopesDiff map[string]*StringsDiff

--- a/diff/server_diff.go
+++ b/diff/server_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // ServerDiff describes the changes between a pair of server objects: https://swagger.io/specification/#server-object

--- a/diff/servers_diff.go
+++ b/diff/servers_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // ServersDiff describes the changes between a pair of sets of encoding objects: https://swagger.io/specification/#server-object

--- a/diff/subschemas_diff.go
+++ b/diff/subschemas_diff.go
@@ -3,7 +3,7 @@ package diff
 import (
 	"strings"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/utils"
 )
 

--- a/diff/tag_diff.go
+++ b/diff/tag_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // TagDiff describes the changes between a pair of tag objects: https://swagger.io/specification/#tag-object

--- a/diff/tags_diff.go
+++ b/diff/tags_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // TagsDiff describes the changes between a pair of lists of tag objects: https://swagger.io/specification/#tag-object

--- a/diff/type_diff.go
+++ b/diff/type_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 func getTypeDiff(types1, types2 *openapi3.Types) *StringsDiff {

--- a/diff/variable_diff.go
+++ b/diff/variable_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // VariableDiff describes the changes between a pair of server variable objects: https://swagger.io/specification/#server-variable-object

--- a/diff/variables_diff.go
+++ b/diff/variables_diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // VariablesDiff describes the changes between a pair of sets of server variable objects: https://swagger.io/specification/#server-variable-object

--- a/flatten/allof/merge_allof.go
+++ b/flatten/allof/merge_allof.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 const (

--- a/flatten/allof/merge_allof_spec.go
+++ b/flatten/allof/merge_allof_spec.go
@@ -1,7 +1,7 @@
 package allof
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // MergeSpec merges all instances in allOf in place

--- a/flatten/allof/merge_allof_spec_test.go
+++ b/flatten/allof/merge_allof_spec_test.go
@@ -3,7 +3,7 @@ package allof_test
 import (
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/load"
 	"github.com/stretchr/testify/require"
 )

--- a/flatten/allof/merge_allof_test.go
+++ b/flatten/allof/merge_allof_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/oasdiff/oasdiff/flatten/allof"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/stretchr/testify/require"
 )
 

--- a/flatten/allof/merge_allof_validation_test.go
+++ b/flatten/allof/merge_allof_validation_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/oasdiff/oasdiff/flatten/allof"
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/openapi3filter"
-	legacyrouter "github.com/getkin/kin-openapi/routers/legacy"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3filter"
+	legacyrouter "github.com/oasdiff/kin-openapi/routers/legacy"
 )
 
 type Test struct {

--- a/flatten/commonparams/params.go
+++ b/flatten/commonparams/params.go
@@ -1,6 +1,6 @@
 package commonparams
 
-import "github.com/getkin/kin-openapi/openapi3"
+import "github.com/oasdiff/kin-openapi/openapi3"
 
 // Move moves common parameters to the operations under the path
 func Move(spec *openapi3.T) {

--- a/flatten/commonparams/params_test.go
+++ b/flatten/commonparams/params_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/flatten/commonparams"
 	"github.com/stretchr/testify/require"
 )

--- a/flatten/headers/params.go
+++ b/flatten/headers/params.go
@@ -3,7 +3,7 @@ package headers
 import (
 	"strings"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // Lowercase replaces header names to lowercase

--- a/flatten/headers/params_test.go
+++ b/flatten/headers/params_test.go
@@ -3,7 +3,7 @@ package headers_test
 import (
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/flatten/headers"
 	"github.com/stretchr/testify/require"
 )

--- a/formatters/format_json.go
+++ b/formatters/format_json.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/diff"
 )

--- a/formatters/format_yaml.go
+++ b/formatters/format_yaml.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/diff"
 	"go.yaml.in/yaml/v3"

--- a/formatters/interface.go
+++ b/formatters/interface.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/checker/localizations"
 	"github.com/oasdiff/oasdiff/diff"

--- a/formatters/not_implemented.go
+++ b/formatters/not_implemented.go
@@ -3,7 +3,7 @@ package formatters
 import (
 	"fmt"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/oasdiff/oasdiff/load"

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	cloud.google.com/go v0.123.0
 	github.com/TwiN/go-color v1.4.1
-	github.com/getkin/kin-openapi v0.134.0
+	github.com/oasdiff/kin-openapi v0.136.0
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
@@ -50,5 +50,3 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/wI2L/jsondiff v0.7.0
 )
-
-replace github.com/getkin/kin-openapi => github.com/oasdiff/kin-openapi v0.135.1

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/mailru/easyjson v0.9.2 h1:dX8U45hQsZpxd80nLvDGihsQ/OxlvTkVUXH2r/8cb2M
 github.com/mailru/easyjson v0.9.2/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
-github.com/oasdiff/kin-openapi v0.135.1 h1:FeO2+aWMijpXQ+QNyLPVOIlNRIz1sM29dmv7kZF4wWA=
-github.com/oasdiff/kin-openapi v0.135.1/go.mod h1:LE+Gon0cru/cES0VUvR6kfK/RwTlfjiUnjmagljRbtI=
+github.com/oasdiff/kin-openapi v0.136.0 h1:znR1xptw6DoK5drWIGEHAPTjgdCXZ6kKNpBCkdBDvBw=
+github.com/oasdiff/kin-openapi v0.136.0/go.mod h1:BMeaLn+GmFJKtHJ31JrgXFt91eZi/q+Og4tr7sq0BzI=
 github.com/oasdiff/yaml v0.0.1 h1:dPrn0F2PJ7HdzHPndJkArvB2Fw0cwgFdVUKCEkoFuds=
 github.com/oasdiff/yaml v0.0.1/go.mod h1:r8bgVgpWT5iIN/AgP0GljFvB6CicK+yL1nIAbm+8/QQ=
 github.com/oasdiff/yaml3 v0.0.1 h1:kReOSraQLTxuuGNX9aNeJ7tcsvUB2MS+iupdUrWe4Z0=

--- a/internal/cmd_flags.go
+++ b/internal/cmd_flags.go
@@ -35,7 +35,7 @@ func addHiddenFlattenFlag(cmd *cobra.Command) {
 }
 
 // addHiddenCircularDepFlag adds --max-circular-dep as a hidden flag
-// --max-circular-dep is no longer needed because kin-openapi3 handles circular references automatically since https://github.com/getkin/kin-openapi/pull/970
+// --max-circular-dep is no longer needed because kin-openapi3 handles circular references automatically since https://github.com/oasdiff/kin-openapi/pull/970
 // we still accept --max-circular-dep to avoid breaking existing scripts, but we ignore this flag
 func addHiddenCircularDepFlag(cmd *cobra.Command) {
 	cmd.PersistentFlags().Int("max-circular-dep", 5, "maximum allowed number of circular dependencies between objects in OpenAPI specs")

--- a/internal/diff.go
+++ b/internal/diff.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/oasdiff/oasdiff/formatters"
 	"github.com/oasdiff/oasdiff/load"

--- a/internal/flatten.go
+++ b/internal/flatten.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/formatters"
 	"github.com/oasdiff/oasdiff/load"
 	"github.com/spf13/cobra"

--- a/load/load.go
+++ b/load/load.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // from is a convenience function that opens an OpenAPI spec from a URL or a local path based on the format of the path parameter

--- a/load/option.go
+++ b/load/option.go
@@ -3,7 +3,7 @@ package load
 import (
 	"fmt"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/flatten/allof"
 	"github.com/oasdiff/oasdiff/flatten/commonparams"
 	"github.com/oasdiff/oasdiff/flatten/headers"

--- a/load/spec_info.go
+++ b/load/spec_info.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/yargevad/filepathx"
 )
 

--- a/load/spec_info_git_test.go
+++ b/load/spec_info_git_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/load"
 	"github.com/stretchr/testify/require"
 )

--- a/load/spec_info_pair_test.go
+++ b/load/spec_info_pair_test.go
@@ -3,7 +3,7 @@ package load_test
 import (
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/load"
 	"github.com/stretchr/testify/require"
 )

--- a/load/spec_info_test.go
+++ b/load/spec_info_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/load"
 	"github.com/stretchr/testify/require"
 )

--- a/load/spec_info_unix_test.go
+++ b/load/spec_info_unix_test.go
@@ -5,7 +5,7 @@ package load_test
 import (
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/load"
 	"github.com/stretchr/testify/require"
 )

--- a/load/spec_info_windows_test.go
+++ b/load/spec_info_windows_test.go
@@ -3,7 +3,7 @@ package load_test
 import (
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/load"
 	"github.com/stretchr/testify/require"
 )

--- a/report/example_test.go
+++ b/report/example_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/oasdiff/oasdiff/report"
 )

--- a/report/text_test.go
+++ b/report/text_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/oasdiff/oasdiff/report"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
## Summary
- Fixes #810: `go install github.com/oasdiff/oasdiff@latest` was failing because `replace` directives are not allowed in non-main modules
- Replaces `github.com/getkin/kin-openapi` (with replace directive) with `github.com/oasdiff/kin-openapi v0.136.0` directly
- `oasdiff/kin-openapi v0.136.0` includes all fixes from #806, #808, and the module rename

## Test plan
- [x] All existing tests pass
- [x] No `replace` directive in `go.mod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)