### PR TITLE
Decide multipleOf generalization on exact rationals

### DIFF
--- a/checker/check_request_property_multiple_of_updated.go
+++ b/checker/check_request_property_multiple_of_updated.go
@@ -1,7 +1,8 @@
 package checker
 
 import (
-	"math"
+	"math/big"
+	"strconv"
 
 	"github.com/oasdiff/oasdiff/diff"
 )
@@ -18,13 +19,20 @@ const (
 )
 
 // isIntegerMultiple reports whether a is an integer multiple of b, in which
-// case every multiple of a is also a multiple of b.
+// case every multiple of a is also a multiple of b. The comparison is exact:
+// each value is read back as the decimal it round-trips to, so 0.3 over 0.1
+// is the rational 3 rather than a float slightly below it, and a ratio that
+// is merely close to an integer is not one.
 func isIntegerMultiple(a, b float64) bool {
 	if b == 0 {
 		return false
 	}
-	ratio := a / b
-	return math.Abs(ratio-math.Round(ratio)) <= 1e-9*math.Max(math.Abs(ratio), 1)
+	ratioA, okA := new(big.Rat).SetString(strconv.FormatFloat(a, 'g', -1, 64))
+	ratioB, okB := new(big.Rat).SetString(strconv.FormatFloat(b, 'g', -1, 64))
+	if !okA || !okB {
+		return false
+	}
+	return new(big.Rat).Quo(ratioA, ratioB).IsInt()
 }
 
 func RequestPropertyMultipleOfUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {

--- a/checker/multiple_of_internal_test.go
+++ b/checker/multiple_of_internal_test.go
@@ -1,0 +1,30 @@
+package checker
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The comparison is exact rational arithmetic on the decimals the values
+// round-trip to, so decimal literals divide the way their author meant
+// (0.3 over 0.1 is 3) and a ratio that is merely close to an integer is not
+// treated as one: reporting a multipleOf change as a generalization claims
+// that every previously valid value remains valid, which a near-integer
+// ratio does not deliver.
+func TestIsIntegerMultiple(t *testing.T) {
+	require.True(t, isIntegerMultiple(6, 3))
+	require.True(t, isIntegerMultiple(0.3, 0.1))
+	require.True(t, isIntegerMultiple(5, 2.5))
+	require.True(t, isIntegerMultiple(0.000006, 0.000002))
+
+	require.False(t, isIntegerMultiple(7, 3))
+	require.False(t, isIntegerMultiple(0.1, 0.3))
+	require.False(t, isIntegerMultiple(1.000000001, 1),
+		"a ratio within float tolerance of an integer is not an integer: 1.000000001 itself would be rejected under multipleOf 1")
+
+	require.False(t, isIntegerMultiple(1, 0))
+	require.False(t, isIntegerMultiple(math.NaN(), 1))
+	require.False(t, isIntegerMultiple(math.Inf(1), 1))
+}


### PR DESCRIPTION
Fixes #1187.

`isIntegerMultiple` compared the ratio of the two bounds against a relative float tolerance (`1e-9`), so a ratio merely close to an integer counted as one:

```console
$ # multipleOf: 1.000000001  ->  multipleOf: 1        (before)
info [request-body-multiple-of-generalized] ...
```

A generalization verdict claims every previously valid value remains valid — and `1.000000001` itself is rejected under the new bound. A safe verdict resting on a tolerance is the direction the checker must never err in, and since the multipleOf rules are new in the upcoming release, fixing this now means the sound version is the only one ever published.

The tolerance existed for a real reason: float division cannot be trusted for decimal literals (`0.3 / 0.1` is `2.9999999999999996` in float64). The fix keeps that case without the hole: each value is read back as the shortest decimal it round-trips to (`strconv.FormatFloat(v, 'g', -1, 64)` recovers the author's literal exactly for every written decimal) and the division is `big.Rat` — the same move getkin/kin-openapi#1252 made in the validator for the same class of bug.

After:

```console
$ # multipleOf: 1.000000001  ->  multipleOf: 1
error [request-body-multiple-of-changed] ...

$ # multipleOf: 0.3  ->  multipleOf: 0.1              (unchanged)
info  [request-body-multiple-of-generalized] ...
```

`NaN`, `Inf` and a zero divisor all fail closed to the incomparable verdict. Unit tests cover the decimal cases, the near-integer regression, and the non-finite inputs.