### PR TITLE
bump: kin-openapi to v0.136.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	cloud.google.com/go v0.123.0
 	github.com/TwiN/go-color v1.4.1
-	github.com/oasdiff/kin-openapi v0.136.3
+	github.com/oasdiff/kin-openapi v0.136.4
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/mailru/easyjson v0.9.2 h1:dX8U45hQsZpxd80nLvDGihsQ/OxlvTkVUXH2r/8cb2M
 github.com/mailru/easyjson v0.9.2/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
-github.com/oasdiff/kin-openapi v0.136.3 h1:rNkvbXSbUG/yFkktRRijuW20as7B/uMRfyOU5juYS6g=
-github.com/oasdiff/kin-openapi v0.136.3/go.mod h1:P7JOZRsZdRww4urEHzu0VFejiJC25RbS7XqQ4h4KDFQ=
+github.com/oasdiff/kin-openapi v0.136.4 h1:idO/oW/6liYIOns49liiCN8KbUke7ckWoi+dePDu6Dc=
+github.com/oasdiff/kin-openapi v0.136.4/go.mod h1:P7JOZRsZdRww4urEHzu0VFejiJC25RbS7XqQ4h4KDFQ=
 github.com/oasdiff/yaml v0.0.4 h1:airPco4LbUoK4nbVwu+wwkRg2WarLC96cgBhgN93fsE=
 github.com/oasdiff/yaml v0.0.4/go.mod h1:EaJ6/lcrRLK+syawtvtrHdbrrln4/SUmQw6aBTIlaMs=
 github.com/oasdiff/yaml3 v0.0.4 h1:U5RTQZpBmsbcyCFlzPVuMctk6Jme6lOrbl0jJoOovMw=


### PR DESCRIPTION
## Summary

- Bumps `github.com/oasdiff/kin-openapi` from v0.136.3 → v0.136.4
- Strips `__origin__` from extension values (`map[string]any`) to prevent spurious diffs when comparing specs loaded from different file paths
- Also strips `__origin__` from slices inside `any`-typed fields (PR #4 fix included in v0.136.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)