### PR TITLE
Detect minItems set and unset through the zero value

### DIFF
--- a/checker/check_request_parameters_min_items_set.go
+++ b/checker/check_request_parameters_min_items_set.go
@@ -32,8 +32,7 @@ func RequestParameterMinItemsSetCheck(diffReport *diff.Diff, operationsSources *
 					if minItemsDiff == nil {
 						continue
 					}
-					if minItemsDiff.From != nil ||
-						minItemsDiff.To == nil {
+					if !uintBoundSet(minItemsDiff) {
 						continue
 					}
 

--- a/checker/check_request_parameters_min_items_set_test.go
+++ b/checker/check_request_parameters_min_items_set_test.go
@@ -1,0 +1,27 @@
+package checker_test
+
+import (
+	"testing"
+
+	"github.com/oasdiff/oasdiff/checker"
+	"github.com/oasdiff/oasdiff/diff"
+	"github.com/stretchr/testify/require"
+)
+
+// setting minItems on a parameter that had none fires the set check; the
+// updated check reports only changes between two existing bounds
+func TestRequestParameterMinItemsSet(t *testing.T) {
+	s1, err := open("../data/checker/min_items_set_base.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/checker/min_items_set_revision.yaml")
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.RequestParameterMinItemsSetCheck), d, osm)
+	change := requireSingleChange(t, errs, checker.RequestParameterMinItemsSetId)
+	require.Equal(t, checker.ERR, change.GetLevel())
+	require.NotEmpty(t, change.GetComment(checker.NewDefaultLocalizer()))
+
+	require.Empty(t, checker.CheckBackwardCompatibility(singleCheckConfig(checker.RequestParameterMinItemsUpdatedCheck), d, osm))
+}

--- a/checker/check_request_parameters_min_items_updated.go
+++ b/checker/check_request_parameters_min_items_updated.go
@@ -33,8 +33,8 @@ func RequestParameterMinItemsUpdatedCheck(diffReport *diff.Diff, operationsSourc
 					if minItemsDiff == nil {
 						continue
 					}
-					if minItemsDiff.From == nil ||
-						minItemsDiff.To == nil {
+					if uintBoundSet(minItemsDiff) {
+						// reported by request-parameter-min-items-set
 						continue
 					}
 

--- a/checker/check_request_property_min_items_increased.go
+++ b/checker/check_request_property_min_items_increased.go
@@ -14,7 +14,7 @@ func RequestPropertyMinItemsIncreasedCheck(diffReport *diff.Diff, operationsSour
 
 	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
 		if minItemsDiff := info.schemaDiff.MinItemsDiff; minItemsDiff != nil &&
-			minItemsDiff.From != nil && minItemsDiff.To != nil && isIncreasedValue(minItemsDiff) {
+			!uintBoundSet(minItemsDiff) && isIncreasedValue(minItemsDiff) {
 			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "minItems")
 			result = append(result, info.newChange(
 				RequestBodyMinItemsIncreasedId,
@@ -25,7 +25,7 @@ func RequestPropertyMinItemsIncreasedCheck(diffReport *diff.Diff, operationsSour
 
 		info.walkProperties(func(p propertyInfo) {
 			minItemsDiff := p.propertyDiff.MinItemsDiff
-			if minItemsDiff == nil || minItemsDiff.From == nil || minItemsDiff.To == nil {
+			if minItemsDiff == nil || uintBoundSet(minItemsDiff) {
 				return
 			}
 			if p.propertyDiff.Revision.ReadOnly {

--- a/checker/check_request_property_min_items_set.go
+++ b/checker/check_request_property_min_items_set.go
@@ -13,8 +13,7 @@ func RequestPropertyMinItemsSetCheck(diffReport *diff.Diff, operationsSources *d
 	result := make(Changes, 0)
 
 	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
-		if minItemsDiff := info.schemaDiff.MinItemsDiff; minItemsDiff != nil &&
-			minItemsDiff.From == nil && minItemsDiff.To != nil {
+		if minItemsDiff := info.schemaDiff.MinItemsDiff; uintBoundSet(minItemsDiff) {
 			_, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "minItems")
 			result = append(result, info.newChange(
 				RequestBodyMinItemsSetId,
@@ -25,7 +24,7 @@ func RequestPropertyMinItemsSetCheck(diffReport *diff.Diff, operationsSources *d
 
 		info.walkProperties(func(p propertyInfo) {
 			minItemsDiff := p.propertyDiff.MinItemsDiff
-			if minItemsDiff == nil || minItemsDiff.From != nil || minItemsDiff.To == nil {
+			if !uintBoundSet(minItemsDiff) {
 				return
 			}
 			if p.propertyDiff.Revision.ReadOnly {

--- a/checker/check_request_property_min_items_set_test.go
+++ b/checker/check_request_property_min_items_set_test.go
@@ -1,0 +1,48 @@
+package checker_test
+
+import (
+	"testing"
+
+	"github.com/oasdiff/oasdiff/checker"
+	"github.com/oasdiff/oasdiff/diff"
+	"github.com/stretchr/testify/require"
+)
+
+// minItems is a value keyword whose zero means no constraint, so the diff
+// reports its absence as 0. Setting it where it was absent fires the set
+// checks, not the increased ones
+func TestRequestMinItemsSet(t *testing.T) {
+	s1, err := open("../data/checker/min_items_set_base.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/checker/min_items_set_revision.yaml")
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.RequestPropertyMinItemsSetCheck), d, osm)
+
+	require.Len(t, errs, 2)
+	body := requireChange(t, errs, checker.RequestBodyMinItemsSetId)
+	require.Equal(t, checker.ERR, body.GetLevel())
+	require.NotEmpty(t, body.GetComment(checker.NewDefaultLocalizer()))
+	prop := requireChange(t, errs, checker.RequestPropertyMinItemsSetId)
+	require.Equal(t, checker.ERR, prop.GetLevel())
+}
+
+// tightening an existing bound stays with the increased checks: the set checks
+// only cover the transition from no constraint
+func TestRequestMinItemsIncreasedNotSet(t *testing.T) {
+	s1, err := open("../data/checker/min_items_set_revision.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/checker/min_items_set_revision.yaml")
+	require.NoError(t, err)
+
+	s2.Spec.Paths.Value("/batch").Post.RequestBody.Value.Content["application/json"].Schema.Value.MinItems = 5
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+
+	require.Empty(t, checker.CheckBackwardCompatibility(singleCheckConfig(checker.RequestPropertyMinItemsSetCheck), d, osm))
+	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.RequestPropertyMinItemsIncreasedCheck), d, osm)
+	requireSingleChange(t, errs, checker.RequestBodyMinItemsIncreasedId)
+}

--- a/checker/check_response_property_min_items_decreased.go
+++ b/checker/check_response_property_min_items_decreased.go
@@ -14,7 +14,7 @@ func ResponsePropertyMinItemsDecreasedCheck(diffReport *diff.Diff, operationsSou
 
 	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
 		if minItemsDiff := info.schemaDiff.MinItemsDiff; minItemsDiff != nil &&
-			minItemsDiff.From != nil && minItemsDiff.To != nil && isDecreasedValue(minItemsDiff) {
+			!uintBoundUnset(minItemsDiff) && isDecreasedValue(minItemsDiff) {
 			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "minItems")
 			result = append(result, info.newChange(
 				ResponseBodyMinItemsDecreasedId,
@@ -25,7 +25,7 @@ func ResponsePropertyMinItemsDecreasedCheck(diffReport *diff.Diff, operationsSou
 
 		info.walkProperties(func(p propertyInfo) {
 			minItemsDiff := p.propertyDiff.MinItemsDiff
-			if minItemsDiff == nil || minItemsDiff.To == nil || minItemsDiff.From == nil {
+			if minItemsDiff == nil || uintBoundUnset(minItemsDiff) {
 				return
 			}
 			if !isDecreasedValue(minItemsDiff) {

--- a/checker/check_response_property_min_items_unset.go
+++ b/checker/check_response_property_min_items_unset.go
@@ -13,8 +13,7 @@ func ResponsePropertyMinItemsUnsetCheck(diffReport *diff.Diff, operationsSources
 	result := make(Changes, 0)
 
 	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
-		if minItemsDiff := info.schemaDiff.MinItemsDiff; minItemsDiff != nil &&
-			minItemsDiff.From != nil && minItemsDiff.To == nil {
+		if minItemsDiff := info.schemaDiff.MinItemsDiff; uintBoundUnset(minItemsDiff) {
 			baseSource, _ := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "minItems")
 			result = append(result, info.newChange(
 				ResponseBodyMinItemsUnsetId,
@@ -25,7 +24,7 @@ func ResponsePropertyMinItemsUnsetCheck(diffReport *diff.Diff, operationsSources
 
 		info.walkProperties(func(p propertyInfo) {
 			minItemsDiff := p.propertyDiff.MinItemsDiff
-			if minItemsDiff == nil || minItemsDiff.To != nil || minItemsDiff.From == nil {
+			if !uintBoundUnset(minItemsDiff) {
 				return
 			}
 			if p.propertyDiff.Revision.WriteOnly {

--- a/checker/check_response_property_min_items_unset_test.go
+++ b/checker/check_response_property_min_items_unset_test.go
@@ -1,0 +1,29 @@
+package checker_test
+
+import (
+	"testing"
+
+	"github.com/oasdiff/oasdiff/checker"
+	"github.com/oasdiff/oasdiff/diff"
+	"github.com/stretchr/testify/require"
+)
+
+// removing minItems from a response drops a guarantee about what the server
+// returns: the unset checks fire, and the decreased checks stay silent since
+// there is no remaining bound to compare
+func TestResponseMinItemsUnset(t *testing.T) {
+	s1, err := open("../data/checker/min_items_set_base.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/checker/min_items_set_revision.yaml")
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.ResponsePropertyMinItemsUnsetCheck), d, osm)
+
+	require.Len(t, errs, 2)
+	require.Equal(t, checker.ERR, requireChange(t, errs, checker.ResponseBodyMinItemsUnsetId).GetLevel())
+	require.Equal(t, checker.ERR, requireChange(t, errs, checker.ResponsePropertyMinItemsUnsetId).GetLevel())
+
+	require.Empty(t, checker.CheckBackwardCompatibility(singleCheckConfig(checker.ResponsePropertyMinItemsDecreasedCheck), d, osm))
+}

--- a/checker/checks_utils.go
+++ b/checker/checks_utils.go
@@ -70,6 +70,17 @@ func IsIncreased(from any, to any) bool {
 	return false
 }
 
+// minItems is a value keyword whose zero is the absent constraint: minItems: 0
+// requires nothing, so the diff reports absence as 0 rather than nil, and
+// setting or unsetting the bound is a transition to or from zero.
+func uintBoundSet(d *diff.ValueDiff) bool {
+	return d != nil && d.From == uint64(0) && d.To != uint64(0)
+}
+
+func uintBoundUnset(d *diff.ValueDiff) bool {
+	return d != nil && d.From != uint64(0) && d.To == uint64(0)
+}
+
 func isIncreasedValue(diff *diff.ValueDiff) bool {
 	return IsIncreased(diff.From, diff.To)
 }

--- a/data/checker/min_items_set_base.yaml
+++ b/data/checker/min_items_set_base.yaml
@@ -1,0 +1,53 @@
+openapi: 3.1.0
+info:
+  title: Test
+  version: "1.0"
+paths:
+  /items:
+    post:
+      operationId: createItem
+      parameters:
+        - name: ids
+          in: query
+          schema:
+            type: array
+            items: {type: string}
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                tags:
+                  type: array
+                  items: {type: string}
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tags:
+                    type: array
+                    items: {type: string}
+                    minItems: 3
+  /batch:
+    post:
+      operationId: createBatch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items: {type: string}
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {type: string}
+                minItems: 2

--- a/data/checker/min_items_set_revision.yaml
+++ b/data/checker/min_items_set_revision.yaml
@@ -1,0 +1,54 @@
+openapi: 3.1.0
+info:
+  title: Test
+  version: "1.0"
+paths:
+  /items:
+    post:
+      operationId: createItem
+      parameters:
+        - name: ids
+          in: query
+          schema:
+            type: array
+            items: {type: string}
+            minItems: 3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                tags:
+                  type: array
+                  items: {type: string}
+                  minItems: 3
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tags:
+                    type: array
+                    items: {type: string}
+  /batch:
+    post:
+      operationId: createBatch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items: {type: string}
+              minItems: 2
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {type: string}


### PR DESCRIPTION
Fixes #1171.

`minItems` is a value keyword whose zero means no constraint, so the diff reports its absence as `0` rather than `nil`. Five checks detected their transition with nil comparisons that can never hold for a value-typed field — the three request `min-items-set` checks (#1171's finding) and, the mirrored case the issue didn't cover, the two response `min-items-unset` checks. All five were dead and none had a test:

```console
$ # add minItems: 3 where there was none            (before)
error [request-property-min-items-increased] minItems was increased to 3

$ # after
error [request-property-min-items-set] minItems was set to 3
        Setting a bound rejects values the previous contract accepted. ...
```

`uintBoundSet` / `uintBoundUnset` read the transition as to-or-from zero, which is semantically exact, not a heuristic: an explicit `minItems: 0` requires nothing, so it is the same contract as an absent bound (and the tests pin that equivalence implicitly — the detection cannot tell them apart by construction). The `increased`/`decreased` checks yield the from-zero and to-zero cases; a bound tightened between two non-zero values still reports as increased, pinned by test.

**Level impact: none.** Since the bound-set escalation, `set` and `increased` are both errors, as are `unset` and `decreased` on a response. What changes is the id and message for absence transitions — and that `--severity-levels` can now target them separately, which is the reason the distinct ids exist. This resolves the note in the v1.30.0 release cycle that three escalated rules could not fire.

The issue's option 2 (remove the ids) became unattractive the moment v1.30.0 published them in the catalog and on the rule pages; option 1 is implemented as specced, with the issue's requested tests.

`minLength` and `minProperties` share the value-typed shape; their set/unset directions stay with #1159 and can reuse these helpers.