### PR TITLE
Report a removed response schema as an error

### DIFF
--- a/checker/check_media_type_schema_existence_test.go
+++ b/checker/check_media_type_schema_existence_test.go
@@ -11,7 +11,7 @@ import (
 // A schema appearing in / disappearing from a media type that exists on both
 // sides is classified by request/response contravariance (#1050):
 //   - request schema added   -> ERR  (narrows accepted input)
-//   - response schema removed -> WARN (drops the output guarantee)
+//   - response schema removed -> ERR  (drops the output guarantee)
 //   - request schema removed  -> INFO (more permissive)
 //   - response schema added   -> INFO (more specific)
 func TestMediaTypeSchemaExistence(t *testing.T) {
@@ -47,4 +47,30 @@ func TestMediaTypeSchemaExistence(t *testing.T) {
 	all = checker.CheckBackwardCompatibilityUntilLevel(allChecksConfig(), d, osm, checker.INFO)
 	require.True(t, containsId(all, checker.RequestBodyMediaTypeSchemaRemovedId),
 		"request schema removed is reported at INFO")
+}
+
+// Removing a response schema is an error, not a warning. It contains changes
+// that are errors on their own: a media type with no schema constrains the body
+// no more than one that never declared a property, and both
+// response-media-type-removed above it and response-required-property-removed
+// below it are errors, so a warning here dips in the middle of a containment
+// chain. See #1140, and #1141 for the guard that would catch the class.
+func TestResponseSchemaRemoved_IsAnError(t *testing.T) {
+	base, err := open("../data/media-type-schema/base.yaml")
+	require.NoError(t, err)
+	revision, err := open("../data/media-type-schema/revision.yaml")
+	require.NoError(t, err)
+
+	// revision -> base, so the response media types lose their schema.
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), revision, base)
+	require.NoError(t, err)
+
+	changes := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
+	for _, c := range changes {
+		if c.GetId() == checker.ResponseBodyMediaTypeSchemaRemovedId {
+			require.Equal(t, checker.ERR, c.GetLevel())
+			return
+		}
+	}
+	t.Fatal("expected a response-body-media-type-schema-removed change")
 }

--- a/checker/rules.go
+++ b/checker/rules.go
@@ -282,7 +282,7 @@ func GetAllRules() BackwardCompatibilityRules {
 		newBackwardCompatibilityRule(RequestBodyMediaTypeSchemaAddedId, ERR, MediaTypeSchemaExistenceCheck, DirectionRequest, AreaRequestBody, KindExistence, ActionAdd),
 		newBackwardCompatibilityRule(RequestBodyMediaTypeSchemaRemovedId, INFO, MediaTypeSchemaExistenceCheck, DirectionRequest, AreaRequestBody, KindExistence, ActionRemove),
 		newBackwardCompatibilityRule(ResponseBodyMediaTypeSchemaAddedId, INFO, MediaTypeSchemaExistenceCheck, DirectionResponse, AreaResponses, KindExistence, ActionAdd),
-		newBackwardCompatibilityRule(ResponseBodyMediaTypeSchemaRemovedId, WARN, MediaTypeSchemaExistenceCheck, DirectionResponse, AreaResponses, KindExistence, ActionRemove),
+		newBackwardCompatibilityRule(ResponseBodyMediaTypeSchemaRemovedId, ERR, MediaTypeSchemaExistenceCheck, DirectionResponse, AreaResponses, KindExistence, ActionRemove),
 		// MediaTypeSchemaExistenceCheck: the same, for the OpenAPI 3.2 itemSchema.
 		newBackwardCompatibilityRule(RequestBodyMediaTypeItemSchemaAddedId, ERR, MediaTypeSchemaExistenceCheck, DirectionRequest, AreaRequestBody, KindExistence, ActionAdd),
 		newBackwardCompatibilityRule(RequestBodyMediaTypeItemSchemaRemovedId, INFO, MediaTypeSchemaExistenceCheck, DirectionRequest, AreaRequestBody, KindExistence, ActionRemove),


### PR DESCRIPTION
Closes #1140.

`response-body-media-type-schema-removed` was `WARN` while both the change that contains it and the change it contains were `ERR`. Confirmed from the rule registry rather than by reading:

| change | level before | level after |
|---|---|---|
| `response-media-type-removed` | error | error |
| `response-body-media-type-schema-removed` | **warning** | **error** |
| `response-required-property-removed` | error | error |

Removing one required property from a response is an error. Removing the schema removes that property, every other property, and the type constraint along with them, and was reported a level lower.

`WARN` is for a change the definition cannot decide. This one it can: a media type with no `schema` places no constraint on the body at all, so every guarantee the consumer had is gone. The argument for the lower level is that the server may keep returning the same shape, which is runtime tolerance rather than contract validity, and severity does not bend to it. Contravariance agrees: `request-body-media-type-schema-added` is `ERR`, and loosening a response is the mirror of constraining a request.

## What changes for users

`oasdiff breaking` reports the same set, since it already includes `WARN`. What changes is the reported level and what `--fail-on ERR` gates on, so a pipeline gating on errors that tolerated this will now fail. That is the point of the change, but it is the reason this is its own PR rather than riding along with other work.

## One thing in the issue is now out of date

#1140 notes the sibling `response-body-media-type-item-schema-removed` has a reason to stay `WARN`, since `schema` and `itemSchema` can coexist. That reasoning was examined in #1139 and did not hold: the two constrain different things, so a remaining body schema does not restore the per-item guarantee. It is already `ERR`. The two rules agree rather than diverge.

## Tests

Nothing pinned this level, which is how it drifted. `TestResponseSchemaRemoved_IsAnError` fails if it moves back, verified by reverting the rule and watching it fail. The file's header comment documented the old `WARN` and is corrected.

The class of defect, and why `TestRuleSymmetry` is structurally blind to it, is #1141.