### PR TITLE
ci: dispatch event to downstream on new release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,3 +48,12 @@ jobs:
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
+
+      - name: Notify downstream
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CROSS_REPO_TOKEN }}
+          repository: oasdiff/enterprise
+          event-type: oasdiff-released
+          client-payload: '{"tag": "${{ github.ref_name }}"}'


### PR DESCRIPTION
## Summary
After a Docker image is published from a tag push, send a `repository_dispatch` event so downstream version bumps can be automated.

## Setup required
- `CROSS_REPO_TOKEN` secret: a PAT or GitHub App token with `repo` scope on the target repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)