### PR TITLE
test: assert on the change requireChange found

### DIFF
--- a/checker/check_api_deprecation_test.go
+++ b/checker/check_api_deprecation_test.go
@@ -173,9 +173,9 @@ func TestBreaking_DeprecationWithProperSunset(t *testing.T) {
 	errs := checker.CheckBackwardCompatibilityUntilLevel(c, d, osm, checker.INFO)
 	require.Len(t, errs, 1)
 	// only a non-breaking change detected
-	requireChange(t, errs, checker.EndpointDeprecatedWithSunsetId)
-	require.Equal(t, checker.INFO, errs[0].GetLevel())
-	require.Contains(t, errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()), "endpoint deprecated")
+	change := requireChange(t, errs, checker.EndpointDeprecatedWithSunsetId)
+	require.Equal(t, checker.INFO, change.GetLevel())
+	require.Contains(t, change.GetUncolorizedText(checker.NewDefaultLocalizer()), "endpoint deprecated")
 }
 
 // path operations that became deprecated
@@ -261,8 +261,8 @@ func TestApiDeprecated_MessageIncludesSunset(t *testing.T) {
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
 
-	requireChange(t, errs, checker.EndpointDeprecatedWithSunsetId)
-	require.Contains(t, errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()), "endpoint deprecated")
+	change := requireChange(t, errs, checker.EndpointDeprecatedWithSunsetId)
+	require.Contains(t, change.GetUncolorizedText(checker.NewDefaultLocalizer()), "endpoint deprecated")
 }
 
 // message includes both sunset and stability when endpoint deprecated with both
@@ -340,8 +340,8 @@ func TestBreaking_DeprecationWithRFC3339Sunset(t *testing.T) {
 	errs := checker.CheckBackwardCompatibilityUntilLevel(c, d, osm, checker.INFO)
 	require.Len(t, errs, 1)
 	// only a non-breaking change detected
-	requireChange(t, errs, checker.EndpointDeprecatedWithSunsetId)
-	require.Equal(t, checker.INFO, errs[0].GetLevel())
+	change := requireChange(t, errs, checker.EndpointDeprecatedWithSunsetId)
+	require.Equal(t, checker.INFO, change.GetLevel())
 }
 
 // deprecating an operation with invalid JSON sunset date is breaking

--- a/checker/check_api_removed_test.go
+++ b/checker/check_api_removed_test.go
@@ -219,7 +219,6 @@ func TestBreaking_PathDeprecationNoSunset(t *testing.T) {
 	require.Equal(t, "api path removed with deprecation", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 	require.Equal(t, checker.INFO, errs[0].GetLevel())
 
-	requireChange(t, errs, checker.APIPathRemovedWithDeprecationId)
 	require.Equal(t, "api path removed with deprecation", errs[1].GetUncolorizedText(checker.NewDefaultLocalizer()))
 	require.Equal(t, checker.INFO, errs[1].GetLevel())
 	require.Equal(t, checker.NewSource("../data/deprecation/deprecated-path-no-sunset.yaml", 12, 5).WithEnd(16, 26), errs[0].GetBaseSource())

--- a/checker/check_breaking_property_test.go
+++ b/checker/check_breaking_property_test.go
@@ -506,7 +506,6 @@ func TestBreaking_WriteOnlyDeleteNonRequiredProperty(t *testing.T) {
 	require.Equal(t, checker.WARN, errs[0].GetLevel())
 	requireChange(t, errs, checker.ResponseOptionalPropertyRemovedId)
 	require.Equal(t, checker.WARN, errs[1].GetLevel())
-	requireChange(t, errs, checker.ResponseOptionalPropertyRemovedId)
 	require.Equal(t, checker.WARN, errs[2].GetLevel())
 }
 
@@ -553,7 +552,6 @@ func TestBreaking_RequiredPropertyWriteOnlyDisabled(t *testing.T) {
 	require.Len(t, errs, 2)
 	requireChange(t, errs, checker.ResponseRequiredPropertyBecameNonWriteOnlyId)
 	require.Equal(t, checker.WARN, errs[0].GetLevel())
-	requireChange(t, errs, checker.ResponseRequiredPropertyBecameNonWriteOnlyId)
 	require.Equal(t, checker.WARN, errs[1].GetLevel())
 }
 

--- a/checker/check_breaking_test.go
+++ b/checker/check_breaking_test.go
@@ -63,7 +63,6 @@ func TestBreaking_AddedResponseEnum(t *testing.T) {
 	require.Len(t, errs, 2)
 	requireChange(t, errs, checker.ResponsePropertyEnumValueAddedId)
 	require.Equal(t, "added the new `QWE` enum value to the `respenum` response property for the response status `default`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
-	requireChange(t, errs, checker.ResponsePropertyEnumValueAddedId)
 	require.Equal(t, "added the new `TER2` enum value to the `respenum2/respenum3` response property for the response status `default`", errs[1].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
@@ -262,8 +261,8 @@ func TestBreaking_RequestBodyEnumRemoved(t *testing.T) {
 	}
 
 	require.Len(t, errs, 3)
-	requireChange(t, errs, checker.RequestBodyEnumValueRemovedId)
-	require.Equal(t, "request body enum value removed `VALUE_1`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	change := requireChange(t, errs, checker.RequestBodyEnumValueRemovedId)
+	require.Equal(t, "request body enum value removed `VALUE_1`", change.GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // removing an enum value from a response property is informational (it narrows the server's output), reported in the changelog
@@ -279,8 +278,8 @@ func TestBreaking_ResponsePropertyEnumRemoved(t *testing.T) {
 		require.Equal(t, checker.INFO, err.GetLevel())
 	}
 	require.Len(t, errs, 2)
-	requireChange(t, errs, checker.ResponsePropertyEnumValueRemovedId)
-	require.Equal(t, "removed the `QWE` enum value from the `respenum` response property for the response status `default`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	change := requireChange(t, errs, checker.ResponsePropertyEnumValueRemovedId)
+	require.Equal(t, "removed the `QWE` enum value from the `respenum` response property for the response status `default`", change.GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // removing/updating a tag is informational, reported in the changelog
@@ -583,7 +582,6 @@ func TestBreaking_SchemaRemoved(t *testing.T) {
 	require.NotEmpty(t, errs)
 	requireChange(t, errs, checker.APISchemasRemovedId)
 	require.Equal(t, "removed the schema `network-policies`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
-	requireChange(t, errs, checker.APISchemasRemovedId)
 	require.Equal(t, "removed the schema `rules`", errs[1].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
@@ -616,13 +614,13 @@ func TestBreaking_RequestPropertyAnyOfRemoved(t *testing.T) {
 
 	require.Len(t, errs, 2)
 
-	requireChange(t, errs, checker.RequestBodyAnyOfRemovedId)
-	require.Equal(t, checker.ERR, errs[0].GetLevel())
-	require.Equal(t, "removed `#/components/schemas/Rabbit` from the request body `anyOf` list", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	change := requireChange(t, errs, checker.RequestBodyAnyOfRemovedId)
+	require.Equal(t, checker.ERR, change.GetLevel())
+	require.Equal(t, "removed `#/components/schemas/Rabbit` from the request body `anyOf` list", change.GetUncolorizedText(checker.NewDefaultLocalizer()))
 
-	requireChange(t, errs, checker.RequestPropertyAnyOfRemovedId)
-	require.Equal(t, checker.ERR, errs[1].GetLevel())
-	require.Equal(t, "removed `#/components/schemas/Breed3` from the `anyOf[#/components/schemas/Dog]/breed` request property `anyOf` list", errs[1].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	change = requireChange(t, errs, checker.RequestPropertyAnyOfRemovedId)
+	require.Equal(t, checker.ERR, change.GetLevel())
+	require.Equal(t, "removed `#/components/schemas/Breed3` from the `anyOf[#/components/schemas/Dog]/breed` request property `anyOf` list", change.GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // removing 'oneOf' schema from the request body or request body property is breaking
@@ -637,13 +635,13 @@ func TestBreaking_RequestPropertyOneOfRemoved(t *testing.T) {
 	errs := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
 
 	require.Len(t, errs, 2)
-	requireChange(t, errs, checker.RequestBodyOneOfRemovedId)
-	require.Equal(t, checker.ERR, errs[0].GetLevel())
-	require.Equal(t, "removed `#/components/schemas/Rabbit` from the request body `oneOf` list", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	change := requireChange(t, errs, checker.RequestBodyOneOfRemovedId)
+	require.Equal(t, checker.ERR, change.GetLevel())
+	require.Equal(t, "removed `#/components/schemas/Rabbit` from the request body `oneOf` list", change.GetUncolorizedText(checker.NewDefaultLocalizer()))
 
-	requireChange(t, errs, checker.RequestPropertyOneOfRemovedId)
-	require.Equal(t, checker.ERR, errs[1].GetLevel())
-	require.Equal(t, "removed `#/components/schemas/Breed3` from the `oneOf[#/components/schemas/Dog]/breed` request property `oneOf` list", errs[1].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	change = requireChange(t, errs, checker.RequestPropertyOneOfRemovedId)
+	require.Equal(t, checker.ERR, change.GetLevel())
+	require.Equal(t, "removed `#/components/schemas/Breed3` from the `oneOf[#/components/schemas/Dog]/breed` request property `oneOf` list", change.GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // adding 'allOf' subschema to the request body or request body property is breaking
@@ -663,13 +661,13 @@ func TestBreaking_RequestPropertyAllOfAdded(t *testing.T) {
 	// accepts. Compared branch by branch oasdiff cannot tell whether this
 	// branch narrows anything the others did not already, so the disclaimer
 	// caps it. Under --flatten-allof the merged schemas settle it.
-	requireChange(t, errs, checker.RequestBodyAllOfAddedId)
-	require.Equal(t, checker.WARN, errs[0].GetLevel())
-	require.Equal(t, "added `#/components/schemas/Rabbit` to the request body `allOf` list", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	change := requireChange(t, errs, checker.RequestBodyAllOfAddedId)
+	require.Equal(t, checker.WARN, change.GetLevel())
+	require.Equal(t, "added `#/components/schemas/Rabbit` to the request body `allOf` list", change.GetUncolorizedText(checker.NewDefaultLocalizer()))
 
-	requireChange(t, errs, checker.RequestPropertyAllOfAddedId)
-	require.Equal(t, checker.WARN, errs[1].GetLevel())
-	require.Equal(t, "added `#/components/schemas/Breed3` to the `allOf[#/components/schemas/Dog]/breed` request property `allOf` list", errs[1].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	change = requireChange(t, errs, checker.RequestPropertyAllOfAddedId)
+	require.Equal(t, checker.WARN, change.GetLevel())
+	require.Equal(t, "added `#/components/schemas/Breed3` to the `allOf[#/components/schemas/Dog]/breed` request property `allOf` list", change.GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // removing 'allOf' subschema from the request body or request body property is breaking with warn
@@ -685,11 +683,11 @@ func TestBreaking_RequestPropertyAllOfRemoved(t *testing.T) {
 
 	require.Len(t, errs, 2)
 
-	requireChange(t, errs, checker.RequestBodyAllOfRemovedId)
-	require.Equal(t, checker.WARN, errs[0].GetLevel())
-	require.Equal(t, "removed `#/components/schemas/Rabbit` from the request body `allOf` list", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	change := requireChange(t, errs, checker.RequestBodyAllOfRemovedId)
+	require.Equal(t, checker.WARN, change.GetLevel())
+	require.Equal(t, "removed `#/components/schemas/Rabbit` from the request body `allOf` list", change.GetUncolorizedText(checker.NewDefaultLocalizer()))
 
-	requireChange(t, errs, checker.RequestPropertyAllOfRemovedId)
-	require.Equal(t, checker.WARN, errs[1].GetLevel())
-	require.Equal(t, "removed `#/components/schemas/Breed3` from the `allOf[#/components/schemas/Dog]/breed` request property `allOf` list", errs[1].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	change = requireChange(t, errs, checker.RequestPropertyAllOfRemovedId)
+	require.Equal(t, checker.WARN, change.GetLevel())
+	require.Equal(t, "removed `#/components/schemas/Breed3` from the `allOf[#/components/schemas/Dog]/breed` request property `allOf` list", change.GetUncolorizedText(checker.NewDefaultLocalizer()))
 }

--- a/checker/check_request_parameter_deprecation_test.go
+++ b/checker/check_request_parameter_deprecation_test.go
@@ -130,9 +130,9 @@ func TestBreaking_ParameterDeprecationWithProperSunset(t *testing.T) {
 	errs := checker.CheckBackwardCompatibilityUntilLevel(c, d, osm, checker.INFO)
 	require.Len(t, errs, 1)
 	// only a non-breaking change detected
-	requireChange(t, errs, checker.RequestParameterDeprecatedId)
-	require.Equal(t, checker.INFO, errs[0].GetLevel())
-	require.Contains(t, errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()), "`query` request parameter `id` was deprecated")
+	change := requireChange(t, errs, checker.RequestParameterDeprecatedId)
+	require.Equal(t, checker.INFO, change.GetLevel())
+	require.Contains(t, change.GetUncolorizedText(checker.NewDefaultLocalizer()), "`query` request parameter `id` was deprecated")
 }
 
 // parameters that became deprecated

--- a/checker/check_request_property_deprecation_test.go
+++ b/checker/check_request_property_deprecation_test.go
@@ -43,7 +43,6 @@ func TestRequestPropertyDeprecationCheck_AllOf(t *testing.T) {
 	// With multiple media types (json and xml), we get one report per media type with distinct details
 	require.Len(t, errs, 2)
 	requireChange(t, errs, checker.RequestPropertyDeprecatedWithSunsetId)
-	requireChange(t, errs, checker.RequestPropertyDeprecatedWithSunsetId)
 	// Each message should include media type context
 	msg0 := errs[0].GetUncolorizedText(checker.NewDefaultLocalizer())
 	msg1 := errs[1].GetUncolorizedText(checker.NewDefaultLocalizer())

--- a/checker/check_request_property_updated_test.go
+++ b/checker/check_request_property_updated_test.go
@@ -177,6 +177,6 @@ func TestRequestPropertyOneOfWrappingIsBreaking(t *testing.T) {
 	// The wrapping must be reported exactly once per request body (not per
 	// property), as a breaking error, and nothing else.
 	require.Len(t, errs, 1, "a oneOf wrapping must produce exactly one finding (#702)")
-	requireChange(t, errs, checker.RequestBodyWrappedInOneOfId)
-	require.Equal(t, checker.ERR, errs[0].GetLevel())
+	change := requireChange(t, errs, checker.RequestBodyWrappedInOneOfId)
+	require.Equal(t, checker.ERR, change.GetLevel())
 }

--- a/checker/check_response_property_deprecation_test.go
+++ b/checker/check_response_property_deprecation_test.go
@@ -43,7 +43,6 @@ func TestResponsePropertyDeprecationCheck_AllOf(t *testing.T) {
 	// With multiple media types (json and xml), we get one report per media type with distinct details
 	require.Len(t, errs, 2)
 	requireChange(t, errs, checker.ResponsePropertyDeprecatedWithSunsetId)
-	requireChange(t, errs, checker.ResponsePropertyDeprecatedWithSunsetId)
 	// Each message should include media type context
 	msg0 := errs[0].GetUncolorizedText(checker.NewDefaultLocalizer())
 	msg1 := errs[1].GetUncolorizedText(checker.NewDefaultLocalizer())

--- a/checker/check_response_required_property_updated_test.go
+++ b/checker/check_response_required_property_updated_test.go
@@ -131,6 +131,6 @@ func TestResponsePropertyOneOfWrappingIsBreaking(t *testing.T) {
 	// The wrapping must be reported exactly once per response body (not per
 	// property), as a breaking error, and nothing else.
 	require.Len(t, errs, 1, "a oneOf wrapping must produce exactly one finding (#702)")
-	requireChange(t, errs, checker.ResponseBodyWrappedInOneOfId)
-	require.Equal(t, checker.ERR, errs[0].GetLevel())
+	change := requireChange(t, errs, checker.ResponseBodyWrappedInOneOfId)
+	require.Equal(t, checker.ERR, change.GetLevel())
 }


### PR DESCRIPTION
`requireChange` looks a change up by id and returns it, so a caller can chain assertions onto it. Its own doc comment says as much. Twelve tests discarded the return and asserted against a positional element instead:

```go
requireChange(t, errs, checker.RequestBodyAnyOfRemovedId)
require.Equal(t, checker.ERR, errs[0].GetLevel())
require.Equal(t, "removed `#/components/schemas/Rabbit` ...", errs[0].GetUncolorizedText(...))
```

The lookup and the assertions are then unrelated to each other. Nothing ties `errs[0]` to the id just looked up, so if the order shifted the lookup would still pass while the level and text assertions moved to a different change. The test would keep passing while checking something else. They agree today only because `CompareChanges` sorts deterministically, which is a property of the production code that these tests are not trying to pin.

They now bind what the helper returns:

```go
change := requireChange(t, errs, checker.RequestBodyAnyOfRemovedId)
require.Equal(t, checker.ERR, change.GetLevel())
require.Equal(t, "removed `#/components/schemas/Rabbit` ...", change.GetUncolorizedText(...))
```

## The seven that are not that

Seven other tests called `requireChange` twice with the same id:

```go
requireChange(t, errs, checker.APISchemasRemovedId)
require.Equal(t, "removed the schema `network-policies`", errs[0]...)
requireChange(t, errs, checker.APISchemasRemovedId)   // asserts what the line above already did
require.Equal(t, "removed the schema `rules`", errs[1]...)
```

The second call asserts nothing the first did not, so it is removed. The positional reads stay: those changes genuinely share an id and differ only by text or by source, so something has to index them, and the sort is deterministic. Binding the return would cover the first of the pair and leave the second positional anyway.

## Scope

Tests only, no production code. Every test here passes before and after, which is the point: the change is about what a future failure would tell you, not about a failure today.

Found while reviewing whether `TestBreaking_RequestPropertyAllOfAdded` and `TestRequestPropertyAllOfAdded` were redundant. They are not, they pin disjoint things, but the first turned out to have this shape.
