### PR TITLE
Report an items schema arriving as or departing from false

### DIFF
--- a/checker/check_schema_became_false.go
+++ b/checker/check_schema_became_false.go
@@ -1,6 +1,8 @@
 package checker
 
 import (
+	"github.com/getkin/kin-openapi/openapi3"
+
 	"github.com/oasdiff/oasdiff/diff"
 )
 
@@ -47,6 +49,29 @@ func falseSchemaChangeId(d *diff.SchemaDiff, falseId, notFalseId string) string 
 	return ""
 }
 
+// falseItemsChangeId is falseSchemaChangeId for an items schema that appears
+// as or disappears from `false` (closing or reopening a tuple). A one-sided
+// diff carries only the added or deleted flag and the property walk skips
+// one-sided nodes, so the transition is detected at the parent, whose
+// document sides hold the schema. Other one-sided sub-schema slots stay
+// unclassified (#1199).
+func falseItemsChangeId(d *diff.SchemaDiff, falseId, notFalseId string) string {
+	if d == nil || d.ItemsDiff == nil {
+		return ""
+	}
+	if d.ItemsDiff.SchemaAdded && d.Revision != nil && isFalseSchemaRef(d.Revision.Items) {
+		return falseId
+	}
+	if d.ItemsDiff.SchemaDeleted && d.Base != nil && isFalseSchemaRef(d.Base.Items) {
+		return notFalseId
+	}
+	return ""
+}
+
+func isFalseSchemaRef(ref *openapi3.SchemaRef) bool {
+	return ref != nil && ref.Value != nil && ref.Value.Always != nil && !*ref.Value.Always
+}
+
 func falseSchemaComment(id string) string {
 	if id == ResponsePropertySchemaBecameFalseId {
 		return ResponsePropertySchemaBecameFalseCommentId
@@ -64,12 +89,26 @@ func RequestPropertySchemaBecameFalseCheck(diffReport *diff.Diff, operationsSour
 				WithSources(baseSource, revisionSource))
 		}
 
+		if id := falseItemsChangeId(info.schemaDiff, RequestPropertySchemaBecameFalseId, RequestPropertySchemaBecameNotFalseId); id != "" {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "items")
+			result = append(result, info.newChange(id, []any{"items"}, "").
+				WithSources(baseSource, revisionSource))
+		}
+
 		info.walkProperties(func(p propertyInfo) {
 			if id := falseSchemaChangeId(p.propertyDiff, RequestPropertySchemaBecameFalseId, RequestPropertySchemaBecameNotFalseId); id != "" {
 				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "type")
 				result = append(result, p.newChange(
 					id,
 					[]any{propertyFullName(p.propertyPath, p.propertyName)},
+					"",
+				).WithSources(propBaseSource, propRevisionSource))
+			}
+			if id := falseItemsChangeId(p.propertyDiff, RequestPropertySchemaBecameFalseId, RequestPropertySchemaBecameNotFalseId); id != "" {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "items")
+				result = append(result, p.newChange(
+					id,
+					[]any{propertyFullName(p.propertyPath, p.propertyName, "items")},
 					"",
 				).WithSources(propBaseSource, propRevisionSource))
 			}
@@ -89,12 +128,26 @@ func ResponsePropertySchemaBecameFalseCheck(diffReport *diff.Diff, operationsSou
 				WithSources(baseSource, revisionSource))
 		}
 
+		if id := falseItemsChangeId(info.schemaDiff, ResponsePropertySchemaBecameFalseId, ResponsePropertySchemaBecameNotFalseId); id != "" {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "items")
+			result = append(result, info.newChange(id, []any{"items", info.responseStatus}, falseSchemaComment(id)).
+				WithSources(baseSource, revisionSource))
+		}
+
 		info.walkProperties(func(p propertyInfo) {
 			if id := falseSchemaChangeId(p.propertyDiff, ResponsePropertySchemaBecameFalseId, ResponsePropertySchemaBecameNotFalseId); id != "" {
 				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "type")
 				result = append(result, p.newChange(
 					id,
 					[]any{propertyFullName(p.propertyPath, p.propertyName), info.responseStatus},
+					falseSchemaComment(id),
+				).WithSources(propBaseSource, propRevisionSource))
+			}
+			if id := falseItemsChangeId(p.propertyDiff, ResponsePropertySchemaBecameFalseId, ResponsePropertySchemaBecameNotFalseId); id != "" {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "items")
+				result = append(result, p.newChange(
+					id,
+					[]any{propertyFullName(p.propertyPath, p.propertyName, "items"), info.responseStatus},
 					falseSchemaComment(id),
 				).WithSources(propBaseSource, propRevisionSource))
 			}

--- a/checker/check_schema_became_false_test.go
+++ b/checker/check_schema_became_false_test.go
@@ -110,3 +110,49 @@ func TestSchemaBecameNotFalseClaims(t *testing.T) {
 	change := requireSingleChange(t, errs, checker.RequestBodySchemaBecameNotFalseId)
 	require.Equal(t, checker.INFO, change.GetLevel())
 }
+
+// an items schema arriving as `false` closes the tuple: arrays longer than
+// prefixItems were valid and no longer are. The diff records a one-sided
+// items arrival with no schema attached, so the transition is detected at the
+// parent schema, at the body level and inside properties alike
+func TestItemsBecameFalse(t *testing.T) {
+	s1, err := open("../data/checker/items_became_false_base.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/checker/items_became_false_revision.yaml")
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(allChecksConfig(), d, osm, checker.INFO)
+
+	require.Len(t, errs, 2)
+
+	req := requireChange(t, errs, checker.RequestPropertySchemaBecameFalseId)
+	require.Equal(t, checker.ERR, req.GetLevel())
+
+	resp := requireChange(t, errs, checker.ResponsePropertySchemaBecameFalseId)
+	require.Equal(t, checker.INFO, resp.GetLevel())
+	require.NotEmpty(t, resp.GetComment(checker.NewDefaultLocalizer()))
+}
+
+// the reverse reopens the tuple: informational on the request side as any
+// widening, breaking on the response side since the server may now return
+// arrays longer than the prefix
+func TestItemsBecameNotFalse(t *testing.T) {
+	s1, err := open("../data/checker/items_became_false_revision.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/checker/items_became_false_base.yaml")
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(allChecksConfig(), d, osm, checker.INFO)
+
+	require.Len(t, errs, 2)
+
+	req := requireChange(t, errs, checker.RequestPropertySchemaBecameNotFalseId)
+	require.Equal(t, checker.INFO, req.GetLevel())
+
+	resp := requireChange(t, errs, checker.ResponsePropertySchemaBecameNotFalseId)
+	require.Equal(t, checker.ERR, resp.GetLevel())
+}

--- a/data/checker/items_became_false_base.yaml
+++ b/data/checker/items_became_false_base.yaml
@@ -1,0 +1,28 @@
+openapi: 3.1.0
+info:
+  title: Test
+  version: "1.0"
+paths:
+  /items:
+    post:
+      operationId: createItem
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              prefixItems:
+                - type: string
+                - type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tags:
+                    type: array
+                    prefixItems:
+                      - type: string

--- a/data/checker/items_became_false_revision.yaml
+++ b/data/checker/items_became_false_revision.yaml
@@ -1,0 +1,30 @@
+openapi: 3.1.0
+info:
+  title: Test
+  version: "1.0"
+paths:
+  /items:
+    post:
+      operationId: createItem
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              prefixItems:
+                - type: string
+                - type: integer
+              items: false
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tags:
+                    type: array
+                    prefixItems:
+                      - type: string
+                    items: false


### PR DESCRIPTION
Fixes #1185.

Closing an open tuple — the idiom the boolean-schema support exists for — reported nothing:

```yaml
# base                          # revision
type: array                     type: array
prefixItems:                    prefixItems:
  - {type: string}                - {type: string}
  - {type: integer}               - {type: integer}
                                items: false
```

```console
$ oasdiff changelog base.yaml revision.yaml     # before
No changes to report, but the specs are different.
```

Three absences lined up: the diff records a one-sided `items` arrival carrying only the added flag (no schema), the property walk skips one-sided nodes by design, and nothing reports the `items` slot's existence. Since this is the first version that can load `items: false` at all, cutting a release without the fix would ship a silent breaking change for the syntax the release introduces.

`falseItemsChangeId` detects the transition at the **parent** schema, whose document sides hold the arriving or departing `items` schema, and reports through the existing property-level ids — no new ids, no walker changes:

```console
$ oasdiff changelog base.yaml revision.yaml     # after
error [request-property-schema-became-false] the schema of the request property `items` became `false`: no value passes validation
```

Levels derive from the law at both levels of nesting: closing a tuple is `error` on a request and `info` on a response (with the existing comment), reopening one is `info` on a request and `error` on a response. Covered at the body level and inside properties by the new fixtures.

Deliberately unchanged: `items` arriving as an ordinary schema stays unreported (waived, as before this change), and the other one-sided sub-schema slots stay unclassified — that's #1199's enumeration.