### PR TITLE
Always report a source location for a validation finding

### DIFF
--- a/data/validate/duplicate-required-field.yaml
+++ b/data/validate/duplicate-required-field.yaml
@@ -1,0 +1,13 @@
+openapi: 3.1.0
+info:
+  title: t
+  version: "1.0"
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      required: [name, name]
+      properties:
+        name:
+          type: string

--- a/data/validate/duplicate-tag.yaml
+++ b/data/validate/duplicate-tag.yaml
@@ -1,0 +1,8 @@
+openapi: 3.1.0
+info:
+  title: t
+  version: "1.0"
+tags:
+  - name: pets
+  - name: pets
+paths: {}

--- a/internal/validate_location_test.go
+++ b/internal/validate_location_test.go
@@ -1,0 +1,184 @@
+package internal_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/oasdiff/oasdiff/internal"
+	"github.com/oasdiff/oasdiff/validate"
+	"github.com/stretchr/testify/require"
+)
+
+// A location is only known to be *right* when a human has looked at a fixture
+// and written down the line it should report. Nothing can derive that. What
+// these tests can do is make sure the judgement happens: every rule either has
+// a fixture pinning its location, or is listed below as one nobody has got to.
+//
+// locationUnpinned is a ledger, not an approval. An entry means the rule's
+// location is unverified, not that it is exempt. Shrink it by adding a fixture
+// under data/validate that triggers the rule and asserting the expected line,
+// the way Test_ValidateCmd_FieldVersionMismatch_LicenseIdentifier does.
+//
+// A kin release that adds a validation code walks the existing chain first
+// (TestRuleIDs_MatchKinCatalog, then TestRuleDescriptions_CoverEveryRuleID) and
+// then fails here, unpinned and unlisted, so whoever adds the code has to
+// decide whether its location deserves a fixture or an entry below.
+var locationUnpinned = []string{
+	"additional-operations-field-for-3-2-plus",
+	"additional-properties-both-forms-exclusive",
+	"ambiguous-parameter-serialization",
+	"anchor-field-for-3-1-plus",
+	"authorization-url-forbidden",
+	"bearer-format-forbidden",
+	"boolean-schema-for-3-1-plus",
+	"boolean-schema-with-other-keywords",
+	"comment-field-for-3-1-plus",
+	"const-not-in-enum",
+	"contains-field-for-3-1-plus",
+	"content-encoding-field-for-3-1-plus",
+	"content-media-type-field-for-3-1-plus",
+	"content-or-schema-exactly-one",
+	"content-schema-field-for-3-1-plus",
+	"default-required",
+	"default-violates-schema",
+	"defs-field-for-3-1-plus",
+	"dependent-required-field-for-3-1-plus",
+	"dependent-schemas-field-for-3-1-plus",
+	"duplicate-enum-value",
+	"dynamic-anchor-field-for-3-1-plus",
+	"dynamic-ref-field-for-3-1-plus",
+	"else-field-for-3-1-plus",
+	"enum-empty",
+	"example-examples-mutually-exclusive",
+	"examples-field-for-3-1-plus",
+	"external-docs-url-required",
+	"flows-forbidden",
+	"flows-required",
+	"header-content-single-entry",
+	"id-field-for-3-1-plus",
+	"if-field-for-3-1-plus",
+	"in-forbidden",
+	"info-required",
+	"info-title-required",
+	"item-schema-field-for-3-2-plus",
+	"json-schema-dialect-required",
+	"jsonschemadialect-field-for-3-1-plus",
+	"license-name-required",
+	"max-contains-field-for-3-1-plus",
+	"min-contains-exceeds-max-contains",
+	"min-contains-field-for-3-1-plus",
+	"min-items-exceeds-max-items",
+	"min-length-exceeds-max-length",
+	"min-properties-exceeds-max-properties",
+	"minimum-exceeds-maximum",
+	"multiple-of-not-positive",
+	"name-forbidden",
+	"oauth-flow-authorization-url-required",
+	"oauth-flow-scopes-required",
+	"oauth-flow-token-url-required",
+	"openid-connect-url-required",
+	"operation-id-operation-ref-mutually-exclusive",
+	"operation-id-or-operation-ref-required",
+	"parameter-content-single-entry",
+	"parameter-name-required",
+	"path-parameters-mismatch",
+	"paths-required",
+	"pattern-properties-field-for-3-1-plus",
+	"prefix-items-field-for-3-1-plus",
+	"property-names-field-for-3-1-plus",
+	"query-field-for-3-2-plus",
+	"read-only-write-only-mutually-exclusive",
+	"request-body-content-required",
+	"required-with-default",
+	"response-description-required",
+	"responses-required",
+	"schema-field-for-3-1-plus",
+	"schema-items-required",
+	"security-scheme-name-required",
+	"serialization-method-invalid",
+	"server-url-required",
+	"spec-validation-error",
+	"subschemas-empty",
+	"summary-field-for-3-1-plus",
+	"then-field-for-3-1-plus",
+	"token-url-forbidden",
+	"type-format-mismatch",
+	"unevaluated-items-both-forms-exclusive",
+	"unevaluated-items-field-for-3-1-plus",
+	"unevaluated-properties-both-forms-exclusive",
+	"unevaluated-properties-field-for-3-1-plus",
+	"unresolved-ref",
+	"url-identifier-mutually-exclusive",
+	"value-external-value-mutually-exclusive",
+	"value-or-external-value-required",
+	"webhook-nil",
+}
+
+// rulesPinnedByFixtures returns the rules that the data/validate corpus
+// triggers *with* a source location.
+func rulesPinnedByFixtures(t *testing.T) []string {
+	t.Helper()
+
+	fixtures, err := filepath.Glob("../data/validate/*.yaml")
+	require.NoError(t, err)
+	require.NotEmpty(t, fixtures, "no validate fixtures found")
+
+	pinned := map[string]bool{}
+	for _, fixture := range fixtures {
+		var stdout bytes.Buffer
+		internal.Run(cmdToArgs("oasdiff validate -f json --fail-on INFO "+fixture), &stdout, io.Discard)
+
+		var findings []struct {
+			Id     string `json:"id"`
+			Source struct {
+				Line int `json:"line"`
+			} `json:"source"`
+		}
+		require.NoError(t, json.Unmarshal(stdout.Bytes(), &findings), "fixture %s", fixture)
+
+		for _, finding := range findings {
+			require.NotZerof(t, finding.Source.Line,
+				"%s reports %s with no source location; every finding a fixture produces must have one",
+				fixture, finding.Id)
+			pinned[finding.Id] = true
+		}
+	}
+
+	ids := make([]string, 0, len(pinned))
+	for id := range pinned {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+// Every rule is either pinned by a fixture or on the ledger. A new rule is
+// neither, so it fails here until someone decides which it is.
+func Test_ValidateCmd_EveryRuleLocationIsPinnedOrLedgered(t *testing.T) {
+	pinned := rulesPinnedByFixtures(t)
+
+	for _, id := range validate.RuleIDs() {
+		if slices.Contains(pinned, id) || slices.Contains(locationUnpinned, id) {
+			continue
+		}
+		t.Errorf("rule %q has no fixture pinning its source location and is not in locationUnpinned: "+
+			"add a data/validate fixture asserting the line it should report, or add it to the ledger", id)
+	}
+}
+
+// The ledger only shrinks. Once a fixture pins a rule, its entry has to go, so
+// the list can't quietly keep claiming coverage is missing where it isn't.
+func Test_ValidateCmd_LocationLedgerHasNoStaleEntries(t *testing.T) {
+	pinned := rulesPinnedByFixtures(t)
+
+	require.True(t, slices.IsSorted(locationUnpinned), "keep locationUnpinned sorted")
+	for _, id := range locationUnpinned {
+		require.Containsf(t, validate.RuleIDs(), id, "locationUnpinned lists %q, which is not a rule", id)
+		require.NotContainsf(t, pinned, id,
+			"%q is pinned by a fixture now; remove it from locationUnpinned", id)
+	}
+}

--- a/internal/validate_test.go
+++ b/internal/validate_test.go
@@ -479,9 +479,8 @@ func Test_ValidateCmd_DuplicateParameter(t *testing.T) {
 // dedicated path item field, and its keys must be RFC 9110 tokens. Both
 // findings pin to the `additionalOperations:` line: the offending thing is a
 // key inside the map, and the error carries the path item's origin, so that
-// field is the closest the error reaches. Asserting the location keeps them
-// from silently regressing to no location at all, which is what they reported
-// before locationForKinError learned these two clusters.
+// field is the closest the error reaches. The line is asserted so a change
+// that coarsens it to the path item shows up here.
 func Test_ValidateCmd_AdditionalOperationsDuplicateMethod(t *testing.T) {
 	var stdout bytes.Buffer
 	require.Equal(t, 1, internal.Run(cmdToArgs("oasdiff validate ../data/validate/additional-operations-duplicate-method.yaml"), &stdout, io.Discard))
@@ -494,6 +493,36 @@ func Test_ValidateCmd_AdditionalOperationsInvalidMethod(t *testing.T) {
 	require.Equal(t, 1, internal.Run(cmdToArgs("oasdiff validate ../data/validate/additional-operations-invalid-method.yaml"), &stdout, io.Discard))
 	require.Contains(t, stdout.String(), "[additional-operations-invalid-method]")
 	require.Contains(t, stdout.String(), "additional-operations-invalid-method.yaml:7:5")
+}
+
+// The same field listed twice in a schema's `required` array. kin puts the
+// Origin on the schema, so the refinement pins to its `required:` line (10)
+// rather than the schema's own line.
+func Test_ValidateCmd_DuplicateRequiredField(t *testing.T) {
+	var stdout bytes.Buffer
+	require.Equal(t, 1, internal.Run(cmdToArgs("oasdiff validate -f yaml ../data/validate/duplicate-required-field.yaml"), &stdout, io.Discard))
+
+	var findings []map[string]any
+	require.NoError(t, yaml.Unmarshal(stdout.Bytes(), &findings))
+	require.Len(t, findings, 1)
+	require.Equal(t, "duplicate-required-field", findings[0]["id"])
+	src := findings[0]["source"].(map[string]any)
+	require.Equal(t, 10, src["line"], "should pin to the required: line, not the schema's line")
+}
+
+// Two tags with the same name. kin puts the Origin on the second (offending)
+// tag, and the enclosing object is the right pin for a duplicated object, so
+// this resolves through originKey rather than a refinement.
+func Test_ValidateCmd_DuplicateTag(t *testing.T) {
+	var stdout bytes.Buffer
+	require.Equal(t, 1, internal.Run(cmdToArgs("oasdiff validate -f yaml --fail-on INFO ../data/validate/duplicate-tag.yaml"), &stdout, io.Discard))
+
+	var findings []map[string]any
+	require.NoError(t, yaml.Unmarshal(stdout.Bytes(), &findings))
+	require.Len(t, findings, 1)
+	require.Equal(t, "duplicate-tag", findings[0]["id"])
+	src := findings[0]["source"].(map[string]any)
+	require.Equal(t, 7, src["line"], "should pin to the second tag, the duplicate")
 }
 
 // A path key without a leading slash → PathMustStartWithSlashError.

--- a/validate/location.go
+++ b/validate/location.go
@@ -9,6 +9,7 @@ package validate
 
 import (
 	"errors"
+	"reflect"
 	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -34,10 +35,21 @@ func lineColumnForKinError(err error) (int, int) {
 //   - Origin.Fields.Lookup(X) points at the specific scalar field X inside
 //     that collection.
 //
-// For clusters that carry a Field, we want Fields.Lookup(Field) (the
-// offending line) rather than Key (the enclosing object's line).
-// Falls back to Key when the per-field entry is missing, and finally
-// to nil for clusters with no Origin at all (WebhookNilError).
+// The cases below are refinements: each names the field its cluster should
+// pin to, so the finding lands on the offending line rather than on the
+// enclosing object. A cluster with no case here still gets a location from
+// originKey, just a coarser one, so a kin error type nobody has looked at
+// yet degrades in precision rather than reporting no location at all.
+//
+// Key is the right answer, not merely the default, whenever the offending
+// thing has no scalar field of its own to point at: a constraint violated
+// across several fields (none of which may even be present), a duplicated
+// object, or a map key, since Origin.Fields tracks struct fields rather
+// than map keys. Those clusters are left to originKey deliberately.
+//
+// Returns nil only for a cluster carrying no Origin at all (WebhookNilError,
+// whose offending key is on the document root, which the loader does not
+// track per-key), or when the document was loaded without origin tracking.
 func locationForKinError(err error) *openapi3.Location {
 	if rfe, ok := errors.AsType[*openapi3.RequiredFieldError](err); ok && rfe.Origin != nil {
 		return fieldLoc(rfe.Origin, rfe.Field)
@@ -50,9 +62,6 @@ func locationForKinError(err error) *openapi3.Location {
 		// — the per-field key under the schema where the value lives.
 		return fieldLoc(sve.Origin, sve.ValueKind)
 	}
-	if ppe, ok := errors.AsType[*openapi3.PathParametersError](err); ok && ppe.Origin != nil {
-		return ppe.Origin.Key
-	}
 	if mef, ok := errors.AsType[*openapi3.MutuallyExclusiveFieldsError](err); ok && mef.Origin != nil {
 		// Prefer Field1's location; either offender pins the finding to
 		// the right object. We don't carry both since a single Source
@@ -62,33 +71,11 @@ func locationForKinError(err error) *openapi3.Location {
 	if ffe, ok := errors.AsType[*openapi3.ForbiddenFieldError](err); ok && ffe.Origin != nil {
 		return fieldLoc(ffe.Origin, ffe.Field)
 	}
-	if sute, ok := errors.AsType[*openapi3.ServerURLTemplateError](err); ok && sute.Origin != nil {
-		return sute.Origin.Key
-	}
-	if efr, ok := errors.AsType[*openapi3.EitherFieldRequiredError](err); ok && efr.Origin != nil {
-		// EitherFieldRequiredError fires when none of {Fields...} are
-		// present, so per-field lookup wouldn't match anything — the
-		// enclosing object's Key is the right pin.
-		return efr.Origin.Key
-	}
 	if sbf, ok := errors.AsType[*openapi3.SchemaBothFormsExclusive](err); ok && sbf.Origin != nil {
 		return fieldLoc(sbf.Origin, sbf.Field)
 	}
-	if eofe, ok := errors.AsType[*openapi3.ExactlyOneFieldError](err); ok && eofe.Origin != nil {
-		// Same reasoning as EitherFieldRequiredError: cluster fires
-		// when the constraint is violated across multiple fields; the
-		// object Key is the cleanest pin.
-		return eofe.Origin.Key
-	}
 	if sec, ok := errors.AsType[*openapi3.SingleEntryContentError](err); ok && sec.Origin != nil {
 		return fieldLoc(sec.Origin, sec.Subject)
-	}
-	if pre, ok := errors.AsType[*openapi3.PathParameterRequiredError](err); ok && pre.Origin != nil {
-		// PathParameterRequiredError fires on a parameter declared with
-		// in: path but without required: true. The Key of the parameter
-		// object pins the finding correctly; the `required` field would
-		// be more precise but is absent (that's the whole bug).
-		return pre.Origin.Key
 	}
 	if ste, ok := errors.AsType[*openapi3.SchemaTypeError](err); ok && ste.Origin != nil {
 		// SchemaTypeError fires on the offending `type:` field of a
@@ -102,13 +89,6 @@ func locationForKinError(err error) *openapi3.Location {
 		// is the field value, not the surrounding block. Falls back
 		// to the operation Key if the loader didn't track the field.
 		return fieldLoc(doid.Origin, "operationId")
-	}
-	if esf, ok := errors.AsType[*openapi3.ExtraSiblingFieldsError](err); ok && esf.Origin != nil {
-		// Origin points at the parent object carrying the unexpected
-		// sibling fields. The fields themselves may not have Origin
-		// entries (Yaml parser tracks structural keys, not the
-		// offending ones), so the object Key is the best pin.
-		return esf.Origin.Key
 	}
 	if ipe, ok := errors.AsType[*openapi3.InvalidParameterInError](err); ok && ipe.Origin != nil {
 		// Pin to the parameter's `in` field if the loader tracks it,
@@ -134,19 +114,6 @@ func locationForKinError(err error) *openapi3.Location {
 	if akie, ok := errors.AsType[*openapi3.APIKeyInInvalidError](err); ok && akie.Origin != nil {
 		return fieldLoc(akie.Origin, "in")
 	}
-	if pmss, ok := errors.AsType[*openapi3.PathMustStartWithSlashError](err); ok && pmss.Origin != nil {
-		// Origin is the paths object; the offending path key lives
-		// inside it but Fields tracks struct fields, not map keys, so
-		// fall back to the paths object's Key.
-		return pmss.Origin.Key
-	}
-	if cpe, ok := errors.AsType[*openapi3.ConflictingPathsError](err); ok && cpe.Origin != nil {
-		return cpe.Origin.Key
-	}
-	if dpe, ok := errors.AsType[*openapi3.DuplicateParameterError](err); ok && dpe.Origin != nil {
-		// Origin is on the second (offending) parameter; pin to its Key.
-		return dpe.Origin.Key
-	}
 	if isme, ok := errors.AsType[*openapi3.InvalidSerializationMethodError](err); ok && isme.Origin != nil {
 		// Pin to the `style` field if the loader tracks it on the
 		// encoding/parameter/header object.
@@ -158,21 +125,82 @@ func locationForKinError(err error) *openapi3.Location {
 	if aoi, ok := errors.AsType[*openapi3.AdditionalOperationsInvalidMethodError](err); ok && aoi.Origin != nil {
 		return additionalOperationsLoc(aoi.Origin)
 	}
-	// WebhookNilError carries no Origin (the offending key is on the
-	// document root, which the loader doesn't track per-key).
-	return nil
+	if drf, ok := errors.AsType[*openapi3.DuplicateRequiredFieldError](err); ok && drf.Origin != nil {
+		// Origin is the schema; the duplicate is inside its `required`
+		// array, so pin there rather than at the schema's own line.
+		return fieldLoc(drf.Origin, "required")
+	}
+	return originKey(err)
 }
 
 // additionalOperationsLoc pins an additionalOperations key error to the
 // `additionalOperations:` field of the path item.
 //
 // The offending thing is a key inside that map, and the loader does record it
-// (on the keyed Operation's own Origin), but the error carries the path item's
-// Origin, so the map field is as close as the error itself reaches. That still
-// lands in the right block rather than nowhere, which is what these two
-// reported before. Falls back to the path item's Key.
+// on the keyed Operation's own Origin, but the error carries the path item's
+// Origin, so the map field is as close as the error itself reaches. Without
+// this the fallback would pin to the path item instead.
 func additionalOperationsLoc(origin *openapi3.Origin) *openapi3.Location {
 	return fieldLoc(origin, "additionalOperations")
+}
+
+// originKey returns the Key of whatever Origin the error carries, or nil if it
+// carries none.
+//
+// The lookup is by reflection rather than a type switch on purpose. Every kin
+// validation error that tracks a source location exposes it the same way, as a
+// public `Origin *openapi3.Origin` field, so reading that field covers the
+// clusters locationForKinError refines, the ones where the enclosing object is
+// the right answer, and any type a later kin release adds, without oasdiff
+// keeping a parallel list of kin's error types.
+//
+// The coupling is to the field's name and type. TestOriginKey_ReadsTheOriginField
+// pins both, so a kin rename fails there rather than silently dropping every
+// location.
+//
+// kin wraps the offending error in section, path and operation context, so the
+// Origin is on a leaf rather than on what the caller holds. Walk the chain the
+// way errors.AsType does and take the first Origin found, innermost wrappers
+// last, so the nearest enclosing object wins over a distant ancestor.
+func originKey(err error) *openapi3.Location {
+	for err != nil {
+		if origin := declaredOrigin(err); origin != nil && origin.Key != nil {
+			return origin.Key
+		}
+		switch unwrapped := err.(type) {
+		case interface{ Unwrap() error }:
+			err = unwrapped.Unwrap()
+		case interface{ Unwrap() []error }:
+			for _, e := range unwrapped.Unwrap() {
+				if loc := originKey(e); loc != nil {
+					return loc
+				}
+			}
+			return nil
+		default:
+			return nil
+		}
+	}
+	return nil
+}
+
+// declaredOrigin reads an error's public `Origin *openapi3.Origin` field, or
+// nil when it has none.
+func declaredOrigin(err error) *openapi3.Origin {
+	v := reflect.ValueOf(err)
+	if v.Kind() != reflect.Pointer || v.IsNil() {
+		return nil
+	}
+	v = v.Elem()
+	if v.Kind() != reflect.Struct {
+		return nil
+	}
+	field := v.FieldByName("Origin")
+	if !field.IsValid() || !field.CanInterface() {
+		return nil
+	}
+	origin, _ := field.Interface().(*openapi3.Origin)
+	return origin
 }
 
 // schemaFieldLocation returns the line/column of the named field inside a

--- a/validate/location_test.go
+++ b/validate/location_test.go
@@ -1,0 +1,46 @@
+package validate
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/require"
+)
+
+// originKey reads kin's `Origin` field by reflection, so it is coupled to that
+// field's name and type rather than to a list of error types. This pins the
+// coupling: if a kin release renames or retypes the field, this fails instead
+// of every finding silently losing its location.
+func TestOriginKey_ReadsTheOriginField(t *testing.T) {
+	loc := &openapi3.Location{Line: 42, Column: 7}
+	origin := &openapi3.Origin{Key: loc}
+
+	// Two unrelated kin error types, neither refined by locationForKinError,
+	// both resolving through the reflective path.
+	require.Equal(t, loc, originKey(&openapi3.DuplicateTagError{Name: "pets", Origin: origin}))
+	require.Equal(t, loc, originKey(&openapi3.ConflictingPathsError{Origin: origin}))
+}
+
+// kin wraps errors in section / path / operation context, so the Origin sits on
+// a leaf rather than on the error the caller holds.
+func TestOriginKey_WalksTheUnwrapChain(t *testing.T) {
+	loc := &openapi3.Location{Line: 11, Column: 3}
+	leaf := &openapi3.DuplicateTagError{Name: "pets", Origin: &openapi3.Origin{Key: loc}}
+
+	require.Equal(t, loc, originKey(fmt.Errorf("path: %w", fmt.Errorf("section: %w", leaf))))
+}
+
+// An error with no Origin at all resolves to nothing rather than to a
+// misleading location borrowed from elsewhere.
+func TestOriginKey_NoOrigin(t *testing.T) {
+	require.Nil(t, originKey(&openapi3.WebhookNilError{}))
+	require.Nil(t, originKey(fmt.Errorf("plain error")))
+	require.Nil(t, originKey(nil))
+}
+
+// A nil Origin field, which is what a load without origin tracking produces,
+// is not a location.
+func TestOriginKey_NilOrigin(t *testing.T) {
+	require.Nil(t, originKey(&openapi3.DuplicateTagError{Name: "pets"}))
+}


### PR DESCRIPTION
`oasdiff validate` reported some findings with a file but no line or column. Two rules were affected, `duplicate-required-field` and `duplicate-tag`, both at error level:

```
error   [duplicate-tag] at spec.yaml
        more than one tag has name "pets"
```

`locationForKinError` matched kin's error types one at a time and returned nil for anything unmatched, so a type without a case reported no location at all.

## What changed

Read the `Origin` off whatever error came in, by reflection, walking the unwrap chain kin builds from its section, path and operation context. Every kin validation error that tracks a source location exposes it as a public `Origin` field, so this covers the types matched today, the ones where the enclosing object is already the right answer, and any type a later kin release adds, without oasdiff keeping a parallel list of them.

The per-type cases stay, as refinements that pin to a specific field instead of the enclosing object. Nine of them returned `Origin.Key` verbatim, which is exactly what the fallback computes, so they go. `duplicate-required-field` gains a refinement onto its `required` array.

Both affected rules now report a line:

```
error   [duplicate-required-field] at spec.yaml:10:7
error   [duplicate-tag] at spec.yaml:7:5      ← the second tag, the duplicate
```

## Knowing a location is right, not just present

A location being present is checkable; a location being the *right* line is a judgement, and it can only be recorded by a fixture asserting the line it expects. So every rule is now either pinned by such a fixture or listed in `locationUnpinned`, currently 84 of 106.

The ledger is not an approval. An entry means the rule's location is unverified, and the list is meant to shrink. A new validation code is neither pinned nor listed, so it fails the check until someone decides which it is, after the existing checks for the rule id and its description.

## Tests

- `TestOriginKey_*` pin the reflective lookup to the field's name and type, so a kin rename fails there rather than silently dropping every location, and cover the unwrap chain, a missing `Origin` and a nil one.
- Fixtures and asserted lines for the two fixed rules.
- Every finding a fixture produces must carry a location.

Verified by mutation: a new rule id, a stale ledger entry, and a finding losing its location each fail the intended check.