### PR TITLE
Move the enum checkers onto the media-type walker

### DIFF
--- a/checker/check_request_body_became_enum.go
+++ b/checker/check_request_body_became_enum.go
@@ -10,42 +10,15 @@ const (
 
 func RequestBodyBecameEnumCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if info.schemaDiff.EnumDiff == nil || !info.schemaDiff.EnumDiff.EnumAdded {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
+		baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "enum")
+		result = append(result, info.newChange(RequestBodyBecameEnumId, nil, "").
+			WithSources(baseSource, revisionSource))
+	})
 
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
-			}
-
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
-				schemaDiff := mediaTypeDiff.SchemaDiff
-				if schemaDiff.EnumDiff == nil || !schemaDiff.EnumDiff.EnumAdded {
-					continue
-				}
-				baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, schemaDiff, "enum")
-				result = append(result, opInfo.NewApiChange(
-					RequestBodyBecameEnumId,
-					nil,
-					"",
-				).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-			}
-		}
-	}
 	return result
 }

--- a/checker/check_request_body_enum_deleted.go
+++ b/checker/check_request_body_enum_deleted.go
@@ -12,48 +12,18 @@ const (
 
 func RequestBodyEnumValueRemovedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		enumDiff := info.schemaDiff.EnumDiff
+		if enumDiff == nil || enumDiff.Deleted == nil {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil {
-				continue
-			}
-			if operationItem.RequestBodyDiff.ContentDiff == nil {
-				continue
-			}
-			if operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
-			}
-
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-
-			mediaTypeChanges := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-
-			for _, mediaTypeItem := range mediaTypeChanges {
-				if mediaTypeItem.SchemaDiff == nil {
-					continue
-				}
-
-				schemaDiff := mediaTypeItem.SchemaDiff
-				enumDiff := schemaDiff.EnumDiff
-				if enumDiff == nil || enumDiff.Deleted == nil {
-					continue
-				}
-				for _, enumVal := range enumDiff.Deleted {
-					baseSource, revisionSource := SchemaDeletedItemSources(operationsSources, operationItem, schemaDiff, "enum", fmt.Sprintf("%v", enumVal))
-					result = append(result, opInfo.NewApiChange(
-						RequestBodyEnumValueRemovedId,
-						[]any{enumVal},
-						"",
-					).WithSources(baseSource, revisionSource))
-				}
-			}
+		for _, enumVal := range enumDiff.Deleted {
+			baseSource, revisionSource := SchemaDeletedItemSources(operationsSources, info.operationItem, info.schemaDiff, "enum", fmt.Sprintf("%v", enumVal))
+			result = append(result, info.newChange(RequestBodyEnumValueRemovedId, []any{enumVal}, "").
+				WithSources(baseSource, revisionSource))
 		}
-	}
+	})
+
 	return result
 }

--- a/checker/check_response_mediatype_enum_value_removed.go
+++ b/checker/check_response_mediatype_enum_value_removed.go
@@ -12,50 +12,18 @@ const (
 
 func ResponseMediaTypeEnumValueRemovedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		enumDiff := info.schemaDiff.EnumDiff
+		if enumDiff == nil {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil {
-				continue
-			}
-			if operationItem.ResponsesDiff.Modified == nil {
-				continue
-			}
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-			for _, responseItems := range operationItem.ResponsesDiff.Modified {
-				if responseItems.ContentDiff == nil {
-					continue
-				}
-
-				if responseItems.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-				for mediaType, mediaTypeItem := range responseItems.ContentDiff.MediaTypeModified {
-					if mediaTypeItem.SchemaDiff == nil {
-						continue
-					}
-
-					enumDiff := mediaTypeItem.SchemaDiff.EnumDiff
-					if enumDiff == nil {
-						continue
-					}
-
-					for _, enumVal := range enumDiff.Deleted {
-						baseSource, revisionSource := SchemaDeletedItemSources(operationsSources, operationItem, mediaTypeItem.SchemaDiff, "enum", fmt.Sprintf("%v", enumVal))
-						result = append(result, opInfo.NewApiChange(
-							ResponseMediaTypeEnumValueRemovedId,
-							[]any{mediaType, enumVal},
-							"",
-						).WithSources(baseSource, revisionSource))
-					}
-				}
-			}
+		for _, enumVal := range enumDiff.Deleted {
+			baseSource, revisionSource := SchemaDeletedItemSources(operationsSources, info.operationItem, info.schemaDiff, "enum", fmt.Sprintf("%v", enumVal))
+			result = append(result, info.newChange(ResponseMediaTypeEnumValueRemovedId, []any{info.mediaType, enumVal}, "").
+				WithSources(baseSource, revisionSource))
 		}
-	}
+	})
+
 	return result
 }


### PR DESCRIPTION
Part of #1121: three of the four traversals it lists. 171 lines of prelude become 82.

The issue calls this cleanup rather than a correctness gap. Migrating turned up two real defects the prelude was hiding, so it is worth reviewing as a fix rather than a tidy-up.

## Two of the three never attached the media-type details

That is the exact bug class the walker was built to prevent: a checker forgetting `WithDetails(mediaTypeDetails)`. A request body with two media types that each drop an enum value reported, before:

```
request body enum value removed `b`
request body enum value removed `b`
```

and now:

```
request body enum value removed `b` (media type: application/xml)
request body enum value removed `b` (media type: application/json)
```

## All three now cover itemSchema

The walker yields the OpenAPI 3.2 `itemSchema` alongside the body schema, so these checks reach streamed items without knowing about them. Removing an enum value from a streamed request item, which narrows what the server accepts:

| | |
|---|---|
| before | no changes detected |
| after | `error request body enum value removed \`b\` (item schema)` |

That was silent, and it is breaking for every producer.

## The one behaviour difference that could have lost findings

The walker requires the schema on **both** sides (`modifiedSchemaPresentBothSides`), where these checkers required only a non-nil `SchemaDiff`. So a media type whose schema is added or removed outright is no longer walked.

Nothing is lost: a wholly removed schema carries no `EnumDiff` to report, and `request-body-media-type-schema-removed` covers the case. Checked against `main` on exactly that input, with identical output before and after, rather than reasoned about.

## Not included

`check_property_stability_level.go`, the fourth file and the one #1121 flags as wanting a closer look. Its four loops emit through `checkPropertyStabilityChange`, which takes config, sources, operation, path and a result pointer rather than going through `opInfo.NewApiChange`, so migrating it means reworking that signature. Separate change, and #1121 stays open for it.

The three files #1121 lists as **cannot migrate** are unchanged and still cannot; the reasons recorded there hold.