### PR TITLE
fix: bump kin-openapi to v0.136.2 and yaml/yaml3 to v0.0.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	cloud.google.com/go v0.123.0
 	github.com/TwiN/go-color v1.4.1
-	github.com/oasdiff/kin-openapi v0.136.1
+	github.com/oasdiff/kin-openapi v0.136.2
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
@@ -19,8 +19,8 @@ require (
 	github.com/go-openapi/swag/jsonname v0.25.5 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/oasdiff/yaml v0.0.1 // indirect
-	github.com/oasdiff/yaml3 v0.0.1 // indirect
+	github.com/oasdiff/yaml v0.0.3 // indirect
+	github.com/oasdiff/yaml3 v0.0.3 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,16 +37,10 @@ github.com/mailru/easyjson v0.9.2 h1:dX8U45hQsZpxd80nLvDGihsQ/OxlvTkVUXH2r/8cb2M
 github.com/mailru/easyjson v0.9.2/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
-github.com/oasdiff/kin-openapi v0.136.1 h1:x1G9doDyPcagCNXDcMK5dt5yAmIgsSCiK7F5gPUiQdM=
-github.com/oasdiff/kin-openapi v0.136.1/go.mod h1:BMeaLn+GmFJKtHJ31JrgXFt91eZi/q+Og4tr7sq0BzI=
 github.com/oasdiff/kin-openapi v0.136.2 h1:0rVZcXuJsS5ekuR4svegnpVXGCkHZhsq3OEipxGidYE=
 github.com/oasdiff/kin-openapi v0.136.2/go.mod h1:xuAA2Bs8GURkUsmEsvVgXeZ6u80ibYUDDe7t8KCmNW4=
-github.com/oasdiff/yaml v0.0.1 h1:dPrn0F2PJ7HdzHPndJkArvB2Fw0cwgFdVUKCEkoFuds=
-github.com/oasdiff/yaml v0.0.1/go.mod h1:r8bgVgpWT5iIN/AgP0GljFvB6CicK+yL1nIAbm+8/QQ=
 github.com/oasdiff/yaml v0.0.3 h1:IORGNY4IZ1+SKFSUuu288zE/33JYxx0FWp3ZTqn+Hdc=
 github.com/oasdiff/yaml v0.0.3/go.mod h1:cGJc1tLIzdmJs4PPPJsLHDh2j1bEgJLDyZ02wyp5tvg=
-github.com/oasdiff/yaml3 v0.0.1 h1:kReOSraQLTxuuGNX9aNeJ7tcsvUB2MS+iupdUrWe4Z0=
-github.com/oasdiff/yaml3 v0.0.1/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 github.com/oasdiff/yaml3 v0.0.3 h1:AoDWNMgx8ND5gmaxeUSX4LjrlxrYB6CGzKdVi/1zAPQ=
 github.com/oasdiff/yaml3 v0.0.3/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=

--- a/go.sum
+++ b/go.sum
@@ -39,10 +39,16 @@ github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/oasdiff/kin-openapi v0.136.1 h1:x1G9doDyPcagCNXDcMK5dt5yAmIgsSCiK7F5gPUiQdM=
 github.com/oasdiff/kin-openapi v0.136.1/go.mod h1:BMeaLn+GmFJKtHJ31JrgXFt91eZi/q+Og4tr7sq0BzI=
+github.com/oasdiff/kin-openapi v0.136.2 h1:0rVZcXuJsS5ekuR4svegnpVXGCkHZhsq3OEipxGidYE=
+github.com/oasdiff/kin-openapi v0.136.2/go.mod h1:xuAA2Bs8GURkUsmEsvVgXeZ6u80ibYUDDe7t8KCmNW4=
 github.com/oasdiff/yaml v0.0.1 h1:dPrn0F2PJ7HdzHPndJkArvB2Fw0cwgFdVUKCEkoFuds=
 github.com/oasdiff/yaml v0.0.1/go.mod h1:r8bgVgpWT5iIN/AgP0GljFvB6CicK+yL1nIAbm+8/QQ=
+github.com/oasdiff/yaml v0.0.3 h1:IORGNY4IZ1+SKFSUuu288zE/33JYxx0FWp3ZTqn+Hdc=
+github.com/oasdiff/yaml v0.0.3/go.mod h1:cGJc1tLIzdmJs4PPPJsLHDh2j1bEgJLDyZ02wyp5tvg=
 github.com/oasdiff/yaml3 v0.0.1 h1:kReOSraQLTxuuGNX9aNeJ7tcsvUB2MS+iupdUrWe4Z0=
 github.com/oasdiff/yaml3 v0.0.1/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
+github.com/oasdiff/yaml3 v0.0.3 h1:AoDWNMgx8ND5gmaxeUSX4LjrlxrYB6CGzKdVi/1zAPQ=
+github.com/oasdiff/yaml3 v0.0.3/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=


### PR DESCRIPTION
Picks up fixes for YAML anchor/alias handling (regression tests for #821):

- **yaml3 v0.0.2**: prevent duplicate `__origin__` keys when a YAML anchor is used as an alias
- **yaml3 v0.0.3**: skip `__origin__` entries during alias expansion to prevent spurious "document contains excessive aliasing" errors on large specs

Dependency chain: `yaml3 v0.0.3` → `yaml v0.0.3` → `kin-openapi v0.136.2` → `oasdiff`