### PR TITLE
Add Fingerprint field to formatters.Change

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -4,7 +4,9 @@ description: Commit changes in the oasdiff repo, running required pre-commit ste
 allowed-tools: Bash, Read, Glob, Grep
 ---
 
-Before committing in this repo, you MUST run:
+## Pre-commit steps (REQUIRED before every commit)
+
+Run this command first:
 
 ```
 make doc-breaking-changes
@@ -12,4 +14,12 @@ make doc-breaking-changes
 
 This regenerates `docs/BREAKING-CHANGES-EXAMPLES.md` from the current test files. The CI build will fail if this file is out of date. Include any changes to this file in the commit.
 
-After running that command, follow the standard commit process: stage files, write a concise commit message, and commit.
+## Git workflow
+
+NEVER push directly to main. Always:
+1. Create a feature/fix branch
+2. Commit changes there
+3. Push the branch
+4. Open a PR
+
+After the pre-commit step and staging files, write a concise commit message and commit.

--- a/docs/FINGERPRINT.md
+++ b/docs/FINGERPRINT.md
@@ -1,0 +1,71 @@
+# Change Fingerprints
+
+Each changelog entry reported by oasdiff includes a `fingerprint` — a short, stable identifier derived from the content of the change.
+
+## What it is
+
+A fingerprint is a 12-character hex string computed as:
+
+```
+SHA256("{id}:{operation}:{path}:{text}")[:12]
+```
+
+Where `id` is the rule ID (e.g. `response-success-status-removed`), `operation` is the HTTP method, `path` is the API path, and `text` is the human-readable change description.
+
+## Why it's useful
+
+The fingerprint is **stable across commits** — the same breaking change in a PR gets the same fingerprint regardless of which commit introduced it. This makes it possible to:
+
+- **Track review decisions** across commits: if a reviewer approves a breaking change on commit A, the approval can be carried forward when commit B is pushed and the same change is still present
+- **Deduplicate changes** when comparing results from multiple runs
+- **Reference specific changes** in external systems (CI, review tools, audit logs) without storing the full change text
+
+## Output formats
+
+Fingerprints appear in JSON and YAML output:
+
+### JSON (`-f json`)
+
+```json
+{
+  "id": "response-success-status-removed",
+  "text": "removed the success response with status '200'",
+  "level": 3,
+  "operation": "GET",
+  "path": "/users/{id}",
+  "section": "paths",
+  "fingerprint": "a3f8c21b9d04"
+}
+```
+
+### YAML (`-f yaml`)
+
+```yaml
+- id: response-success-status-removed
+  text: removed the success response with status '200'
+  level: 3
+  operation: GET
+  path: /users/{id}
+  section: paths
+  fingerprint: a3f8c21b9d04
+```
+
+## Usage in Go
+
+When using oasdiff as a Go library, the fingerprint is available on each `formatters.Change`:
+
+```go
+import (
+    "github.com/oasdiff/oasdiff/formatters"
+    "github.com/oasdiff/oasdiff/checker"
+)
+
+changes := formatters.NewChanges(checkerChanges, localizer)
+for _, c := range changes {
+    fmt.Printf("change %s fingerprint: %s\n", c.Id, c.Fingerprint)
+}
+```
+
+## Collision probability
+
+The fingerprint is 12 hex characters (48 bits). For a typical PR with tens of breaking changes, the collision probability is negligible. If two changes happen to share a fingerprint, they are treated as the same change — in practice this will not occur for realistic API diffs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@ docker run --rm -t tufin/oasdiff changelog https://raw.githubusercontent.com/oas
 ## Features
 - [OpenAPI 3.1 support](OPENAPI-31.md) (beta)
 - [Source location tracking](SOURCE-LOCATOR.md) for inline PR annotations
+- [Change fingerprints](FINGERPRINT.md) for stable cross-commit change identity
 - Detect [breaking changes](BREAKING-CHANGES.md)
 - Display a user-friendly [changelog](BREAKING-CHANGES.md) of all important API changes
 - Generate comprehensive [diff](DIFF.md) reports including all aspects of [OpenAPI Specification](https://swagger.io/specification/): paths, operations, parameters, request bodies, responses, schemas, enums, callbacks, security etc.

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,15 +54,15 @@ docker run --rm -t tufin/oasdiff changelog https://raw.githubusercontent.com/oas
 
 ## Features
 - [OpenAPI 3.1 support](OPENAPI-31.md) (beta)
-- [Source location tracking](SOURCE-LOCATOR.md) for inline PR annotations
-- [Change fingerprints](FINGERPRINT.md) for stable cross-commit change identity
 - Detect [breaking changes](BREAKING-CHANGES.md)
 - Display a user-friendly [changelog](BREAKING-CHANGES.md) of all important API changes
 - Generate comprehensive [diff](DIFF.md) reports including all aspects of [OpenAPI Specification](https://swagger.io/specification/): paths, operations, parameters, request bodies, responses, schemas, enums, callbacks, security etc.
 - Output reports in YAML, JSON, Text, Markdown, HTML, JUnit XML or the [github actions annotation format](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-warning-message)
+- [Source location tracking](SOURCE-LOCATOR.md)
 - [Customize HTML and Markdown changelog reports](USAGE_EXAMPLES.md#openapi-changelog-with-custom-template)
 - Compare specs from local files, http/s URLs, or [git revisions](GIT-REVISION.md)
 - Compare specs in YAML or JSON format
+- [Change fingerprints](FINGERPRINT.md) for stable cross-commit change identity
 - [Compare two collections of specs](COMPOSED.md)
 - [Deprecate APIs and Parameters](DEPRECATION.md)
 - [API stability levels](STABILITY.md)

--- a/formatters/changes.go
+++ b/formatters/changes.go
@@ -1,6 +1,10 @@
 package formatters
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
 	"github.com/oasdiff/oasdiff/checker"
 )
 
@@ -18,6 +22,7 @@ type Change struct {
 	Attributes     map[string]any  `json:"attributes,omitempty" yaml:"attributes,omitempty"`
 	BaseSource     *checker.Source `json:"baseSource,omitempty" yaml:"baseSource,omitempty"`
 	RevisionSource *checker.Source `json:"revisionSource,omitempty" yaml:"revisionSource,omitempty"`
+	Fingerprint    string          `json:"fingerprint,omitempty" yaml:"fingerprint,omitempty"`
 }
 
 type Changes []Change
@@ -25,20 +30,31 @@ type Changes []Change
 func NewChanges(originalChanges checker.Changes, l checker.Localizer) Changes {
 	changes := make(Changes, len(originalChanges))
 	for i, change := range originalChanges {
+		id := change.GetId()
+		operation := change.GetOperation()
+		path := change.GetPath()
+		text := change.GetUncolorizedText(l)
 		changes[i] = Change{
 			Section:        change.GetSection(),
-			Id:             change.GetId(),
-			Text:           change.GetUncolorizedText(l),
+			Id:             id,
+			Text:           text,
 			Comment:        change.GetComment(l),
 			Level:          change.GetLevel(),
-			Operation:      change.GetOperation(),
+			Operation:      operation,
 			OperationId:    change.GetOperationId(),
-			Path:           change.GetPath(),
+			Path:           path,
 			Source:         change.GetSource(),
 			Attributes:     change.GetAttributes(),
 			BaseSource:     change.GetBaseSource(),
 			RevisionSource: change.GetRevisionSource(),
+			Fingerprint:    computeFingerprint(id, operation, path, text),
 		}
 	}
 	return changes
+}
+
+func computeFingerprint(id, operation, path, text string) string {
+	h := fmt.Sprintf("%s:%s:%s:%s", id, operation, path, text)
+	sum := sha256.Sum256([]byte(h))
+	return hex.EncodeToString(sum[:])[:12]
 }

--- a/formatters/format_json_test.go
+++ b/formatters/format_json_test.go
@@ -29,7 +29,7 @@ func TestJsonFormatter_RenderChangelog(t *testing.T) {
 
 	out, err := jsonFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), "", "")
 	require.NoError(t, err)
-	require.Equal(t, "[{\"id\":\"change_id\",\"text\":\"This is a breaking change.\",\"level\":3,\"section\":\"components\"}]", string(out))
+	require.Equal(t, "[{\"id\":\"change_id\",\"text\":\"This is a breaking change.\",\"level\":3,\"section\":\"components\",\"fingerprint\":\"d22c5b8b9cec\"}]", string(out))
 }
 
 func TestJsonFormatter_RenderChecks(t *testing.T) {
@@ -87,6 +87,6 @@ func TestJsonFormatter_RenderChangelog_WithSources(t *testing.T) {
 	require.NoError(t, err)
 
 	// Parse and check that baseSource is included but revisionSource is not (due to omitempty)
-	expected := `[{"id":"change_id","text":"This is a breaking change.","level":3,"operation":"GET","path":"/test","section":"paths","baseSource":{"file":"base.yaml","line":10,"column":5}}]`
+	expected := `[{"id":"change_id","text":"This is a breaking change.","level":3,"operation":"GET","path":"/test","section":"paths","baseSource":{"file":"base.yaml","line":10,"column":5},"fingerprint":"ebee3a862e95"}]`
 	require.Equal(t, expected, string(out))
 }

--- a/formatters/format_yaml_test.go
+++ b/formatters/format_yaml_test.go
@@ -30,7 +30,7 @@ func TestYamlFormatter_RenderChangelog(t *testing.T) {
 
 	out, err := yamlFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), "", "")
 	require.NoError(t, err)
-	require.Equal(t, "- id: change_id\n  text: This is a breaking change.\n  level: 3\n  section: components\n", string(out))
+	require.Equal(t, "- id: change_id\n  text: This is a breaking change.\n  level: 3\n  section: components\n  fingerprint: d22c5b8b9cec\n", string(out))
 }
 
 func TestYamlFormatter_RenderChangelogWithWrapInObject(t *testing.T) {
@@ -114,6 +114,7 @@ func TestYamlFormatter_RenderChangelog_WithSources(t *testing.T) {
     file: revision.yaml
     line: 12
     column: 7
+  fingerprint: 50fb7e2d3284
 `
 	require.Equal(t, expected, string(out))
 }


### PR DESCRIPTION
## Summary

- Adds a `Fingerprint` field to `formatters.Change`, computed as `SHA256({id}:{operation}:{path}:{text})[:12]`
- Fingerprint is stable across commits — the same breaking change always gets the same fingerprint
- Included in JSON and YAML output; computed once in `NewChanges()` and flows through all consumers
- Adds `docs/FINGERPRINT.md` explaining the feature with output examples and Go API usage

## Use cases

- Track review decisions across commits (approve a change on commit A, carry the decision forward to commit B)
- Deduplicate changes across multiple runs
- Reference specific changes in external systems without storing full change text

🤖 Generated with [Claude Code](https://claude.com/claude-code)