### PR TITLE
Compare prefixItems by index

### DIFF
--- a/checker/check_request_property_prefix_items_updated_test.go
+++ b/checker/check_request_property_prefix_items_updated_test.go
@@ -79,3 +79,23 @@ func TestRequestPropertyPrefixItemsRemoved(t *testing.T) {
 	require.NotEmpty(t, errs)
 	require.True(t, containsId(errs, checker.RequestPropertyPrefixItemsRemovedId), "expected request-property-prefix-items-removed")
 }
+
+// reordering prefixItems entries changes which schema validates each position,
+// so both positions are reported as type changes; the previous content-based
+// pairing matched each entry with its identical twin and reported nothing
+func TestRequestBodyPrefixItemsReordered(t *testing.T) {
+	s1, err := open("../data/checker/prefix_items_reordered_base.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/checker/prefix_items_reordered_revision.yaml")
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
+
+	require.Len(t, errs, 2)
+	for _, e := range errs {
+		require.Equal(t, checker.RequestPropertyTypeChangedId, e.GetId())
+		require.Equal(t, checker.ERR, e.GetLevel())
+	}
+}

--- a/data/checker/prefix_items_reordered_base.yaml
+++ b/data/checker/prefix_items_reordered_base.yaml
@@ -1,0 +1,19 @@
+openapi: 3.1.0
+info:
+  title: Test
+  version: "1.0"
+paths:
+  /items:
+    post:
+      operationId: createItem
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              prefixItems:
+                - type: string
+                - type: integer
+      responses:
+        "200":
+          description: OK

--- a/data/checker/prefix_items_reordered_revision.yaml
+++ b/data/checker/prefix_items_reordered_revision.yaml
@@ -1,0 +1,19 @@
+openapi: 3.1.0
+info:
+  title: Test
+  version: "1.0"
+paths:
+  /items:
+    post:
+      operationId: createItem
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              prefixItems:
+                - type: integer
+                - type: string
+      responses:
+        "200":
+          description: OK

--- a/diff/prefix_items_diff.go
+++ b/diff/prefix_items_diff.go
@@ -1,0 +1,40 @@
+package diff
+
+import "github.com/getkin/kin-openapi/openapi3"
+
+// getPrefixItemsDiff compares prefixItems by index: the schema at index i of
+// prefixItems validates the array element at index i, so entry i on each side
+// is a pair and is diffed as one. An entry past the end of the shorter list is
+// an addition or a deletion at its index.
+//
+// This is why prefixItems does not go through getSubschemasDiff: that
+// matching is built for allOf, anyOf and oneOf, where order carries no
+// meaning, so it pairs subschemas by $ref name, content and title. Under it,
+// swapping two prefixItems entries pairs each with its identical twin on the
+// other side and reports no change, when every position it touches now
+// validates against a different schema (#1180).
+func getPrefixItemsDiff(config *Config, state *state, schemaRefs1, schemaRefs2 openapi3.SchemaRefs) (*SubschemasDiff, error) {
+	if len(schemaRefs1) == 0 && len(schemaRefs2) == 0 {
+		return nil, nil
+	}
+
+	result := NewSubschemasDiff()
+
+	for i := range min(len(schemaRefs1), len(schemaRefs2)) {
+		if err := result.appendModified(config, state, schemaRefs1[i], schemaRefs2[i], i, i); err != nil {
+			return nil, err
+		}
+	}
+	for i := len(schemaRefs2); i < len(schemaRefs1); i++ {
+		result.appendDeleted(i, schemaRefs1[i], schemaValue(schemaRefs1[i]).Title)
+	}
+	for i := len(schemaRefs1); i < len(schemaRefs2); i++ {
+		result.appendAdded(i, schemaRefs2[i], schemaValue(schemaRefs2[i]).Title)
+	}
+
+	if result.Empty() {
+		return nil, nil
+	}
+
+	return result, nil
+}

--- a/diff/prefix_items_diff_test.go
+++ b/diff/prefix_items_diff_test.go
@@ -1,0 +1,59 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPrefixItemsDiff_Positional(t *testing.T) {
+	cfg := NewConfig()
+	str := func() *openapi3.SchemaRef {
+		return &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}}
+	}
+	integer := func() *openapi3.SchemaRef {
+		return &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"integer"}}}
+	}
+	boolean := func() *openapi3.SchemaRef {
+		return &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"boolean"}}}
+	}
+	prefix := func(refs ...*openapi3.SchemaRef) openapi3.SchemaRefs { return refs }
+
+	// reordering: each position now validates against a different schema, so
+	// both positions are modified; the content matcher reported no change
+	d, err := getPrefixItemsDiff(cfg, newState(), prefix(str(), integer()), prefix(integer(), str()))
+	require.NoError(t, err)
+	require.Len(t, d.Modified, 2)
+	require.Empty(t, d.Added)
+	require.Empty(t, d.Deleted)
+	require.Equal(t, 0, d.Modified[0].Base.Index)
+	require.Equal(t, 0, d.Modified[0].Revision.Index)
+
+	// inserting at the front shifts every later position: both existing
+	// positions change type and a third appears
+	d, err = getPrefixItemsDiff(cfg, newState(), prefix(str(), integer()), prefix(boolean(), str(), integer()))
+	require.NoError(t, err)
+	require.Len(t, d.Modified, 2)
+	require.Len(t, d.Added, 1)
+	require.Equal(t, 2, d.Added[0].Index)
+
+	// appending leaves the covered positions untouched
+	d, err = getPrefixItemsDiff(cfg, newState(), prefix(str(), integer()), prefix(str(), integer(), boolean()))
+	require.NoError(t, err)
+	require.Empty(t, d.Modified)
+	require.Len(t, d.Added, 1)
+	require.Equal(t, 2, d.Added[0].Index)
+
+	// truncating deletes at the index
+	d, err = getPrefixItemsDiff(cfg, newState(), prefix(str(), integer()), prefix(str()))
+	require.NoError(t, err)
+	require.Empty(t, d.Modified)
+	require.Len(t, d.Deleted, 1)
+	require.Equal(t, 1, d.Deleted[0].Index)
+
+	// identical lists report nothing
+	d, err = getPrefixItemsDiff(cfg, newState(), prefix(str(), integer()), prefix(str(), integer()))
+	require.NoError(t, err)
+	require.Nil(t, d)
+}

--- a/diff/schema_diff.go
+++ b/diff/schema_diff.go
@@ -246,7 +246,7 @@ func getSchemaDiffInternal(config *Config, state *state, schema1, schema2 *opena
 	// OpenAPI 3.1 / JSON Schema 2020-12 fields
 	result.ConstDiff = getValueDiff(value1.Const, value2.Const)
 	result.ExamplesDiff = getValueDiff(value1.Examples, value2.Examples)
-	result.PrefixItemsDiff, err = getSubschemasDiff(config, state, value1.PrefixItems, value2.PrefixItems)
+	result.PrefixItemsDiff, err = getPrefixItemsDiff(config, state, value1.PrefixItems, value2.PrefixItems)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #1180.

`prefixItems` is positional: the schema at index *i* validates the array element at index *i*. The diff compared it with `getSubschemasDiff`, which is built for `allOf`, `anyOf` and `oneOf`, where order carries no meaning, so it paired entries by `$ref` name, content and title. Under that matching, swapping two entries paired each with its identical twin on the other side and reported no change, when every position it touches now validates against a different schema. Inserting an entry at the front reported one addition while every later position changed type.

`getPrefixItemsDiff` pairs entry *i* on each side and diffs the pair; an entry past the end of the shorter list is an addition or a deletion at its index. The output type is unchanged, so the diff JSON keeps its shape, and the subschema walker already descends into modified `prefixItems` entries, so the property-level checks inherit per-position reporting with no checker change.

The three cases from the issue, after:

```console
$ # reorder [string, integer] -> [integer, string]   (was: No changes detected)
error [request-property-type-changed] the `/prefixItems[subschema #1]/` request property `type` changed from `string` to `integer`
error [request-property-type-changed] the `/prefixItems[subschema #2]/` request property `type` changed from `integer` to `string`

$ # insert boolean at the front   (was: one addition, "subschema #1")
error [request-property-type-changed] the `/prefixItems[subschema #1]/` request property `type` changed from `string` to `boolean`
error [request-property-type-changed] the `/prefixItems[subschema #2]/` request property `type` changed from `integer` to `string`
info  [request-body-prefix-items-added] added `subschema #3` to the request body 'prefixItems' list

$ # append   (the case the old message described)
info  [request-body-prefix-items-added] added `subschema #3` to the request body 'prefixItems' list
```

`getSubschemasDiff` is untouched: it is correct for the unordered constructs it was built for.

The full suite passes with no other change, which says nothing had pinned the unordered behaviour; `TestGetPrefixItemsDiff_Positional` and `TestRequestBodyPrefixItemsReordered` pin the positional one.