### PR TITLE
fix: strip origin metadata from extensions before comparing

### DIFF
--- a/diff/extensions_diff.go
+++ b/diff/extensions_diff.go
@@ -17,6 +17,16 @@ func getExtensionsDiff(config *Config, extensions1, extensions2 map[string]any) 
 	filtered1 := filterExtensions(extensions1, config)
 	filtered2 := filterExtensions(extensions2, config)
 
+	// Strip origin metadata from extension values before comparing.
+	// When IncludeOrigin is enabled, the YAML parser injects __origin__ keys
+	// into all parsed objects. For known schema fields, kin-openapi strips these
+	// during unmarshal, but unknown fields (e.g. propertyNames) stored in the
+	// raw Extensions map retain embedded __origin__ data that includes file paths.
+	// This causes false diffs when comparing identical content loaded from
+	// different files.
+	stripOrigin(filtered1)
+	stripOrigin(filtered2)
+
 	diff, err := getExtensionsDiffInternal(filtered1, filtered2)
 	if err != nil {
 		return nil, err
@@ -31,6 +41,16 @@ func getExtensionsDiff(config *Config, extensions1, extensions2 map[string]any) 
 
 func getExtensionsDiffInternal(extensions1, extensions2 map[string]any) (*InterfaceMapDiff, error) {
 	return getInterfaceMapDiff(extensions1, extensions2)
+}
+
+// stripOrigin recursively removes __origin__ keys from a map.
+func stripOrigin(m map[string]any) {
+	delete(m, "__origin__")
+	for _, v := range m {
+		if nested, ok := v.(map[string]any); ok {
+			stripOrigin(nested)
+		}
+	}
 }
 
 // filterExtensions returns a copy of the extensions map with excluded extensions removed

--- a/diff/subschemas_diff.go
+++ b/diff/subschemas_diff.go
@@ -286,7 +286,7 @@ func getNonContainedInlineSchemas(config *Config, state *state, schemaRefs1, sch
 
 func findIndenticalSchema(config *Config, state *state, schemaRef1 *openapi3.SchemaRef, schemasRefs2 openapi3.SchemaRefs, matched map[int]struct{}, filter schemaRefsFilter) (bool, int, error) {
 	for index2, schemaRef2 := range schemasRefs2 {
-		if !filter(schemaRef1) {
+		if !filter(schemaRef2) {
 			continue
 		}
 		if alreadyMatched(index2, matched) {


### PR DESCRIPTION
When IncludeOrigin is enabled, the YAML parser injects __origin__ keys (containing file paths and line numbers) into all parsed objects. For known schema fields, kin-openapi strips these during unmarshal. However, unknown JSON Schema keywords (e.g. propertyNames) are stored in the raw Extensions map and retain embedded __origin__ data.

This causes false diffs when comparing identical specs loaded from different file paths, because the __origin__.fields.*.file values differ.

The fix strips __origin__ keys recursively from extension values before comparing them.

Also fixes the filter in findIndenticalSchema which was checking schemaRef1 instead of schemaRef2, meaning the filter had no effect on which candidates were considered for matching.

Minimum repro:

```yaml
# repro.yaml
openapi: 3.1.0
info:
  title: Repro
  version: 1.0.0
paths:
  /test:
    get:
      responses:
        "200":
          description: OK
          content:
            application/json:
              schema:
                type: object
                properties:
                  data:
                    anyOf:
                      - type: object
                        properties:
                          a:
                            type: object
                            propertyNames:
                              type: string
                      - type: object
                        properties:
                          b:
                            type: object
                            propertyNames:
                              type: string
```