### PR TITLE
internal: reject an unsupported template format before loading the specs

### DIFF
--- a/internal/changelog.go
+++ b/internal/changelog.go
@@ -138,11 +138,6 @@ func outputChangelog(flags *Flags, stdout io.Writer, errs checker.Changes, specI
 		return getErrUnsupportedFormat(flags.getFormat(), changelogCmd)
 	}
 
-	// validate template usage
-	if flags.getTemplate() != "" && !formatter.SupportsTemplate() {
-		return getErrTemplateNotSupported(flags.getFormat())
-	}
-
 	// render
 	colorMode, err := checker.NewColorMode(flags.getColor())
 	if err != nil {

--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 
+	"github.com/oasdiff/oasdiff/formatters"
 	"github.com/oasdiff/oasdiff/load"
 	"github.com/spf13/cobra"
 )
@@ -27,6 +28,9 @@ func getParseArgs() cobra.PositionalArgs {
 			return err
 		}
 		if err := checkColor(cmd); err != nil {
+			return err
+		}
+		if err := checkTemplate(cmd); err != nil {
 			return err
 		}
 
@@ -86,6 +90,36 @@ func checkColor(cmd *cobra.Command) error {
 	}
 
 	return errors.New(`--color flag is only relevant with 'text' or 'singleline' formats`)
+}
+
+// checkTemplate rejects --template with a format that renders no template,
+// before the specs are loaded rather than after the diff is computed.
+func checkTemplate(cmd *cobra.Command) error {
+
+	// only the changelog-shaped commands define it (via addCommonChangelogFlags)
+	if cmd.Flags().Lookup("template") == nil {
+		return nil
+	}
+
+	if template, _ := cmd.Flags().GetString("template"); template == "" {
+		return nil
+	}
+
+	format, _ := cmd.Flags().GetString("format")
+	formatter, err := formatters.Lookup(format, formatters.DefaultFormatterOpts())
+	if err != nil {
+		// an unsupported format is reported when the output is rendered
+		return nil
+	}
+	if !formatter.SupportsTemplate() {
+		err := getErrTemplateNotSupported(format)
+		// keep the exit code the command reported when this was checked
+		// after the diff
+		setReturnValue(cmd, err.Code)
+		return err
+	}
+
+	return nil
 }
 
 func checkReviewFlagsRequireOpen(cmd *cobra.Command) error {

--- a/internal/template_validation_test.go
+++ b/internal/template_validation_test.go
@@ -85,3 +85,13 @@ func TestTemplateValidationInChangelog(t *testing.T) {
 		})
 	}
 }
+
+// The template/format mismatch is a flag error, so it is reported before the
+// specs are loaded: an unreadable spec must not pre-empt it.
+func TestTemplateValidation_PrecedesSpecLoading(t *testing.T) {
+	var stderr bytes.Buffer
+	exitCode := internal.Run(cmdToArgsLocal("oasdiff changelog no-such-base.yaml no-such-revision.yaml --format json --template ../data/template.md"), io.Discard, &stderr)
+
+	require.Equal(t, 111, exitCode)
+	require.Contains(t, stderr.String(), "template flag is not supported for format \"json\"")
+}

--- a/internal/viper.go
+++ b/internal/viper.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"slices"
+
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/checker/localizations"
 	"github.com/oasdiff/oasdiff/diff"
@@ -13,7 +15,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	"slices"
 )
 
 // EnvConfigPath is the environment variable that overrides the default


### PR DESCRIPTION
`--template` with a format that renders no template was rejected in the render step, after both specs were loaded, the diff computed and every check run. On large specs, or with git refs and URLs that fetch, the caller waits for all of that to be told a flag combination is wrong.

The same command already rejects the analogous `--color` mismatch in its `Args` validator, before anything loads, so the two flag errors were reported at opposite ends of the run:

```
# before
$ oasdiff changelog --format json --color always missing1.yaml missing2.yaml
Error: --color flag is only relevant with 'text' or 'singleline' formats     # immediate

$ oasdiff changelog --format json --template t.md missing1.yaml missing2.yaml
Error: failed to load base spec from "missing1.yaml": ...                    # loads first
```

`checkTemplate` now sits beside `checkColor` in `getParseArgs`, so the mismatch is reported immediately. The message and the exit code (111) are unchanged, and the existing template tests pass untouched; a new test pins the ordering by passing unreadable specs and asserting the template error still wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDvUFsg5nu1NBWQffErGDw
