### PR TITLE
docs+test: improve NewSource doc and harden repo-root $ref test

### DIFF
--- a/load/source.go
+++ b/load/source.go
@@ -21,20 +21,23 @@ type Source struct {
 	Type SourceType
 }
 
-// NewSource creates a Source by categorizing the input path as stdin, URL, or file.
+// NewSource creates a Source by categorizing the input path as stdin, URL, git revision, or file.
 // This function is intentionally infallible (does not return an error) to allow
 // clean usage in struct literal initialization and avoid error handling boilerplate
 // in hundreds of call sites throughout the codebase.
 //
-// Design rationale:
-//   - Valid http/https URLs are categorized as SourceTypeURL
-//   - "-" is categorized as SourceTypeStdin
-//   - Everything else (including URLs with invalid schemes like ftp://) is categorized as SourceTypeFile
-//   - Actual validation and error handling occurs later when the Loader interface methods
-//     (LoadFromURI, LoadFromFile, LoadFromStdin) are called
+// Categorization rules (evaluated in order):
+//   - "-" → SourceTypeStdin
+//   - Git revision syntax (e.g. "HEAD:openapi.yaml", "origin/main:api/openapi.yaml") → SourceTypeGitRevision
+//   - Valid http/https URLs → SourceTypeURL
+//   - Everything else (including URLs with unsupported schemes) → SourceTypeFile
 //
-// This design provides clean separation of concerns: NewSource categorizes inputs,
-// while Loader implementations handle validation and produce appropriate error messages.
+// Git revision syntax is "<ref>:<path>" where <ref> is any git ref (branch, tag, commit SHA,
+// or expressions like HEAD~1) and <path> is the file path within the repo. Multi-file specs
+// with relative $refs are fully supported — referenced files are also read via "git show".
+//
+// Actual validation and error handling occurs later when the source is loaded, providing
+// clean separation of concerns between categorization and I/O.
 func NewSource(path string) *Source {
 	if path == "-" {
 		return &Source{

--- a/load/spec_info_git_test.go
+++ b/load/spec_info_git_test.go
@@ -191,6 +191,13 @@ properties:
 	run("git", "add", ".")
 	run("git", "commit", "-m", "add multi-file spec")
 
+	// Remove the files after committing so they only exist in git history.
+	// This ensures $ref resolution must go through "git show" — if the
+	// repo-root gitPrefix restoration fails, the relative ref resolves to
+	// "schemas/pet.yaml" (no "HEAD:" prefix) and the load will fail.
+	require.NoError(t, os.Remove(filepath.Join(dir, "openapi.yaml")))
+	require.NoError(t, os.Remove(filepath.Join(dir, "schemas", "pet.yaml")))
+
 	oldDir, err := os.Getwd()
 	require.NoError(t, err)
 	require.NoError(t, os.Chdir(dir))


### PR DESCRIPTION
## Changes

**`load/source.go`** — `NewSource` doc comment now covers git revision syntax:
- Documents all 4 source types in categorization order
- Explains the `<ref>:<path>` format with examples
- Notes multi-file `$ref` support via `git show`

**`load/spec_info_git_test.go`** — `TestLoadInfo_GitRevisionWithExternalRef` now deletes the committed files after `git commit`, forcing all `$ref` resolution through `git show`. Previously the files remained on disk, so the test would pass even if the repo-root gitPrefix restoration was broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)