### PR TITLE
Move the property stability checks onto the media-type walker

### DIFF
--- a/checker/check_property_stability_level.go
+++ b/checker/check_property_stability_level.go
@@ -1,7 +1,6 @@
 package checker
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 )
 
@@ -16,31 +15,15 @@ const (
 // Only emits changes when the property's base stability meets the configured threshold.
 func RequestPropertyStabilityUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if config == nil || diffReport.PathsDiff == nil {
+	if config == nil {
 		return result
 	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
-			}
-			op := operationItem.Revision
-			for _, mediaTypeDiff := range operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified {
-				checkModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						checkPropertyStabilityChange(propertyDiff, propertyPath, propertyName,
-							RequestPropertyStabilityDecreasedId, RequestPropertyStabilityIncreasedId,
-							config, operationsSources, op, operation, path, &result)
-					})
-			}
-		}
-	}
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		info.walkProperties(func(p propertyInfo) {
+			checkPropertyStabilityChange(p,
+				RequestPropertyStabilityDecreasedId, RequestPropertyStabilityIncreasedId, &result)
+		})
+	})
 	return result
 }
 
@@ -48,72 +31,39 @@ func RequestPropertyStabilityUpdatedCheck(diffReport *diff.Diff, operationsSourc
 // Only emits changes when the property's base stability meets the configured threshold.
 func ResponsePropertyStabilityUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if config == nil || diffReport.PathsDiff == nil {
+	if config == nil {
 		return result
 	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
-			}
-			op := operationItem.Revision
-			for _, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff == nil ||
-					responseDiff.ContentDiff == nil ||
-					responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-				for _, mediaTypeDiff := range responseDiff.ContentDiff.MediaTypeModified {
-					checkModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							checkPropertyStabilityChange(propertyDiff, propertyPath, propertyName,
-								ResponsePropertyStabilityDecreasedId, ResponsePropertyStabilityIncreasedId,
-								config, operationsSources, op, operation, path, &result)
-						})
-				}
-			}
-		}
-	}
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		info.walkProperties(func(p propertyInfo) {
+			checkPropertyStabilityChange(p,
+				ResponsePropertyStabilityDecreasedId, ResponsePropertyStabilityIncreasedId, &result)
+		})
+	})
 	return result
 }
 
-func checkPropertyStabilityChange(
-	propertyDiff *diff.SchemaDiff,
-	propertyPath string, propertyName string,
-	decreasedId string, increasedId string,
-	config *Config, operationsSources *diff.OperationsSourcesMap,
-	op *openapi3.Operation, operation string, path string,
-	result *Changes,
-) {
-	if propertyDiff.ExtensionsDiff == nil {
+func checkPropertyStabilityChange(p propertyInfo, decreasedId string, increasedId string, result *Changes) {
+	if p.propertyDiff.ExtensionsDiff == nil {
 		return
 	}
 
-	var baseStability, revisionStability string
-	var err error
+	op := p.operationItem.Revision
 
 	// An unparseable x-stability-level on a property is reported here: unlike
 	// the endpoint case, checkInvalidStabilityLevels does not descend into
 	// property schemas, so there is no other backstop for it.
-	if propertyDiff.Base != nil {
-		baseStability, err = getStabilityLevel(propertyDiff.Base.Extensions)
-		if err != nil {
-			baseSource := stabilityFieldSource(operationsSources, op, propertyDiff.Base.Origin)
-			*result = append(*result, getAPIInvalidStabilityLevel(config, op, operationsSources, operation, path, err).WithSources(baseSource, nil))
-			return
-		}
+	baseStability, err := getStabilityLevel(p.propertyDiff.Base.Extensions)
+	if err != nil {
+		baseSource := stabilityFieldSource(p.operationsSources, op, p.propertyDiff.Base.Origin)
+		*result = append(*result, getAPIInvalidStabilityLevel(p.config, op, p.operationsSources, p.method, p.path, err).WithSources(baseSource, nil))
+		return
 	}
-	if propertyDiff.Revision != nil {
-		revisionStability, err = getStabilityLevel(propertyDiff.Revision.Extensions)
-		if err != nil {
-			revisionSource := stabilityFieldSource(operationsSources, op, propertyDiff.Revision.Origin)
-			*result = append(*result, getAPIInvalidStabilityLevel(config, op, operationsSources, operation, path, err).WithSources(nil, revisionSource))
-			return
-		}
+	revisionStability, err := getStabilityLevel(p.propertyDiff.Revision.Extensions)
+	if err != nil {
+		revisionSource := stabilityFieldSource(p.operationsSources, op, p.propertyDiff.Revision.Origin)
+		*result = append(*result, getAPIInvalidStabilityLevel(p.config, op, p.operationsSources, p.method, p.path, err).WithSources(nil, revisionSource))
+		return
 	}
 
 	baseLabel := normalizedStability(baseStability)
@@ -128,7 +78,7 @@ func checkPropertyStabilityChange(
 	// Gate on the base stability (the level the property is leaving), consistent
 	// with the endpoint-level check, so a destabilization from a tracked level is
 	// reported rather than dropped.
-	if !config.StabilityLevel.IsIncluded(baseLabel) {
+	if !p.config.StabilityLevel.IsIncluded(baseLabel) {
 		return
 	}
 
@@ -137,28 +87,12 @@ func checkPropertyStabilityChange(
 		changeId = decreasedId
 	}
 
-	propName := propertyFullName(propertyPath, propertyName)
+	baseSource := stabilityFieldSource(p.operationsSources, op, p.propertyDiff.Base.Origin)
+	revisionSource := stabilityFieldSource(p.operationsSources, op, p.propertyDiff.Revision.Origin)
 
-	// Base/Revision can be nil here (a sub-schema present on only one side);
-	// stabilityFieldSource tolerates a nil origin.
-	var baseOrigin, revisionOrigin *openapi3.Origin
-	if propertyDiff.Base != nil {
-		baseOrigin = propertyDiff.Base.Origin
-	}
-	if propertyDiff.Revision != nil {
-		revisionOrigin = propertyDiff.Revision.Origin
-	}
-	baseSource := stabilityFieldSource(operationsSources, op, baseOrigin)
-	revisionSource := stabilityFieldSource(operationsSources, op, revisionOrigin)
-
-	*result = append(*result, NewApiChange(
+	*result = append(*result, p.newChange(
 		changeId,
-		config,
-		[]any{propName, baseLabel, revisionLabel},
+		[]any{propertyFullName(p.propertyPath, p.propertyName), baseLabel, revisionLabel},
 		"",
-		operationsSources,
-		op,
-		operation,
-		path,
 	).WithSources(baseSource, revisionSource))
 }

--- a/checker/check_property_stability_level_test.go
+++ b/checker/check_property_stability_level_test.go
@@ -113,3 +113,18 @@ func TestResponsePropertyStability_NilPathsDiff(t *testing.T) {
 	errs := checker.ResponsePropertyStabilityUpdatedCheck(&diff.Diff{}, nil, config)
 	require.Empty(t, errs)
 }
+
+// A property inside an OpenAPI 3.2 itemSchema, which types one item of a
+// streamed body, is checked by the same rules as a body property: both checks
+// reach it through the media-type walkers, and the "(item schema)" detail tells
+// the two apart.
+func TestPropertyStability_ItemSchema_Decreased(t *testing.T) {
+	errs := stabilityChanges(t, "base-item-schema.yaml", "revision-item-schema.yaml", checker.StabilityLevelDraft)
+
+	request := requireChange(t, errs, checker.RequestPropertyStabilityDecreasedId)
+	require.Equal(t, "/stream", request.GetPath())
+	require.Contains(t, request.GetUncolorizedText(checker.NewDefaultLocalizer()), "item schema")
+
+	response := requireChange(t, errs, checker.ResponsePropertyStabilityDecreasedId)
+	require.Contains(t, response.GetUncolorizedText(checker.NewDefaultLocalizer()), "item schema")
+}

--- a/data/stability/base-item-schema.yaml
+++ b/data/stability/base-item-schema.yaml
@@ -1,0 +1,28 @@
+openapi: "3.2.0"
+info:
+  title: Test
+  version: "1.0"
+paths:
+  /stream:
+    post:
+      operationId: streamTest
+      requestBody:
+        content:
+          application/jsonl:
+            itemSchema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  x-stability-level: stable
+      responses:
+        '200':
+          description: OK
+          content:
+            text/event-stream:
+              itemSchema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    x-stability-level: stable

--- a/data/stability/revision-item-schema.yaml
+++ b/data/stability/revision-item-schema.yaml
@@ -1,0 +1,28 @@
+openapi: "3.2.0"
+info:
+  title: Test
+  version: "1.0"
+paths:
+  /stream:
+    post:
+      operationId: streamTest
+      requestBody:
+        content:
+          application/jsonl:
+            itemSchema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  x-stability-level: draft
+      responses:
+        '200':
+          description: OK
+          content:
+            text/event-stream:
+              itemSchema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    x-stability-level: draft


### PR DESCRIPTION
Closes #1121, the last file on its list.

#1143 migrated the three enum checkers. This is the fourth, the one the issue flagged as "worth a closer look than the others": four traversal loops, request and response, each hand-iterating `ContentDiff.MediaTypeModified`.

## The change

The loops become `walkModifiedRequestBodySchemas` / `walkModifiedResponseSchemas` + `walkProperties`. `checkPropertyStabilityChange` took eight parameters threaded down through those loops (`config`, `operationsSources`, `op`, `operation`, `path`, the two ids, `result`) and now takes the `propertyInfo` the walker already carries. 164 lines to 98.

## What going through the walker changes

The closer look the issue asked for. All three are the reason to migrate, not side effects:

- **A property inside an OpenAPI 3.2 `itemSchema` is now checked.** The walkers cover streamed items, so the stability rules reach them for free, the same way every other body check did in #1139. `TestPropertyStability_ItemSchema_Decreased` pins it; verified it fails against the pre-migration checker.
- **The media-type detail comes from `newChange`** rather than from the call site remembering to add it. That is the bug class #936 opened the walker for, now structurally prevented here too.
- **A stability change inside an unflattened `allOf` carries the disclaimer**, so it reports at WARN like every other change oasdiff could not compare exactly (#1147). Previously these two checks were exempt by accident, not by decision.

## The one thing that could have lost findings, and why it does not

`walkProperties` skips a sub-schema whose `Base` or `Revision` is nil; the old code handled that case explicitly, with a comment saying so. That looks like dropped coverage. It is not:

`getSchemaDiffInternal` returns `&SchemaDiff{SchemaAdded: true}` or `{SchemaDeleted: true}` for a schema present on one side only, carrying neither `Base`, `Revision`, nor `ExtensionsDiff`, and computes `ExtensionsDiff` only after both values are known non-nil. `checkPropertyStabilityChange` returns early unless `ExtensionsDiff != nil`. So the branch could never run with a nil side, and the nil handling was unreachable defensive code. Dropped rather than carried forward.

## Verification

Full suite, `make` and `make lint` clean. The 30 existing stability tests pass unchanged, which is the equivalence argument for the paths that were already covered; the itemSchema test covers the path that was not.

After this, the only files still iterating `MediaTypeModified` are the three #1121 records as intentional: `check_media_type_schema_existence.go` (reports a schema added or removed on one side, exactly what the walker skips), `check_request_body_mediatype_updated.go` and `check_response_mediatype_name_updated.go` (no modified schema involved).
