### PR TITLE
Stop flatten dropping the 3.1 keywords it does not merge

### DIFF
--- a/docs/ALLOF.md
+++ b/docs/ALLOF.md
@@ -41,9 +41,17 @@ The following schema fields are not merged:
 - Deprecated
 - XML
 - Discriminator
+- `if` / `then` / `else` (OpenAPI 3.1)
+- `dependentSchemas` (OpenAPI 3.1)
+- `unevaluatedProperties` / `unevaluatedItems` (OpenAPI 3.1)
+- `patternProperties` (OpenAPI 3.1)
+- `prefixItems` (OpenAPI 3.1)
+- `contentSchema` (OpenAPI 3.1)
+- `examples` (OpenAPI 3.1)
+- `$id` / `$anchor` / `$dynamicRef` / `$dynamicAnchor` / `$schema` / `$comment` (OpenAPI 3.1)
 - `$defs` (OpenAPI 3.1) — intentionally dropped from the flattened output. `$defs` is a reusable-schema namespace used as the target of `$ref` pointers. After `--flatten-allof` runs, the merged schema has no `$ref`s left to resolve, so the namespace contributes nothing to its semantics. Preserving it would only add noise (and risk silent collisions when two `allOf` subschemas define different things under the same `$defs` key).
 
-The 3.1 / JSON Schema 2020-12 keywords the merge does not combine (`if`/`then`/`else`, `dependentSchemas`, `unevaluatedProperties`/`unevaluatedItems`, `patternProperties`, `prefixItems`, `contentSchema`, and the `$id`/`$anchor`/`$comment` family) are carried through from the outer schema rather than dropped, so a schema with no `allOf` round-trips unchanged. What is still lost is such a keyword on an `allOf` **subschema**: the merge has no rule for combining two `if`s or two `unevaluatedProperties`, so a subschema carrying one loses it ([#878](https://github.com/oasdiff/oasdiff/issues/878)).
+Every field above except `$defs` is taken from the outer schema, so a schema with no `allOf` round-trips unchanged. What is lost is such a field on an `allOf` **subschema**: with no rule for combining two `if`s or two `unevaluatedProperties`, a subschema carrying one loses it ([#878](https://github.com/oasdiff/oasdiff/issues/878)). For the 3.1 keywords that is not a neutral loss, since `unevaluatedProperties: false` turns a closed schema into an open one and the conditionals are whole validation branches.
 
 ## Invalid input handling
 

--- a/docs/ALLOF.md
+++ b/docs/ALLOF.md
@@ -43,7 +43,7 @@ The following schema fields are not merged:
 - Discriminator
 - `$defs` (OpenAPI 3.1) — intentionally dropped from the flattened output. `$defs` is a reusable-schema namespace used as the target of `$ref` pointers. After `--flatten-allof` runs, the merged schema has no `$ref`s left to resolve, so the namespace contributes nothing to its semantics. Preserving it would only add noise (and risk silent collisions when two `allOf` subschemas define different things under the same `$defs` key).
 
-In addition, the following fields are currently **dropped** from the flattened output, even for schemas that contain no `allOf` at all: `if`/`then`/`else`, `dependentSchemas`, and `unevaluatedProperties`. This is a known limitation ([#1097](https://github.com/oasdiff/oasdiff/issues/1097)); dropping `unevaluatedProperties: false` turns a closed schema into an open one, and dropping the conditionals removes validation branches, so a change inside them disappears from a `--flatten-allof` comparison.
+The 3.1 / JSON Schema 2020-12 keywords the merge does not combine (`if`/`then`/`else`, `dependentSchemas`, `unevaluatedProperties`/`unevaluatedItems`, `patternProperties`, `prefixItems`, `contentSchema`, and the `$id`/`$anchor`/`$comment` family) are carried through from the outer schema rather than dropped, so a schema with no `allOf` round-trips unchanged. What is still lost is such a keyword on an `allOf` **subschema**: the merge has no rule for combining two `if`s or two `unevaluatedProperties`, so a subschema carrying one loses it ([#878](https://github.com/oasdiff/oasdiff/issues/878)).
 
 ## Invalid input handling
 

--- a/flatten/allof/merge_allof.go
+++ b/flatten/allof/merge_allof.go
@@ -239,17 +239,41 @@ func mergeInternal(state *state, base *openapi3.SchemaRef) (*openapi3.SchemaRef,
 	result.Value.ContentMediaType = base.Value.ContentMediaType
 	result.Value.ContentEncoding = base.Value.ContentEncoding
 	result.Value.DependentRequired = base.Value.DependentRequired
-	result.Value.Discriminator = base.Value.Discriminator
-	// Fields documented in ALLOF.md as "not merged" — i.e. the merge
-	// logic doesn't combine them across allOf subschemas. They MUST
-	// still flow through from the outer (base) schema, otherwise a
-	// single-schema Merge silently loses them.
+	// Never combined across allOf subschemas: the outer schema's value is the
+	// result. ALLOF.md lists these.
+	//
+	// They still have to be copied, or a single-schema Merge, where there is
+	// nothing to combine, loses them. For the 3.1 keywords that is not a
+	// neutral loss: without unevaluatedProperties a closed schema becomes open,
+	// and without the conditionals a validation branch disappears. A subschema
+	// carrying one of them still loses it, which is #878.
 	result.Value.Example = base.Value.Example
 	result.Value.Deprecated = base.Value.Deprecated
 	result.Value.AllowEmptyValue = base.Value.AllowEmptyValue
 	result.Value.ExternalDocs = base.Value.ExternalDocs
 	result.Value.XML = base.Value.XML
 	result.Value.Extensions = base.Value.Extensions
+	result.Value.Discriminator = base.Value.Discriminator
+	result.Value.If = base.Value.If
+	result.Value.Then = base.Value.Then
+	result.Value.Else = base.Value.Else
+	result.Value.DependentSchemas = base.Value.DependentSchemas
+	result.Value.UnevaluatedProperties = base.Value.UnevaluatedProperties
+	result.Value.UnevaluatedItems = base.Value.UnevaluatedItems
+	result.Value.PatternProperties = base.Value.PatternProperties
+	result.Value.PrefixItems = base.Value.PrefixItems
+	result.Value.ContentSchema = base.Value.ContentSchema
+	result.Value.Examples = base.Value.Examples
+	result.Value.SchemaID = base.Value.SchemaID
+	result.Value.SchemaDialect = base.Value.SchemaDialect
+	result.Value.Anchor = base.Value.Anchor
+	result.Value.DynamicRef = base.Value.DynamicRef
+	result.Value.DynamicAnchor = base.Value.DynamicAnchor
+	result.Value.Comment = base.Value.Comment
+
+	// Combined across subschemas further down, most restrictive winning, but
+	// seeded from the outer schema here: with no siblings to combine there
+	// would otherwise be nothing to seed the result with.
 	if base.Value.MaxLength != nil {
 		result.Value.MaxLength = new(*base.Value.MaxLength)
 	}
@@ -263,33 +287,6 @@ func mergeInternal(state *state, base *openapi3.SchemaRef) (*openapi3.SchemaRef,
 	if base.Value.MaxProps != nil {
 		result.Value.MaxProps = new(*base.Value.MaxProps)
 	}
-	// The 3.1 / JSON Schema 2020-12 keywords the merge does not combine across
-	// allOf siblings. They flow through from the outer schema for the reason
-	// given above, and dropping them is not neutral: without
-	// unevaluatedProperties a closed schema silently becomes open, and without
-	// the conditionals a validation branch disappears from the comparison.
-	//
-	// A subschema carrying one of these still loses it, which is #878. Passed
-	// through as-is rather than merged, the same way contains and propertyNames
-	// are when only one is present.
-	result.Value.If = base.Value.If
-	result.Value.Then = base.Value.Then
-	result.Value.Else = base.Value.Else
-	result.Value.DependentSchemas = base.Value.DependentSchemas
-	result.Value.UnevaluatedProperties = base.Value.UnevaluatedProperties
-	result.Value.UnevaluatedItems = base.Value.UnevaluatedItems
-	result.Value.PatternProperties = base.Value.PatternProperties
-	result.Value.PrefixItems = base.Value.PrefixItems
-	result.Value.ContentSchema = base.Value.ContentSchema
-	result.Value.Examples = base.Value.Examples
-	// Identity and dialect keywords: annotations on the schema itself, nothing
-	// to merge. $defs is deliberately not here, see ALLOF.md.
-	result.Value.SchemaID = base.Value.SchemaID
-	result.Value.SchemaDialect = base.Value.SchemaDialect
-	result.Value.Anchor = base.Value.Anchor
-	result.Value.DynamicRef = base.Value.DynamicRef
-	result.Value.DynamicAnchor = base.Value.DynamicAnchor
-	result.Value.Comment = base.Value.Comment
 
 	// merge all fields of type SchemaRef
 	allOf, err := mergeSchemaRefs(state, base.Value.AllOf)

--- a/flatten/allof/merge_allof.go
+++ b/flatten/allof/merge_allof.go
@@ -263,6 +263,33 @@ func mergeInternal(state *state, base *openapi3.SchemaRef) (*openapi3.SchemaRef,
 	if base.Value.MaxProps != nil {
 		result.Value.MaxProps = new(*base.Value.MaxProps)
 	}
+	// The 3.1 / JSON Schema 2020-12 keywords the merge does not combine across
+	// allOf siblings. They flow through from the outer schema for the reason
+	// given above, and dropping them is not neutral: without
+	// unevaluatedProperties a closed schema silently becomes open, and without
+	// the conditionals a validation branch disappears from the comparison.
+	//
+	// A subschema carrying one of these still loses it, which is #878. Passed
+	// through as-is rather than merged, the same way contains and propertyNames
+	// are when only one is present.
+	result.Value.If = base.Value.If
+	result.Value.Then = base.Value.Then
+	result.Value.Else = base.Value.Else
+	result.Value.DependentSchemas = base.Value.DependentSchemas
+	result.Value.UnevaluatedProperties = base.Value.UnevaluatedProperties
+	result.Value.UnevaluatedItems = base.Value.UnevaluatedItems
+	result.Value.PatternProperties = base.Value.PatternProperties
+	result.Value.PrefixItems = base.Value.PrefixItems
+	result.Value.ContentSchema = base.Value.ContentSchema
+	result.Value.Examples = base.Value.Examples
+	// Identity and dialect keywords: annotations on the schema itself, nothing
+	// to merge. $defs is deliberately not here, see ALLOF.md.
+	result.Value.SchemaID = base.Value.SchemaID
+	result.Value.SchemaDialect = base.Value.SchemaDialect
+	result.Value.Anchor = base.Value.Anchor
+	result.Value.DynamicRef = base.Value.DynamicRef
+	result.Value.DynamicAnchor = base.Value.DynamicAnchor
+	result.Value.Comment = base.Value.Comment
 
 	// merge all fields of type SchemaRef
 	allOf, err := mergeSchemaRefs(state, base.Value.AllOf)

--- a/flatten/allof/merge_allof_test.go
+++ b/flatten/allof/merge_allof_test.go
@@ -3271,12 +3271,12 @@ func setNonZero(v reflect.Value, tag string) bool {
 	}
 	// A schema position needs a usable schema, not just a non-nil pointer:
 	// Merge dereferences it.
-	if v.Type() == reflect.TypeOf((*openapi3.SchemaRef)(nil)) {
+	if v.Type() == reflect.TypeFor[*openapi3.SchemaRef]() {
 		v.Set(reflect.ValueOf(openapi3.NewSchemaRef("", openapi3.NewSchema())))
 		return true
 	}
 	// An empty Types is semantically "no type", which the merge resolves away.
-	if v.Type() == reflect.TypeOf((*openapi3.Types)(nil)) {
+	if v.Type() == reflect.TypeFor[*openapi3.Types]() {
 		v.Set(reflect.ValueOf(&openapi3.Types{"object"}))
 		return true
 	}
@@ -3318,8 +3318,8 @@ func setNonZero(v reflect.Value, tag string) bool {
 		return true
 	case reflect.Struct:
 		any := false
-		for i := range v.NumField() {
-			if setNonZero(v.Field(i), tag) {
+		for _, fv := range v.Fields() {
+			if setNonZero(fv, tag) {
 				any = true
 			}
 		}

--- a/flatten/allof/merge_allof_test.go
+++ b/flatten/allof/merge_allof_test.go
@@ -3194,16 +3194,20 @@ func TestMerge_MultiType_RedundantNumericSet(t *testing.T) {
 	require.Equal(t, &openapi3.Types{"number"}, merged.Type)
 }
 
-// The per-field tests above can only catch a regression on a field someone
-// already thought of. They cannot catch an omission, because the list of
-// fields they check is written by hand from the same mental model as the copy
-// block in mergeInternal: a field missing from one is missing from both. That
-// is how sixteen keywords were dropped for as long as they were (#1097).
+// Merge on a schema with no allOf must return what it was given: there is
+// nothing to combine, so every field should survive.
 //
-// This walks openapi3.Schema by reflection instead, so a field kin adds is
-// covered without anyone remembering. Fields that are deliberately not carried
-// through are listed with a reason, and the list fails if one of them starts
-// surviving, so it cannot rot.
+// This walks openapi3.Schema by reflection rather than naming the fields,
+// which is the point. mergeInternal copies field by field, and a test that
+// lists the fields it checks is written from the same mental model as that
+// copy block, so a field missing from one is missing from both. Sixteen
+// keywords were dropped for exactly that long (#1097). Here a field kin adds
+// is covered without anyone remembering.
+//
+// Each field gets a value derived from its own name, so a copy reading the
+// wrong source shows up as a changed value rather than passing a non-zero
+// check. Fields deliberately not carried through are listed with a reason,
+// and the list fails if one of them starts surviving, so it cannot rot.
 var notCarriedThrough = map[string]string{
 	"Defs":   "intentionally dropped, see ALLOF.md: after flattening there are no $refs left for the namespace to serve.",
 	"Origin": "source position of the input schema; a merged schema does not come from one place in the file.",

--- a/flatten/allof/merge_allof_test.go
+++ b/flatten/allof/merge_allof_test.go
@@ -2,11 +2,13 @@ package allof_test
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/oasdiff/oasdiff/flatten/allof"
 
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -3267,7 +3269,8 @@ func TestMerge_SingleSchema_Preserves31Keywords(t *testing.T) {
 			Properties: openapi3.Schemas{prop: openapi3.NewSchemaRef("", openapi3.NewStringSchema())},
 		})
 	}
-	merged, err := allof.Merge(openapi3.SchemaRef{Value: &openapi3.Schema{
+
+	x := openapi3.SchemaRef{Value: &openapi3.Schema{
 		If:                    sub("k"),
 		Then:                  sub("p"),
 		Else:                  sub("q"),
@@ -3284,7 +3287,8 @@ func TestMerge_SingleSchema_Preserves31Keywords(t *testing.T) {
 		DynamicRef:            "#meta",
 		DynamicAnchor:         "meta",
 		Comment:               "c",
-	}})
+	}}
+	merged, err := allof.Merge(x)
 	require.NoError(t, err)
 
 	require.NotNil(t, merged.If, "if")
@@ -3303,4 +3307,129 @@ func TestMerge_SingleSchema_Preserves31Keywords(t *testing.T) {
 	require.Equal(t, "#meta", merged.DynamicRef, "$dynamicRef")
 	require.Equal(t, "meta", merged.DynamicAnchor, "$dynamicAnchor")
 	require.Equal(t, "c", merged.Comment, "$comment")
+}
+
+// The per-field tests above can only catch a regression on a field someone
+// already thought of. They cannot catch an omission, because the list of
+// fields they check is written by hand from the same mental model as the copy
+// block in mergeInternal: a field missing from one is missing from both. That
+// is how sixteen keywords were dropped for as long as they were (#1097).
+//
+// This walks openapi3.Schema by reflection instead, so a field kin adds is
+// covered without anyone remembering. Fields that are deliberately not carried
+// through are listed with a reason, and the list fails if one of them starts
+// surviving, so it cannot rot.
+var notCarriedThrough = map[string]string{
+	"Defs":   "intentionally dropped, see ALLOF.md: after flattening there are no $refs left for the namespace to serve.",
+	"Origin": "source position of the input schema; a merged schema does not come from one place in the file.",
+}
+
+// notPopulated is left unset because the case under test is a schema with no
+// allOf. Populating it would exercise the merge rather than the copy, and its
+// subschemas carry zero values that legitimately win: a fresh subschema is not
+// nullable, and nullable merges to false if any sibling says false.
+var notPopulated = map[string]bool{"AllOf": true}
+
+func TestMerge_SingleSchema_PreservesEveryField(t *testing.T) {
+	in := &openapi3.Schema{}
+	v := reflect.ValueOf(in).Elem()
+	typ := v.Type()
+
+	populated := make([]string, 0, typ.NumField())
+	for i := range typ.NumField() {
+		f := typ.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		if notPopulated[f.Name] {
+			continue
+		}
+		if !setNonZero(v.Field(i)) {
+			continue // no generic way to populate this kind; the typed tests cover it
+		}
+		populated = append(populated, f.Name)
+	}
+	require.Greater(t, len(populated), 40, "sanity: most fields should be populated")
+
+	merged, err := allof.Merge(openapi3.SchemaRef{Value: in})
+	require.NoError(t, err)
+
+	out := reflect.ValueOf(merged).Elem()
+	for _, name := range populated {
+		got := out.FieldByName(name)
+		survived := !got.IsZero()
+		if reason, expected := notCarriedThrough[name]; expected {
+			assert.False(t, survived,
+				"%s is listed in notCarriedThrough (%s) but survived the merge; remove it from the list", name, reason)
+			continue
+		}
+		assert.True(t, survived,
+			"Merge dropped %s on a schema with no allOf.\n"+
+				"  add it to the copy block in mergeInternal, or to notCarriedThrough with a reason", name)
+	}
+}
+
+// setNonZero gives v a value distinguishable from its zero, reporting whether
+// it could.
+func setNonZero(v reflect.Value) bool {
+	if !v.CanSet() {
+		return false
+	}
+	// A schema position needs a usable schema, not just a non-nil pointer:
+	// Merge dereferences it.
+	if v.Type() == reflect.TypeOf((*openapi3.SchemaRef)(nil)) {
+		v.Set(reflect.ValueOf(openapi3.NewSchemaRef("", openapi3.NewSchema())))
+		return true
+	}
+	// An empty Types is semantically "no type", which the merge resolves away.
+	if v.Type() == reflect.TypeOf((*openapi3.Types)(nil)) {
+		v.Set(reflect.ValueOf(&openapi3.Types{"object"}))
+		return true
+	}
+	switch v.Kind() {
+	case reflect.String:
+		v.SetString("x")
+		return true
+	case reflect.Bool:
+		v.SetBool(true)
+		return true
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v.SetInt(1)
+		return true
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v.SetUint(1)
+		return true
+	case reflect.Float64:
+		v.SetFloat(1)
+		return true
+	case reflect.Slice:
+		v.Set(reflect.MakeSlice(v.Type(), 1, 1))
+		setNonZero(v.Index(0))
+		return true
+	case reflect.Map:
+		m := reflect.MakeMap(v.Type())
+		k := reflect.New(v.Type().Key()).Elem()
+		setNonZero(k)
+		m.SetMapIndex(k, reflect.New(v.Type().Elem()).Elem())
+		v.Set(m)
+		return true
+	case reflect.Pointer:
+		// Allocated, not filled: Schema points at itself through SchemaRef, so
+		// descending would not terminate, and a non-nil pointer is already
+		// distinguishable from the zero value.
+		v.Set(reflect.New(v.Type().Elem()))
+		return true
+	case reflect.Interface:
+		v.Set(reflect.ValueOf("x"))
+		return true
+	case reflect.Struct:
+		any := false
+		for i := range v.NumField() {
+			if setNonZero(v.Field(i)) {
+				any = true
+			}
+		}
+		return any
+	}
+	return false
 }

--- a/flatten/allof/merge_allof_test.go
+++ b/flatten/allof/merge_allof_test.go
@@ -30,71 +30,6 @@ func exclusiveBoundValue(v float64) openapi3.ExclusiveBound {
 // These tests pin "round-trip preserves the field" so a future regression
 // in the copy block is caught.
 
-func TestMerge_SingleSchema_PreservesExample(t *testing.T) {
-	merged, err := allof.Merge(openapi3.SchemaRef{
-		Value: &openapi3.Schema{Example: "sample-value"},
-	})
-	require.NoError(t, err)
-	require.Equal(t, "sample-value", merged.Example)
-}
-
-func TestMerge_SingleSchema_PreservesDeprecated(t *testing.T) {
-	merged, err := allof.Merge(openapi3.SchemaRef{
-		Value: &openapi3.Schema{Deprecated: true},
-	})
-	require.NoError(t, err)
-	require.True(t, merged.Deprecated)
-}
-
-func TestMerge_SingleSchema_PreservesAllowEmptyValue(t *testing.T) {
-	merged, err := allof.Merge(openapi3.SchemaRef{
-		Value: &openapi3.Schema{AllowEmptyValue: true},
-	})
-	require.NoError(t, err)
-	require.True(t, merged.AllowEmptyValue)
-}
-
-func TestMerge_SingleSchema_PreservesExternalDocs(t *testing.T) {
-	docs := &openapi3.ExternalDocs{Description: "more info", URL: "https://example.com/docs"}
-	merged, err := allof.Merge(openapi3.SchemaRef{
-		Value: &openapi3.Schema{ExternalDocs: docs},
-	})
-	require.NoError(t, err)
-	require.Same(t, docs, merged.ExternalDocs)
-}
-
-func TestMerge_SingleSchema_PreservesXML(t *testing.T) {
-	xml := &openapi3.XML{Name: "user", Namespace: "https://example.com/ns"}
-	merged, err := allof.Merge(openapi3.SchemaRef{
-		Value: &openapi3.Schema{XML: xml},
-	})
-	require.NoError(t, err)
-	require.Same(t, xml, merged.XML)
-}
-
-func TestMerge_SingleSchema_PreservesExtensions(t *testing.T) {
-	ext := map[string]any{"x-internal-id": "abc-123"}
-	merged, err := allof.Merge(openapi3.SchemaRef{
-		Value: &openapi3.Schema{Extensions: ext},
-	})
-	require.NoError(t, err)
-	require.Equal(t, ext, merged.Extensions)
-}
-
-// Single-schema with Type set must round-trip the Type. Pins regression
-// against the duplicate `result.Value.Type = base.Value.Type` lines that
-// existed before — if both were removed accidentally, the field would
-// be lost; if only the duplicate was removed (the intended cleanup),
-// this test still passes.
-func TestMerge_SingleSchema_PreservesType(t *testing.T) {
-	merged, err := allof.Merge(openapi3.SchemaRef{
-		Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
-	})
-	require.NoError(t, err)
-	require.NotNil(t, merged.Type)
-	require.True(t, merged.Type.Is("string"))
-}
-
 // identical Default fields are merged successfully
 func TestMerge_Default(t *testing.T) {
 	merged, err := allof.Merge(
@@ -3259,56 +3194,6 @@ func TestMerge_MultiType_RedundantNumericSet(t *testing.T) {
 	require.Equal(t, &openapi3.Types{"number"}, merged.Type)
 }
 
-// The 3.1 / JSON Schema 2020-12 keywords were absent from the copy block, so a
-// Merge on a schema with no allOf dropped every one of them (#1097). Dropping
-// them is not neutral: unevaluatedProperties: false turns a closed schema open,
-// and the conditionals are whole validation branches.
-func TestMerge_SingleSchema_Preserves31Keywords(t *testing.T) {
-	sub := func(prop string) *openapi3.SchemaRef {
-		return openapi3.NewSchemaRef("", &openapi3.Schema{
-			Properties: openapi3.Schemas{prop: openapi3.NewSchemaRef("", openapi3.NewStringSchema())},
-		})
-	}
-
-	x := openapi3.SchemaRef{Value: &openapi3.Schema{
-		If:                    sub("k"),
-		Then:                  sub("p"),
-		Else:                  sub("q"),
-		DependentSchemas:      openapi3.Schemas{"k": sub("r")},
-		PatternProperties:     openapi3.Schemas{"^x": sub("s")},
-		PrefixItems:           openapi3.SchemaRefs{sub("t")},
-		ContentSchema:         sub("u"),
-		UnevaluatedProperties: openapi3.BoolSchema{Has: openapi3.Ptr(false)},
-		UnevaluatedItems:      openapi3.BoolSchema{Has: openapi3.Ptr(false)},
-		Examples:              []any{"e"},
-		SchemaID:              "https://example.com/s",
-		SchemaDialect:         "https://json-schema.org/draft/2020-12/schema",
-		Anchor:                "a",
-		DynamicRef:            "#meta",
-		DynamicAnchor:         "meta",
-		Comment:               "c",
-	}}
-	merged, err := allof.Merge(x)
-	require.NoError(t, err)
-
-	require.NotNil(t, merged.If, "if")
-	require.NotNil(t, merged.Then, "then")
-	require.NotNil(t, merged.Else, "else")
-	require.Len(t, merged.DependentSchemas, 1, "dependentSchemas")
-	require.Len(t, merged.PatternProperties, 1, "patternProperties")
-	require.Len(t, merged.PrefixItems, 1, "prefixItems")
-	require.NotNil(t, merged.ContentSchema, "contentSchema")
-	require.NotNil(t, merged.UnevaluatedProperties.Has, "unevaluatedProperties")
-	require.NotNil(t, merged.UnevaluatedItems.Has, "unevaluatedItems")
-	require.Equal(t, []any{"e"}, merged.Examples, "examples")
-	require.Equal(t, "https://example.com/s", merged.SchemaID, "$id")
-	require.Equal(t, "https://json-schema.org/draft/2020-12/schema", merged.SchemaDialect, "$schema")
-	require.Equal(t, "a", merged.Anchor, "$anchor")
-	require.Equal(t, "#meta", merged.DynamicRef, "$dynamicRef")
-	require.Equal(t, "meta", merged.DynamicAnchor, "$dynamicAnchor")
-	require.Equal(t, "c", merged.Comment, "$comment")
-}
-
 // The per-field tests above can only catch a regression on a field someone
 // already thought of. They cannot catch an omission, because the list of
 // fields they check is written by hand from the same mental model as the copy
@@ -3336,6 +3221,7 @@ func TestMerge_SingleSchema_PreservesEveryField(t *testing.T) {
 	typ := v.Type()
 
 	populated := make([]string, 0, typ.NumField())
+	want := map[string]any{}
 	for i := range typ.NumField() {
 		f := typ.Field(i)
 		if !f.IsExported() {
@@ -3344,9 +3230,10 @@ func TestMerge_SingleSchema_PreservesEveryField(t *testing.T) {
 		if notPopulated[f.Name] {
 			continue
 		}
-		if !setNonZero(v.Field(i)) {
-			continue // no generic way to populate this kind; the typed tests cover it
+		if !setNonZero(v.Field(i), f.Name) {
+			continue // no generic way to populate this kind
 		}
+		want[f.Name] = v.Field(i).Interface()
 		populated = append(populated, f.Name)
 	}
 	require.Greater(t, len(populated), 40, "sanity: most fields should be populated")
@@ -3363,15 +3250,22 @@ func TestMerge_SingleSchema_PreservesEveryField(t *testing.T) {
 				"%s is listed in notCarriedThrough (%s) but survived the merge; remove it from the list", name, reason)
 			continue
 		}
-		assert.True(t, survived,
+		if !assert.True(t, survived,
 			"Merge dropped %s on a schema with no allOf.\n"+
-				"  add it to the copy block in mergeInternal, or to notCarriedThrough with a reason", name)
+				"  add it to the copy block in mergeInternal, or to notCarriedThrough with a reason", name) {
+			continue
+		}
+		// Every field gets a value derived from its own name, so a copy reading
+		// the wrong source shows up as a changed value rather than slipping past
+		// a non-zero check.
+		assert.Equal(t, want[name], got.Interface(),
+			"Merge changed %s on a schema with no allOf; the copy block may be reading the wrong source field", name)
 	}
 }
 
 // setNonZero gives v a value distinguishable from its zero, reporting whether
 // it could.
-func setNonZero(v reflect.Value) bool {
+func setNonZero(v reflect.Value, tag string) bool {
 	if !v.CanSet() {
 		return false
 	}
@@ -3388,7 +3282,7 @@ func setNonZero(v reflect.Value) bool {
 	}
 	switch v.Kind() {
 	case reflect.String:
-		v.SetString("x")
+		v.SetString("v-" + tag)
 		return true
 	case reflect.Bool:
 		v.SetBool(true)
@@ -3404,12 +3298,12 @@ func setNonZero(v reflect.Value) bool {
 		return true
 	case reflect.Slice:
 		v.Set(reflect.MakeSlice(v.Type(), 1, 1))
-		setNonZero(v.Index(0))
+		setNonZero(v.Index(0), tag)
 		return true
 	case reflect.Map:
 		m := reflect.MakeMap(v.Type())
 		k := reflect.New(v.Type().Key()).Elem()
-		setNonZero(k)
+		setNonZero(k, tag)
 		m.SetMapIndex(k, reflect.New(v.Type().Elem()).Elem())
 		v.Set(m)
 		return true
@@ -3420,12 +3314,12 @@ func setNonZero(v reflect.Value) bool {
 		v.Set(reflect.New(v.Type().Elem()))
 		return true
 	case reflect.Interface:
-		v.Set(reflect.ValueOf("x"))
+		v.Set(reflect.ValueOf("v-" + tag))
 		return true
 	case reflect.Struct:
 		any := false
 		for i := range v.NumField() {
-			if setNonZero(v.Field(i)) {
+			if setNonZero(v.Field(i), tag) {
 				any = true
 			}
 		}

--- a/flatten/allof/merge_allof_test.go
+++ b/flatten/allof/merge_allof_test.go
@@ -3256,3 +3256,51 @@ func TestMerge_MultiType_RedundantNumericSet(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, &openapi3.Types{"number"}, merged.Type)
 }
+
+// The 3.1 / JSON Schema 2020-12 keywords were absent from the copy block, so a
+// Merge on a schema with no allOf dropped every one of them (#1097). Dropping
+// them is not neutral: unevaluatedProperties: false turns a closed schema open,
+// and the conditionals are whole validation branches.
+func TestMerge_SingleSchema_Preserves31Keywords(t *testing.T) {
+	sub := func(prop string) *openapi3.SchemaRef {
+		return openapi3.NewSchemaRef("", &openapi3.Schema{
+			Properties: openapi3.Schemas{prop: openapi3.NewSchemaRef("", openapi3.NewStringSchema())},
+		})
+	}
+	merged, err := allof.Merge(openapi3.SchemaRef{Value: &openapi3.Schema{
+		If:                    sub("k"),
+		Then:                  sub("p"),
+		Else:                  sub("q"),
+		DependentSchemas:      openapi3.Schemas{"k": sub("r")},
+		PatternProperties:     openapi3.Schemas{"^x": sub("s")},
+		PrefixItems:           openapi3.SchemaRefs{sub("t")},
+		ContentSchema:         sub("u"),
+		UnevaluatedProperties: openapi3.BoolSchema{Has: openapi3.Ptr(false)},
+		UnevaluatedItems:      openapi3.BoolSchema{Has: openapi3.Ptr(false)},
+		Examples:              []any{"e"},
+		SchemaID:              "https://example.com/s",
+		SchemaDialect:         "https://json-schema.org/draft/2020-12/schema",
+		Anchor:                "a",
+		DynamicRef:            "#meta",
+		DynamicAnchor:         "meta",
+		Comment:               "c",
+	}})
+	require.NoError(t, err)
+
+	require.NotNil(t, merged.If, "if")
+	require.NotNil(t, merged.Then, "then")
+	require.NotNil(t, merged.Else, "else")
+	require.Len(t, merged.DependentSchemas, 1, "dependentSchemas")
+	require.Len(t, merged.PatternProperties, 1, "patternProperties")
+	require.Len(t, merged.PrefixItems, 1, "prefixItems")
+	require.NotNil(t, merged.ContentSchema, "contentSchema")
+	require.NotNil(t, merged.UnevaluatedProperties.Has, "unevaluatedProperties")
+	require.NotNil(t, merged.UnevaluatedItems.Has, "unevaluatedItems")
+	require.Equal(t, []any{"e"}, merged.Examples, "examples")
+	require.Equal(t, "https://example.com/s", merged.SchemaID, "$id")
+	require.Equal(t, "https://json-schema.org/draft/2020-12/schema", merged.SchemaDialect, "$schema")
+	require.Equal(t, "a", merged.Anchor, "$anchor")
+	require.Equal(t, "#meta", merged.DynamicRef, "$dynamicRef")
+	require.Equal(t, "meta", merged.DynamicAnchor, "$dynamicAnchor")
+	require.Equal(t, "c", merged.Comment, "$comment")
+}

--- a/flatten/allof/merge_allof_test.go
+++ b/flatten/allof/merge_allof_test.go
@@ -3235,7 +3235,12 @@ func TestMerge_SingleSchema_PreservesEveryField(t *testing.T) {
 			continue
 		}
 		if !setNonZero(v.Field(i), f.Name) {
-			continue // no generic way to populate this kind
+			// Silently skipping would reopen the hole this test exists to
+			// close: a field of a kind setNonZero cannot build would go
+			// unchecked and the test would still pass. Teach setNonZero the
+			// kind instead.
+			t.Errorf("cannot populate %s (%s); extend setNonZero so the field is covered", f.Name, f.Type)
+			continue
 		}
 		want[f.Name] = v.Field(i).Interface()
 		populated = append(populated, f.Name)


### PR DESCRIPTION
Fixes #1097.

`mergeInternal` copies the outer schema into the result field by field, and sixteen 3.1 / JSON Schema 2020-12 keywords were never on the list. They were dropped from every `Merge`, **including a schema with no `allOf` at all**, where nothing is being merged and the output should equal the input.

The copy block already states the rule this broke:

> Fields documented in ALLOF.md as "not merged" ... MUST still flow through from the outer (base) schema, otherwise a single-schema Merge silently loses them.

## Why it matters

Dropping these is not neutral. Without `unevaluatedProperties` a closed schema silently becomes open, so the flattened spec accepts payloads the original rejects. Without the conditionals a whole validation branch disappears from a `--flatten-allof` comparison, so a change inside it is reported as no change.

The issue's own input, before and after:

| | keys in the flattened schema |
|---|---|
| before | `propertyNames`, `type` |
| after | `dependentSchemas`, `else`, `if`, `propertyNames`, `then`, `type`, `unevaluatedProperties` |

And `oasdiff diff` between the original spec and its flattened output is now `{}`, where it previously reported the loss.

## Scope

Passed through rather than merged, which is what `contains` and `propertyNames` already do when only one is present. I checked that this matches the existing standard rather than assuming: a nested `allOf` inside a single `contains` is not flattened today either.

**A keyword on an `allOf` subschema is still lost.** The merge has no rule for combining two `if`s or two `unevaluatedProperties`, which is the hard half of #878. Verified it still happens, so the residual is real and documented rather than assumed away. ALLOF.md described the outer-schema case as the limitation; it now describes this one.

`$defs` is deliberately still dropped, for the reason ALLOF.md already gives.

## Why no test caught this, and the one that now would

The file already had a "round-trip preserves the field" section for exactly this class. It could not have caught it: those tests name the fields they check by hand, from the same mental model as the copy block they guard, so a field missing from one is missing from both. **Reverting the fix leaves all seven of them passing.** They catch a regression on a field someone thought of, never an omission.

So there are two tests here. One names the sixteen keywords, matching the existing style. The other walks `openapi3.Schema` by reflection and asserts every field survives a single-schema `Merge`. With the fix reverted it names all sixteen in one run, and a field kin adds in future is covered without anyone remembering.

Two fields are listed as deliberately not carried through, with reasons, and the list fails if one starts surviving, so it cannot rot. `AllOf` is left unpopulated rather than waived: the case under test is a schema without it, and a fresh subschema carries zero values that legitimately win the merge, which would make the test lie about `nullable`.

This does not remove the need for #886. The registry is the fix that stops the drop happening; this is the test that stops it going unnoticed.
