### PR TITLE
Move to kin-openapi v0.149.0

### DIFF
--- a/flatten/allof/merge_allof.go
+++ b/flatten/allof/merge_allof.go
@@ -270,6 +270,9 @@ func mergeInternal(state *state, base *openapi3.SchemaRef) (*openapi3.SchemaRef,
 	result.Value.DynamicRef = base.Value.DynamicRef
 	result.Value.DynamicAnchor = base.Value.DynamicAnchor
 	result.Value.Comment = base.Value.Comment
+	// A boolean schema carries no other keyword, so there is nothing to merge
+	// into it and nothing of its own to merge elsewhere; it survives as written.
+	result.Value.Always = base.Value.Always
 
 	// Combined across subschemas further down, most restrictive winning, but
 	// seeded from the outer schema here: with no siblings to combine there

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	cloud.google.com/go v0.123.0
 	github.com/TwiN/go-color v1.4.1
-	github.com/getkin/kin-openapi v0.147.0
+	github.com/getkin/kin-openapi v0.149.0
 	github.com/invopop/jsonschema v0.14.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
-github.com/getkin/kin-openapi v0.147.0 h1:s+Xsm9gUMPJbgCnABZ2to3zSQQ5A9dyj/zo62VVsldY=
-github.com/getkin/kin-openapi v0.147.0/go.mod h1:3BH9M9XDe/y9M5DSvEocVYAYq1w0qrhJHjC/vZi0AaY=
+github.com/getkin/kin-openapi v0.149.0 h1:ZbhmVJ4yq5RZDUsyP8lcBcGMsjsaTqXEFt6isdtMDfA=
+github.com/getkin/kin-openapi v0.149.0/go.mod h1:1+BHDzstro+P5CKtPy1X4PfofnFgmRe6uvMy9+r9fKY=
 github.com/go-openapi/jsonpointer v0.22.5 h1:8on/0Yp4uTb9f4XvTrM2+1CPrV05QPZXu+rvu2o9jcA=
 github.com/go-openapi/jsonpointer v0.22.5/go.mod h1:gyUR3sCvGSWchA2sUBJGluYMbe1zazrYWIkWPjjMUY0=
 github.com/go-openapi/swag/jsonname v0.25.5 h1:8p150i44rv/Drip4vWI3kGi9+4W9TdI3US3uUYSFhSo=

--- a/validate/rule_descriptions.go
+++ b/validate/rule_descriptions.go
@@ -34,15 +34,17 @@ var ruleDescriptions = map[string]string{
 	"spec-validation-error":        "a spec violation with no more specific rule",
 
 	// Paths and operations
-	"path-must-start-with-slash":    "path key does not start with a slash",
-	"conflicting-paths":             "two paths differ only by parameter name and cannot be told apart",
-	"path-parameters-mismatch":      "path template and declared path parameters disagree",
-	"path-parameter-required":       "a path parameter is not marked required",
-	"duplicate-operation-id":        "the same operationId is used by more than one operation",
-	"operation-responses-required":  "operation has no responses object",
-	"responses-required":            "responses object is missing",
-	"response-description-required": "response has no description",
-	"request-body-content-required": "request body has no content",
+	"path-must-start-with-slash":         "path key does not start with a slash",
+	"conflicting-paths":                  "two paths differ only by parameter name and cannot be told apart",
+	"path-parameters-mismatch":           "path template and declared path parameters disagree",
+	"path-parameter-required":            "a path parameter is not marked required",
+	"duplicate-operation-id":             "the same operationId is used by more than one operation",
+	"operation-responses-required":       "operation has no responses object",
+	"boolean-schema-for-3-1-plus":        "a schema is written as `true` or `false`, which is only valid in OpenAPI 3.1 or later",
+	"boolean-schema-with-other-keywords": "a boolean schema carries other keywords, which would be lost when it is written back",
+	"responses-required":                 "responses object is missing",
+	"response-description-required":      "response has no description",
+	"request-body-content-required":      "request body has no content",
 	// additionalOperations is the OpenAPI 3.2 map of custom http methods. The
 	// version gate on the field itself is described by versionGateDescription.
 	"additional-operations-duplicate-method": "an additionalOperations key names a method that already has its own path item field",

--- a/validate/rule_ids.go
+++ b/validate/rule_ids.go
@@ -18,6 +18,8 @@ var ruleIDs = []string{
 	"anchor-field-for-3-1-plus",
 	"authorization-url-forbidden",
 	"bearer-format-forbidden",
+	"boolean-schema-for-3-1-plus",
+	"boolean-schema-with-other-keywords",
 	"comment-field-for-3-1-plus",
 	"conflicting-paths",
 	"const-field-for-3-1-plus",


### PR DESCRIPTION
Picks up two changes made upstream for oasdiff's benefit:

- **Boolean schemas** (getkin/kin-openapi#1258). JSON Schema 2020-12 allows `true` or `false` wherever a schema is expected, and `items: false` is how a tuple is closed to a fixed length. Until now a spec using one failed to load at all: `cannot unmarshal bool into field Schema.items`.
- **Positional prefixItems** (getkin/kin-openapi#1259). `items` now applies only to the positions past `prefixItems`, so a tuple with a typed prefix and a differently-typed tail is satisfiable, and the prefix is checked position by position.

v0.148.0 also brings schema format validators carried into 3.1, UUID v6-v8 formats, and exact-rational `multipleOf` comparison.

## What the bump needed

Two drift gates caught it, which is what they are for.

`TestMerge_SingleSchema_PreservesEveryField` reported that the merge dropped the new `Always` field, so a boolean schema would have lost its value when flattened on a spec with no `allOf`. It is copied alongside the other scalar fields; a boolean schema carries no other keyword, so there is nothing to merge into it.

`TestRuleIDs_MatchKinCatalog` reported two codes missing from the validate registry, `boolean-schema-for-3-1-plus` and `boolean-schema-with-other-keywords`. Both carry written descriptions rather than derived ones, since `versionGateDescription` keys on `-field-for-` and these name a schema form rather than a field.

## Verified

```
$ oasdiff checks validate | grep boolean-schema
boolean-schema-for-3-1-plus          a schema is written as `true` or `false`, which is only valid in OpenAPI 3.1 or later   error
boolean-schema-with-other-keywords   a boolean schema carries other keywords, which would be lost when it is written back    error
```

A spec using `items: false` loads and diffs rather than failing to unmarshal. Full suite, vet and gofmt pass.

## Follow-ups this unblocks

#1181 listed two lints as blocked on boolean schemas being readable, `min-items-exceeds-prefix-items` and the redundant-`maxItems` case. They are implementable after this.