### PR TITLE
Add --base so breaking can run as a pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,6 +2,7 @@
   name: oasdiff breaking
   description: Fail on breaking API changes between the staged OpenAPI spec and its version on the base branch
   language: golang
-  entry: oasdiff breaking --base origin/main --fail-on ERR
+  entry: oasdiff breaking
+  args: [--base, origin/main, --fail-on, ERR]
   files: (^|/)openapi\.(ya?ml|json)$
   pass_filenames: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: oasdiff-breaking
+  name: oasdiff breaking
+  description: Fail on breaking API changes between the staged OpenAPI spec and its version on the base branch
+  language: golang
+  entry: oasdiff breaking --base origin/main --fail-on ERR
+  files: (^|/)openapi\.(ya?ml|json)$
+  pass_filenames: true

--- a/docs/BREAKING-CHANGES.md
+++ b/docs/BREAKING-CHANGES.md
@@ -81,12 +81,13 @@ The hook compares each changed spec against its version on `origin/main` and fai
 ```
 oasdiff breaking --base origin/main openapi.yaml
 ```
-By default the hook only runs on files named `openapi.yaml`, `openapi.yml`, or `openapi.json`. Override `files` (and any breaking flags via `args`) in your config to match your setup:
+By default the hook only runs on files named `openapi.yaml`, `openapi.yml`, or `openapi.json`. Override `files` (and any breaking flags via `args`) in your config to match your setup. `args` replaces the hook's defaults, so keep `--base` when you override it:
 ```yaml
       - id: oasdiff-breaking
         files: (^|/)api/.*\.yaml$
-        args: [--fail-on, WARN]
+        args: [--base, origin/main, --fail-on, WARN]
 ```
+A spec that is not present in the base ref is treated as newly added and skipped, since a new API has no prior version to break.
 
 ## Output Formats
 By default, oasdiff displays changes in a human-readable [colorized](#color) text format.  

--- a/docs/BREAKING-CHANGES.md
+++ b/docs/BREAKING-CHANGES.md
@@ -68,6 +68,26 @@ For example:
 oasdiff breaking --fail-on ERR data/openapi-test1.yaml data/openapi-test3.yaml
 ```
 
+## Pre-commit hook
+oasdiff ships a [pre-commit](https://pre-commit.com/) hook so breaking changes are caught before a commit lands, not only in CI. Add it to your `.pre-commit-config.yaml`:
+```yaml
+repos:
+  - repo: https://github.com/oasdiff/oasdiff
+    rev: v1.29.1
+    hooks:
+      - id: oasdiff-breaking
+```
+The hook compares each changed spec against its version on `origin/main` and fails the commit on any `ERR`-level change. It uses the `--base` flag, which turns the positional arguments into the changed files and compares each one against the given git ref (`--base` accepts any ref, e.g. `--base origin/develop`):
+```
+oasdiff breaking --base origin/main openapi.yaml
+```
+By default the hook only runs on files named `openapi.yaml`, `openapi.yml`, or `openapi.json`. Override `files` (and any breaking flags via `args`) in your config to match your setup:
+```yaml
+      - id: oasdiff-breaking
+        files: (^|/)api/.*\.yaml$
+        args: [--fail-on, WARN]
+```
+
 ## Output Formats
 By default, oasdiff displays changes in a human-readable [colorized](#color) text format.  
 Additional formats can be generated using the `--format` flag:

--- a/internal/breaking_base_test.go
+++ b/internal/breaking_base_test.go
@@ -1,5 +1,3 @@
-//go:build unix
-
 package internal_test
 
 import (
@@ -8,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/oasdiff/oasdiff/internal"
@@ -60,10 +57,9 @@ func breakingBaseRepo(t *testing.T, files map[string]string) string {
 	}
 	gitRun("git", "commit", "-m", "base")
 
-	oldDir, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(dir))
-	t.Cleanup(func() { _ = os.Chdir(oldDir) })
+	// t.Chdir restores the previous directory automatically and fails the test
+	// if it is parallel, so it can't quietly corrupt sibling tests.
+	t.Chdir(dir)
 
 	return dir
 }
@@ -102,10 +98,31 @@ func Test_BreakingBase_MultipleFiles(t *testing.T) {
 	exitCode := internal.Run(cmdToArgs("oasdiff breaking --base HEAD --fail-on ERR openapi.yaml other.yaml"), &stdout, io.Discard)
 
 	require.Equal(t, 1, exitCode)
-	// both files reported: the breaking one names the removed path, the
-	// unchanged one reports no breaking changes
+	// both files reported: the breaking one names the removed path, and each
+	// result is labelled with its filename so they can be told apart
 	require.Contains(t, stdout.String(), "api-path-removed-without-deprecation")
-	require.Equal(t, 2, strings.Count(stdout.String(), "changes"))
+	require.Contains(t, stdout.String(), "openapi.yaml")
+	require.Contains(t, stdout.String(), "other.yaml")
+}
+
+// Test_BreakingBase_NewFileSkipped checks that a file absent from the base ref
+// (a newly added spec) is skipped rather than aborting the run: the new file is
+// listed first, yet the breaking change in a later, existing file is still
+// caught and fails the command.
+func Test_BreakingBase_NewFileSkipped(t *testing.T) {
+	dir := breakingBaseRepo(t, map[string]string{"openapi.yaml": baseSpec})
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "openapi.yaml"), []byte(breakingSpec), 0644))
+	// new-api.yaml exists in the working tree but was never committed, so it has
+	// no version in HEAD
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "new-api.yaml"), []byte(baseSpec), 0644))
+
+	var stdout bytes.Buffer
+	exitCode := internal.Run(cmdToArgs("oasdiff breaking --base HEAD --fail-on ERR new-api.yaml openapi.yaml"), &stdout, io.Discard)
+
+	require.Equal(t, 1, exitCode)
+	require.Contains(t, stdout.String(), "new file, not in base ref, skipped")
+	require.Contains(t, stdout.String(), "new-api.yaml")
+	require.Contains(t, stdout.String(), "api-path-removed-without-deprecation")
 }
 
 // Test_BreakingBase_NoFailOn prints breaking changes but keeps exit 0 when

--- a/internal/breaking_base_test.go
+++ b/internal/breaking_base_test.go
@@ -137,3 +137,55 @@ func Test_BreakingBase_NoFailOn(t *testing.T) {
 	require.Zero(t, exitCode)
 	require.Contains(t, stdout.String(), "api-path-removed-without-deprecation")
 }
+
+// A path in neither the base ref nor the working tree is a mistake, not a new
+// file. Reporting it as newly added would exit 0 and tell the caller their
+// specs are clean when nothing was compared.
+func Test_BreakingBase_MissingFileIsNotNew(t *testing.T) {
+	breakingBaseRepo(t, map[string]string{"openapi.yaml": baseSpec})
+
+	var stderr bytes.Buffer
+	exitCode := internal.Run(cmdToArgs("oasdiff breaking --base HEAD --fail-on ERR does-not-exist.yaml"), io.Discard, &stderr)
+
+	require.NotZero(t, exitCode, "a path that exists nowhere must not pass")
+	require.NotContains(t, stderr.String(), "skipped")
+}
+
+// The positionals are working-tree files that also have a version in the base
+// ref, so stdin has nothing to compare against and is rejected up front rather
+// than treated as a filename.
+func Test_BreakingBase_RejectsStdin(t *testing.T) {
+	breakingBaseRepo(t, map[string]string{"openapi.yaml": baseSpec})
+
+	var stderr bytes.Buffer
+	exitCode := internal.Run(cmdToArgs("oasdiff breaking --base HEAD -"), io.Discard, &stderr)
+
+	require.Equal(t, 100, exitCode)
+	require.Contains(t, stderr.String(), "can't read from stdin with --base")
+}
+
+// Composed mode merges several specs into one comparison, which is the opposite
+// of comparing each file against its own version in the base ref.
+func Test_BreakingBase_RejectsComposed(t *testing.T) {
+	breakingBaseRepo(t, map[string]string{"openapi.yaml": baseSpec})
+
+	var stderr bytes.Buffer
+	exitCode := internal.Run(cmdToArgs("oasdiff breaking --base HEAD --composed openapi.yaml"), io.Discard, &stderr)
+
+	require.Equal(t, 100, exitCode)
+	require.Contains(t, stderr.String(), "can't use --composed with --base")
+}
+
+// The flag-only validations are shared with the base+revision path, so a check
+// added to checkCommonFlags reaches --base too. Pinned here because the two
+// paths validate their positionals differently and could drift again.
+func Test_BreakingBase_SharesCommonFlagChecks(t *testing.T) {
+	breakingBaseRepo(t, map[string]string{"openapi.yaml": baseSpec})
+
+	var stderr bytes.Buffer
+	exitCode := internal.Run(cmdToArgs("oasdiff breaking --base HEAD --format json --template x.tmpl openapi.yaml"), io.Discard, &stderr)
+
+	require.NotZero(t, exitCode)
+	require.Contains(t, stderr.String(), "template flag is not supported")
+	require.NotContains(t, stderr.String(), "=== openapi.yaml ===", "must fail before any per-file output")
+}

--- a/internal/breaking_base_test.go
+++ b/internal/breaking_base_test.go
@@ -151,17 +151,26 @@ func Test_BreakingBase_MissingFileIsNotNew(t *testing.T) {
 	require.NotContains(t, stderr.String(), "skipped")
 }
 
-// The positionals are working-tree files that also have a version in the base
-// ref, so stdin has nothing to compare against and is rejected up front rather
-// than treated as a filename.
-func Test_BreakingBase_RejectsStdin(t *testing.T) {
-	breakingBaseRepo(t, map[string]string{"openapi.yaml": baseSpec})
+// Each positional is joined to the base ref as "<ref>:<path>", so only a file
+// path makes sense. The others are rejected by what they are, not one at a
+// time: stdin and a URL have no version in the ref, and a git revision would
+// be joined into "HEAD:HEAD:openapi.yaml".
+func Test_BreakingBase_RejectsNonFileArguments(t *testing.T) {
+	for name, arg := range map[string]string{
+		"stdin":        "-",
+		"url":          "https://example.com/openapi.yaml",
+		"git revision": "HEAD:openapi.yaml",
+	} {
+		t.Run(name, func(t *testing.T) {
+			breakingBaseRepo(t, map[string]string{"openapi.yaml": baseSpec})
 
-	var stderr bytes.Buffer
-	exitCode := internal.Run(cmdToArgs("oasdiff breaking --base HEAD -"), io.Discard, &stderr)
+			var stderr bytes.Buffer
+			exitCode := internal.Run(cmdToArgs("oasdiff breaking --base HEAD "+arg), io.Discard, &stderr)
 
-	require.Equal(t, 100, exitCode)
-	require.Contains(t, stderr.String(), "can't read from stdin with --base")
+			require.Equal(t, 100, exitCode)
+			require.Contains(t, stderr.String(), "every argument must be a file path")
+		})
+	}
 }
 
 // Composed mode merges several specs into one comparison, which is the opposite

--- a/internal/breaking_base_unix_test.go
+++ b/internal/breaking_base_unix_test.go
@@ -1,0 +1,122 @@
+//go:build unix
+
+package internal_test
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/oasdiff/oasdiff/internal"
+	"github.com/stretchr/testify/require"
+)
+
+const baseSpec = `openapi: "3.0.0"
+info:
+  title: Test
+  version: "1.0"
+paths:
+  /pets:
+    get:
+      responses:
+        "200":
+          description: ok
+`
+
+// breakingSpec removes the /pets endpoint, a breaking change (ERR).
+const breakingSpec = `openapi: "3.0.0"
+info:
+  title: Test
+  version: "1.0"
+paths: {}
+`
+
+// breakingBaseRepo creates a git repo committing the given files, then chdirs
+// into it. Callers overwrite files in the working tree to stage changes for the
+// breaking check to compare against HEAD.
+func breakingBaseRepo(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	gitRun := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(out))
+	}
+
+	gitRun("git", "init")
+	gitRun("git", "config", "user.email", "test@test.com")
+	gitRun("git", "config", "user.name", "Test")
+
+	for name, content := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0644))
+		gitRun("git", "add", name)
+	}
+	gitRun("git", "commit", "-m", "base")
+
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(oldDir) })
+
+	return dir
+}
+
+// Test_BreakingBase_Fails compares a working-tree file that dropped an endpoint
+// against its committed version and asserts --fail-on ERR blocks with exit 1.
+func Test_BreakingBase_Fails(t *testing.T) {
+	dir := breakingBaseRepo(t, map[string]string{"openapi.yaml": baseSpec})
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "openapi.yaml"), []byte(breakingSpec), 0644))
+
+	var stdout bytes.Buffer
+	exitCode := internal.Run(cmdToArgs("oasdiff breaking --base HEAD --fail-on ERR openapi.yaml"), &stdout, io.Discard)
+
+	require.Equal(t, 1, exitCode)
+	require.Contains(t, stdout.String(), "api-path-removed-without-deprecation")
+}
+
+// Test_BreakingBase_Passes asserts an unchanged file is not a breaking change,
+// so the command exits 0 even with --fail-on ERR.
+func Test_BreakingBase_Passes(t *testing.T) {
+	breakingBaseRepo(t, map[string]string{"openapi.yaml": baseSpec})
+
+	exitCode := internal.Run(cmdToArgs("oasdiff breaking --base HEAD --fail-on ERR openapi.yaml"), io.Discard, io.Discard)
+
+	require.Zero(t, exitCode)
+}
+
+// Test_BreakingBase_MultipleFiles checks every file and aggregates the result:
+// one breaking file among several still fails the whole run, and both files'
+// output is printed.
+func Test_BreakingBase_MultipleFiles(t *testing.T) {
+	dir := breakingBaseRepo(t, map[string]string{"openapi.yaml": baseSpec, "other.yaml": baseSpec})
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "openapi.yaml"), []byte(breakingSpec), 0644))
+
+	var stdout bytes.Buffer
+	exitCode := internal.Run(cmdToArgs("oasdiff breaking --base HEAD --fail-on ERR openapi.yaml other.yaml"), &stdout, io.Discard)
+
+	require.Equal(t, 1, exitCode)
+	// both files reported: the breaking one names the removed path, the
+	// unchanged one reports no breaking changes
+	require.Contains(t, stdout.String(), "api-path-removed-without-deprecation")
+	require.Equal(t, 2, strings.Count(stdout.String(), "changes"))
+}
+
+// Test_BreakingBase_NoFailOn prints breaking changes but keeps exit 0 when
+// --fail-on isn't set, matching the non-base breaking command.
+func Test_BreakingBase_NoFailOn(t *testing.T) {
+	dir := breakingBaseRepo(t, map[string]string{"openapi.yaml": baseSpec})
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "openapi.yaml"), []byte(breakingSpec), 0644))
+
+	var stdout bytes.Buffer
+	exitCode := internal.Run(cmdToArgs("oasdiff breaking --base HEAD openapi.yaml"), &stdout, io.Discard)
+
+	require.Zero(t, exitCode)
+	require.Contains(t, stdout.String(), "api-path-removed-without-deprecation")
+}

--- a/internal/breaking_changes.go
+++ b/internal/breaking_changes.go
@@ -1,28 +1,111 @@
 package internal
 
 import (
+	"errors"
 	"io"
 
 	"github.com/oasdiff/oasdiff/checker"
+	"github.com/oasdiff/oasdiff/load"
 	"github.com/spf13/cobra"
 )
+
+const breakingBaseHelp = `
+
+With --base, the positional arguments are the changed spec files (not a base/revision pair)
+and each one is compared against its own version in the given git ref. This is the shape a
+pre-commit hook needs, where the tool receives the list of changed files: see .pre-commit-hooks.yaml.`
 
 func getBreakingChangesCmd() *cobra.Command {
 
 	cmd := cobra.Command{
 		Use:   "breaking base revision [flags]",
 		Short: "Display breaking changes",
-		Long:  "Display breaking changes between base and revision specs." + specHelp,
-		Args:  getParseArgs(),
-		RunE:  getRun(runBreakingChanges),
+		Long:  "Display breaking changes between base and revision specs." + specHelp + breakingBaseHelp,
+		Args:  getBreakingArgs(),
+		RunE:  runBreaking,
 	}
 
 	addCommonDiffFlags(&cmd)
 	addCommonBreakingFlags(&cmd)
 	enumWithOptions(&cmd, newEnumValue(GetBreakingLevels(), ""), "fail-on", "o", "exit with return code 1 when output includes errors with this level or higher")
 	addOpenFlags(&cmd, "breaking changes")
+	cmd.Flags().String("base", "", "compare each changed spec file against this git ref (e.g. origin/main); positional arguments become the changed files, one comparison per file")
 
 	return &cmd
+}
+
+// getBreakingArgs validates the positional arguments for the breaking command.
+// Without --base it keeps the standard base+revision pair (getParseArgs). With
+// --base the positionals are the changed files, so at least one is required and
+// the base/revision-pair rules (exactly two, composed globs) don't apply.
+func getBreakingArgs() cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		base, _ := cmd.Flags().GetString("base")
+		if base == "" {
+			return getParseArgs()(cmd, args)
+		}
+
+		if len(args) < 1 {
+			return errors.New("with --base, specify one or more spec files to compare against the base version")
+		}
+		if err := checkReviewFlagsRequireOpen(cmd); err != nil {
+			return err
+		}
+		return checkColor(cmd)
+	}
+}
+
+func runBreaking(cmd *cobra.Command, args []string) error {
+	base, _ := cmd.Flags().GetString("base")
+	if base == "" {
+		return getRun(runBreakingChanges)(cmd, args)
+	}
+	return runBreakingBase(cmd, base, args)
+}
+
+// runBreakingBase runs the breaking-change check for every changed file against
+// its version in the base git ref, printing each result and failing the command
+// if any file has changes meeting the --fail-on threshold. This is the pre-commit
+// entry point: pre-commit passes the changed files as positional arguments and
+// only needs a non-zero exit to block the commit.
+func runBreakingBase(cmd *cobra.Command, base string, files []string) error {
+
+	flags := NewFlags()
+	if err := RunViper(cmd, flags.getViper()); err != nil {
+		setReturnValue(cmd, err.Code)
+		return err
+	}
+
+	// flags parsed successfully, so don't show usage on comparison errors
+	cmd.Root().SilenceUsage = true
+
+	failed := false
+	for _, file := range files {
+		// Same "<ref>:<path>" git-revision syntax the git-diff driver uses; the
+		// revision is the file in the working tree.
+		baseSource := load.NewSource(base + ":" + file)
+		baseSource.Fetch = flags.getFetch()
+		flags.setBase(baseSource)
+
+		revSource := load.NewSource(file)
+		revSource.Fetch = flags.getFetch()
+		flags.setRevision(revSource)
+
+		failOn, err := runBreakingChanges(flags, cmd.OutOrStdout())
+		if err != nil {
+			setReturnValue(cmd, err.Code)
+			return err
+		}
+		if failOn {
+			failed = true
+		}
+	}
+
+	if failed {
+		setReturnValue(cmd, 1)
+	}
+
+	return nil
 }
 
 func runBreakingChanges(flags *Flags, stdout io.Writer) (bool, *ReturnError) {

--- a/internal/breaking_changes.go
+++ b/internal/breaking_changes.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"slices"
 
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/load"
@@ -49,10 +51,17 @@ func getBreakingArgs() cobra.PositionalArgs {
 		if len(args) < 1 {
 			return errors.New("with --base, specify one or more spec files to compare against the base version")
 		}
-		if err := checkReviewFlagsRequireOpen(cmd); err != nil {
-			return err
+		// The positionals are working-tree files to compare against the base
+		// ref, so neither stdin nor a glob has a version in that ref to compare
+		// against. Reject them here rather than let them fail further in.
+		if slices.Contains(args, "-") {
+			return errors.New("can't read from stdin with --base: the positional arguments are files that also exist in the base ref")
 		}
-		return checkColor(cmd)
+		if composed, err := cmd.Flags().GetBool("composed"); err == nil && composed {
+			return errors.New("can't use --composed with --base: each file is compared against its own version in the base ref")
+		}
+
+		return checkCommonFlags(cmd)
 	}
 }
 
@@ -84,7 +93,7 @@ func runBreakingBase(cmd *cobra.Command, base string, files []string) error {
 	for _, file := range files {
 		// Label each file so a multi-file run says which result belongs to which
 		// spec (otherwise a bare "No changes detected" is ambiguous).
-		fmt.Fprintf(cmd.OutOrStdout(), "=== %s ===\n", file)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "=== %s ===\n", file)
 
 		// Same "<ref>:<path>" git-revision syntax the git-diff driver uses; the
 		// revision is the file in the working tree.
@@ -98,11 +107,16 @@ func runBreakingBase(cmd *cobra.Command, base string, files []string) error {
 
 		failOn, err := runBreakingChanges(flags, cmd.OutOrStdout())
 		if err != nil {
-			// A file that isn't in the base ref is newly added: it has no prior
-			// version, and a new API cannot contain breaking changes. Skip it and
-			// keep checking the remaining files instead of aborting the whole run.
-			if load.IsPathMissingInRef(base, file) {
-				fmt.Fprintln(cmd.OutOrStdout(), "new file, not in base ref, skipped")
+			// A file that isn't in the base ref but is in the working tree is
+			// newly added: it has no prior version, and a new API cannot contain
+			// breaking changes. Skip it and keep checking the remaining files
+			// instead of aborting the whole run.
+			//
+			// The working-tree check is what separates a new file from a
+			// mistyped one. Without it a path in neither place looks new, and a
+			// typo would pass the check it was supposed to fail.
+			if fileExists(file) && load.IsPathMissingInRef(base, file) {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "new file, not in base ref, skipped")
 				continue
 			}
 			setReturnValue(cmd, err.Code)
@@ -122,4 +136,10 @@ func runBreakingBase(cmd *cobra.Command, base string, files []string) error {
 
 func runBreakingChanges(flags *Flags, stdout io.Writer) (bool, *ReturnError) {
 	return getChangelog(flags, stdout, checker.WARN, true)
+}
+
+// fileExists reports whether path names an existing file in the working tree.
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
 }

--- a/internal/breaking_changes.go
+++ b/internal/breaking_changes.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/oasdiff/oasdiff/checker"
@@ -81,6 +82,10 @@ func runBreakingBase(cmd *cobra.Command, base string, files []string) error {
 
 	failed := false
 	for _, file := range files {
+		// Label each file so a multi-file run says which result belongs to which
+		// spec (otherwise a bare "No changes detected" is ambiguous).
+		fmt.Fprintf(cmd.OutOrStdout(), "=== %s ===\n", file)
+
 		// Same "<ref>:<path>" git-revision syntax the git-diff driver uses; the
 		// revision is the file in the working tree.
 		baseSource := load.NewSource(base + ":" + file)
@@ -93,6 +98,13 @@ func runBreakingBase(cmd *cobra.Command, base string, files []string) error {
 
 		failOn, err := runBreakingChanges(flags, cmd.OutOrStdout())
 		if err != nil {
+			// A file that isn't in the base ref is newly added: it has no prior
+			// version, and a new API cannot contain breaking changes. Skip it and
+			// keep checking the remaining files instead of aborting the whole run.
+			if load.IsPathMissingInRef(base, file) {
+				fmt.Fprintln(cmd.OutOrStdout(), "new file, not in base ref, skipped")
+				continue
+			}
 			setReturnValue(cmd, err.Code)
 			return err
 		}

--- a/internal/breaking_changes.go
+++ b/internal/breaking_changes.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"slices"
 
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/load"
@@ -51,11 +50,15 @@ func getBreakingArgs() cobra.PositionalArgs {
 		if len(args) < 1 {
 			return errors.New("with --base, specify one or more spec files to compare against the base version")
 		}
-		// The positionals are working-tree files to compare against the base
-		// ref, so neither stdin nor a glob has a version in that ref to compare
-		// against. Reject them here rather than let them fail further in.
-		if slices.Contains(args, "-") {
-			return errors.New("can't read from stdin with --base: the positional arguments are files that also exist in the base ref")
+		// Each positional is joined to the base ref as "<ref>:<path>", so it has
+		// to be a plain file path. Stdin, a URL and a git revision have no
+		// version in the ref to compare against, and joining them produces
+		// nonsense like "HEAD:HEAD:openapi.yaml". Reject them by what they are
+		// rather than one at a time, so a source type added later is covered.
+		for _, arg := range args {
+			if !load.NewSource(arg).IsFile() {
+				return fmt.Errorf("can't use %q with --base: every argument must be a file path, since each is compared against its own version in the base ref", arg)
+			}
 		}
 		if composed, err := cmd.Flags().GetBool("composed"); err == nil && composed {
 			return errors.New("can't use --composed with --base: each file is compared against its own version in the base ref")

--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -24,18 +24,24 @@ func getParseArgs() cobra.PositionalArgs {
 		if err := checkStdinWithComposed(cmd, args); err != nil {
 			return err
 		}
-		if err := checkReviewFlagsRequireOpen(cmd); err != nil {
-			return err
-		}
-		if err := checkColor(cmd); err != nil {
-			return err
-		}
-		if err := checkTemplate(cmd); err != nil {
-			return err
-		}
 
-		return nil
+		return checkCommonFlags(cmd)
 	}
+}
+
+// checkCommonFlags runs the validations that depend only on flags, not on the
+// shape of the positional arguments. Every argument validator calls it, so a
+// check added here reaches all of them rather than only the caller it was
+// written for.
+func checkCommonFlags(cmd *cobra.Command) error {
+	if err := checkReviewFlagsRequireOpen(cmd); err != nil {
+		return err
+	}
+	if err := checkColor(cmd); err != nil {
+		return err
+	}
+
+	return checkTemplate(cmd)
 }
 
 type runner func(flags *Flags, stdout io.Writer) (bool, *ReturnError)

--- a/internal/run_test.go
+++ b/internal/run_test.go
@@ -583,3 +583,11 @@ func Test_BothSidesStdin(t *testing.T) {
 	require.Equal(t, 2, strings.Count(stdout.String(), "1.2.3"), "both sides carry the document's version")
 	require.NotContains(t, stdout.String(), "n/a")
 }
+
+// breaking --base turns the positionals into the changed files to check, so at
+// least one is required; supplying none is an argument error, not an empty run.
+func Test_BreakingBaseRequiresFiles(t *testing.T) {
+	var stderr bytes.Buffer
+	require.Equal(t, 100, internal.Run(cmdToArgs("oasdiff breaking --base origin/main"), io.Discard, &stderr))
+	require.Contains(t, stderr.String(), "specify one or more spec files")
+}

--- a/load/git.go
+++ b/load/git.go
@@ -218,6 +218,22 @@ func gitFetch(ref string) error {
 	return nil
 }
 
+// IsPathMissingInRef reports whether filePath is absent from an otherwise
+// resolvable git ref: the ref's commit is present in the local clone but does
+// not contain the path. This is the "newly added file" case, where there is no
+// prior version to compare against. It returns false when the commit itself is
+// not in the local clone (a missing-commit problem, surfaced elsewhere with a
+// fetch hint) and when git cannot run, so it never masks those errors as a new
+// file.
+func IsPathMissingInRef(ref, filePath string) bool {
+	if !commitExistsLocally(ref) {
+		return false
+	}
+	// "git cat-file -e <ref>:<path>" exits non-zero when the path is not in the
+	// ref, so a failed run means the file was added after that ref.
+	return exec.Command("git", "cat-file", "-e", "--end-of-options", ref+":"+filePath).Run() != nil
+}
+
 // commitExistsLocally reports whether ref names an object already present in the
 // local repository, via "git cat-file -e". Returns false when the object is
 // absent or when git cannot run.


### PR DESCRIPTION
Closes #857.

This adds `--base` to `breaking` so it can run as a pre-commit hook. pre-commit hands the tool the list of changed files, but `breaking` wanted a base/revision pair, so there wasn't a clean way to wire it up. With `--base <ref>` the positional args become the changed files and each one is compared against `<ref>:<file>`, the same git-revision syntax the git-diff driver already uses. If any file has changes meeting `--fail-on`, the command exits non-zero, which is all pre-commit needs to block the commit.

I followed the v1 scope we landed on in the issue: `breaking` only, `--base` defaulted to `origin/main` in the hook's `args:` (overridable), iterate every file and aggregate. It also ships `.pre-commit-hooks.yaml` and a docs section under BREAKING-CHANGES.md.

Without `--base` the command is unchanged (still base + revision). Tests cover the new path: single file pass/fail, multi-file aggregation, no `--fail-on`, and the missing-files arg error.