### PR TITLE
Merge allOf where a schema is used, not only where it is defined

### DIFF
--- a/data/allof/ref-to-allof.yaml
+++ b/data/allof/ref-to-allof.yaml
@@ -1,0 +1,30 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: a schema whose allOf is reached through a $ref
+paths:
+  /pets:
+    get:
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+components:
+  schemas:
+    BaseEntity:
+      type: object
+      required: [id]
+      properties:
+        id: {type: integer}
+    PetFields:
+      type: object
+      required: [name]
+      properties:
+        name: {type: string}
+    Pet:
+      allOf:
+        - $ref: "#/components/schemas/BaseEntity"
+        - $ref: "#/components/schemas/PetFields"

--- a/flatten/allof/merge_allof_spec.go
+++ b/flatten/allof/merge_allof_spec.go
@@ -14,7 +14,10 @@ func MergeSpec(spec *openapi3.T) (*openapi3.T, error) {
 		if err != nil {
 			return err
 		}
-		s.Value = m
+		// Every $ref to this schema shares one Value, so writing the merge
+		// into it updates every use. Assigning s.Value would update only
+		// this reference and leave the rest unmerged.
+		*s.Value = *m
 		return openapi3.SkipSubtree
 	})
 	return spec, err

--- a/flatten/allof/merge_allof_spec_test.go
+++ b/flatten/allof/merge_allof_spec_test.go
@@ -94,3 +94,18 @@ func Test_MergeSpecWebhook(t *testing.T) {
 	require.True(t, schema.Properties["a"].Value.Type.Is("string"))
 	require.True(t, schema.Properties["b"].Value.Type.Is("integer"))
 }
+
+// A schema used through a $ref must be merged where it is used, not only where
+// it is defined. Each $ref is a separate SchemaRef sharing one Value, so a
+// merge that repointed the definition's SchemaRef left every use unmerged, and
+// the allOf reached the diff even though --flatten-allof was given.
+func TestMergeSpec_SchemaReachedThroughRef(t *testing.T) {
+	spec, err := load.NewSpecInfo(openapi3.NewLoader(), load.NewSource("../../data/allof/ref-to-allof.yaml"), load.WithFlattenAllOf())
+	require.NoError(t, err)
+
+	used := spec.Spec.Paths.Value("/pets").Get.Responses.Value("200").Value.Content["application/json"].Schema.Value
+	require.Empty(t, used.AllOf, "the allOf survived at the point of use")
+	require.ElementsMatch(t, []string{"id", "name"}, used.Required)
+	require.Contains(t, used.Properties, "id")
+	require.Contains(t, used.Properties, "name")
+}


### PR DESCRIPTION
Found by the oasdiff-action CI on the v1.29.0 bump PR (oasdiff/oasdiff-action#200), whose `flatten-allof` test started reporting a warning where it had reported an error.

## The bug

`MergeSpec` walks every `SchemaRef` and replaces the one it is handed:

```go
s.Value = m
```

A `$ref` is a **separate `SchemaRef` sharing the definition's `Value`**. Repointing the definition's `SchemaRef` therefore leaves every *use* of that schema pointing at the unmerged original, and the diff reads the schema through the use. So an `allOf` reached under a `$ref` survived `--flatten-allof` completely.

That is the common shape:

```yaml
responses:
  '200':
    content:
      application/json:
        schema: { $ref: '#/components/schemas/Pet' }   # <- diff reads this
components:
  schemas:
    Pet:
      allOf: [ { $ref: '#/.../BaseEntity' }, { $ref: '#/.../PetFields' } ]
```

On `main`, `oasdiff breaking base-allof.yaml revision-allof.yaml --flatten-allof` produces output **identical** to running without the flag, down to the `allOf[#/components/schemas/PetFields]/name` in the property path.

## Why nothing caught it

`oasdiff flatten` looked correct, because the merged component is right wherever the document is *serialized*: the response keeps its `$ref`, and `components.schemas.Pet` is merged. The bug only shows in the in-memory graph the diff traverses. Every existing `MergeSpec` test asserts on schemas at their definition site, where the old code worked.

## The fix

Write the merged content into the schema every `$ref` already points at, instead of pointing one reference at a new schema. `TestMergeSpec_SchemaReachedThroughRef` asserts the `allOf` is gone **at the point of use**; verified it fails without the fix.

## Consequences for `--flatten-allof` users

Both are the point of the flag, but they are visible changes and belong in the release notes:

- Property paths lose their `allOf[...]` prefix, since the branch is no longer part of the path.
- Verdicts sharpen where a sibling branch previously hid a change.
- Changes under such an `allOf` stop carrying the disclaimer from #1147, which had been advising users to pass a flag they had already passed. That false advice is what surfaced the bug.

## Verification

Full suite, `make` and `make lint` clean. The oasdiff-action case now returns `1 changes: 1 error, 0 warning, 0 info`, which is what oasdiff/oasdiff-action#200's workflow expects.