### PR TITLE
internal: pin that every --fail-on level the CLI offers is accepted by the checker

### DIFF
--- a/internal/changelog.go
+++ b/internal/changelog.go
@@ -95,9 +95,9 @@ func getChangelog(flags *Flags, stdout io.Writer, level checker.Level, isBreakin
 	}
 
 	if flags.getFailOn() != "" {
-		level, err := checker.NewLevel(flags.getFailOn())
-		if err != nil {
-			return false, getErrInvalidFlags(fmt.Errorf("invalid fail-on value %s", flags.getFailOn()))
+		level, returnErr := flags.failOnLevel()
+		if returnErr != nil {
+			return false, returnErr
 		}
 		return errs.HasLevelOrHigher(level), nil
 	}

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -1,6 +1,9 @@
 package internal
 
 import (
+	"fmt"
+
+	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/oasdiff/oasdiff/load"
 	"github.com/spf13/viper"
@@ -184,4 +187,17 @@ func (flags *Flags) getTemplate() string {
 
 func (flags *Flags) getStabilityLevel() string {
 	return flags.v.GetString("stability-level")
+}
+
+// failOnLevel converts the --fail-on value to the severity that fails the
+// command. The flag rejects anything outside GetSupportedLevels and the
+// config file does the same, so the error is unreachable for a value that
+// got this far, and is returned rather than dropped in case the two ever
+// disagree.
+func (flags *Flags) failOnLevel() (checker.Level, *ReturnError) {
+	level, err := checker.NewLevel(flags.getFailOn())
+	if err != nil {
+		return checker.NONE, getErrInvalidFlags(fmt.Errorf("invalid fail-on value %q", flags.getFailOn()))
+	}
+	return level, nil
 }

--- a/internal/level_test.go
+++ b/internal/level_test.go
@@ -1,0 +1,20 @@
+package internal_test
+
+import (
+	"testing"
+
+	"github.com/oasdiff/oasdiff/checker"
+	"github.com/oasdiff/oasdiff/internal"
+	"github.com/stretchr/testify/require"
+)
+
+// The --fail-on flag and the config file accept these names, and the run
+// then converts them with the checker: a name the checker does not accept
+// would reach the user as a run-time error on a value oasdiff had already
+// told them was valid.
+func TestLevels_AcceptedByChecker(t *testing.T) {
+	for _, level := range internal.GetSupportedLevels() {
+		_, err := checker.NewLevel(level)
+		require.NoError(t, err, level)
+	}
+}

--- a/internal/validate.go
+++ b/internal/validate.go
@@ -92,9 +92,9 @@ func runValidate(flags *Flags, stdout io.Writer) (bool, *ReturnError) {
 	// Findings are always printed; the --fail-on level decides whether they
 	// also fail the command. Default is error, so warnings and info surface
 	// without failing CI unless the caller lowers the threshold.
-	failOn, err := checker.NewLevel(flags.getFailOn())
-	if err != nil {
-		return false, getErrInvalidFlags(fmt.Errorf("invalid fail-on value: %q", flags.getFailOn()))
+	failOn, returnErr := flags.failOnLevel()
+	if returnErr != nil {
+		return false, returnErr
 	}
 
 	return findings.HasLevelOrHigher(failOn), nil


### PR DESCRIPTION
`--fail-on` names a severity, and two packages have to agree on the names. `internal` offers `ERR`, `WARN` and `INFO` through `GetSupportedLevels`, which is what the flag and the config file validate against, and `checker.NewLevel` is what converts the accepted string at run time. Nothing checks that those two lists match.

They match today, so nothing is broken. But renaming a level, or adding one to `GetSupportedLevels`, would surface as a run-time error on a value oasdiff had just told the user was valid:

```
Error: invalid argument "BOGUS" for "-o, --fail-on" flag: BOGUS is not one of the allowed values: ERR, WARN, or INFO
```

This adds a test pinning that the checker accepts every name the flag and the config offer, so the two lists cannot drift apart silently.

## The conversion

While there, the conversion itself moves into one place. `changelog` and `validate` each did it, and their error text had already drifted:

```go
// changelog
return false, getErrInvalidFlags(fmt.Errorf("invalid fail-on value %s", flags.getFailOn()))
// validate
return false, getErrInvalidFlags(fmt.Errorf("invalid fail-on value: %q", flags.getFailOn()))
```

Neither can fire, since the flag is registered with `enumWithOptions` and the config path validates the same list, so a value reaching the run is already one of the three. The error is still returned rather than dropped, because Go cannot express "this string is known valid", but it is now unreachable by construction rather than by luck, and the reason is written down in one place instead of nowhere.

Nothing is deleted and no behavior changes for valid values. The full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
