### PR TITLE
Move the parameter and header checks onto the walkers

### DIFF
--- a/checker/check_new_requried_request_header_property.go
+++ b/checker/check_new_requried_request_header_property.go
@@ -13,48 +13,27 @@ const (
 
 func NewRequiredRequestHeaderPropertyCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedParameters(diffReport, operationsSources, config, func(p paramInfo) {
+		if p.location != "header" {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-
-			if operationItem.ParametersDiff == nil {
-				continue
-			}
-
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-
-			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
-
-				if paramLocation != "header" {
-					continue
+		baseSource, revisionSource := ParameterSources(operationsSources, p.opInfo.methodDiff, p.paramDiff)
+		checkAddedPropertiesDiff(
+			p.paramDiff.SchemaDiff,
+			func(propertyPath string, newPropertyName string, newProperty *openapi3.Schema, parent *diff.SchemaDiff) {
+				if newProperty.ReadOnly {
+					return
+				}
+				if !slices.Contains(parent.Revision.Required, newPropertyName) {
+					return
 				}
 
-				for paramName, paramDiff := range paramDiffs {
-					baseSource, revisionSource := ParameterSources(operationsSources, operationItem, paramDiff)
-					checkAddedPropertiesDiff(
-						paramDiff.SchemaDiff,
-						func(propertyPath string, newPropertyName string, newProperty *openapi3.Schema, parent *diff.SchemaDiff) {
-							if newProperty.ReadOnly {
-								return
-							}
-							if !slices.Contains(parent.Revision.Required, newPropertyName) {
-								return
-							}
-
-							result = append(result, opInfo.NewApiChange(
-								NewRequiredRequestHeaderPropertyId,
-								[]any{paramName, propertyFullName(propertyPath, newPropertyName)},
-								"",
-							).WithSources(baseSource, revisionSource))
-						})
-				}
-			}
-		}
-	}
+				result = append(result, p.opInfo.NewApiChange(
+					NewRequiredRequestHeaderPropertyId,
+					[]any{p.name, propertyFullName(propertyPath, newPropertyName)},
+					"",
+				).WithSources(baseSource, revisionSource))
+			})
+	})
 	return result
 }

--- a/checker/check_request_header_property_became_enum.go
+++ b/checker/check_request_header_property_became_enum.go
@@ -10,59 +10,38 @@ const (
 
 func RequestHeaderPropertyBecameEnumCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedParameters(diffReport, operationsSources, config, func(p paramInfo) {
+		if p.location != "header" {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
+		if p.paramDiff.SchemaDiff == nil {
+			return
+		}
 
-			if operationItem.ParametersDiff == nil {
-				continue
-			}
+		baseSource, revisionSource := SchemaFieldSources(operationsSources, p.opInfo.methodDiff, p.paramDiff.SchemaDiff, "enum")
+		if p.paramDiff.SchemaDiff.EnumDiff != nil && p.paramDiff.SchemaDiff.EnumDiff.EnumAdded {
+			result = append(result, p.opInfo.NewApiChange(
+				RequestHeaderPropertyBecameEnumId,
+				[]any{p.name},
+				"",
+			).WithSources(baseSource, revisionSource))
+		}
 
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
+		checkModifiedPropertiesDiff(
+			p.paramDiff.SchemaDiff,
+			func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
 
-			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
-
-				if paramLocation != "header" {
-					continue
+				if enumDiff := propertyDiff.EnumDiff; enumDiff == nil || !enumDiff.EnumAdded {
+					return
 				}
 
-				for paramName, paramDiff := range paramDiffs {
-					if paramDiff.SchemaDiff == nil {
-						continue
-					}
-
-					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramDiff.SchemaDiff, "enum")
-					if paramDiff.SchemaDiff.EnumDiff != nil && paramDiff.SchemaDiff.EnumDiff.EnumAdded {
-						result = append(result, opInfo.NewApiChange(
-							RequestHeaderPropertyBecameEnumId,
-							[]any{paramName},
-							"",
-						).WithSources(baseSource, revisionSource))
-					}
-
-					checkModifiedPropertiesDiff(
-						paramDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-
-							if enumDiff := propertyDiff.EnumDiff; enumDiff == nil || !enumDiff.EnumAdded {
-								return
-							}
-
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "enum")
-							result = append(result, opInfo.NewApiChange(
-								RequestHeaderPropertyBecameEnumId,
-								[]any{paramName, propertyFullName(propertyPath, propertyName)},
-								"",
-							).WithSources(propBaseSource, propRevisionSource))
-						})
-				}
-			}
-		}
-	}
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, p.opInfo.methodDiff, propertyDiff, "enum")
+				result = append(result, p.opInfo.NewApiChange(
+					RequestHeaderPropertyBecameEnumId,
+					[]any{p.name, propertyFullName(propertyPath, propertyName)},
+					"",
+				).WithSources(propBaseSource, propRevisionSource))
+			})
+	})
 	return result
 }

--- a/checker/check_request_header_property_became_required.go
+++ b/checker/check_request_header_property_became_required.go
@@ -10,80 +10,59 @@ const (
 
 func RequestHeaderPropertyBecameRequiredCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedParameters(diffReport, operationsSources, config, func(p paramInfo) {
+		if p.location != "header" {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
+		if p.paramDiff.SchemaDiff == nil {
+			return
+		}
 
-			if operationItem.ParametersDiff == nil {
-				continue
-			}
-
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-
-			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
-
-				if paramLocation != "header" {
+		if p.paramDiff.SchemaDiff.RequiredDiff != nil {
+			for _, changedRequiredPropertyName := range p.paramDiff.SchemaDiff.RequiredDiff.Added {
+				if p.paramDiff.SchemaDiff.Revision.Properties[changedRequiredPropertyName] == nil {
+					continue
+				}
+				if p.paramDiff.SchemaDiff.Revision.Properties[changedRequiredPropertyName].Value.ReadOnly {
 					continue
 				}
 
-				for paramName, paramDiff := range paramDiffs {
-					if paramDiff.SchemaDiff == nil {
-						continue
-					}
-
-					if paramDiff.SchemaDiff.RequiredDiff != nil {
-						for _, changedRequiredPropertyName := range paramDiff.SchemaDiff.RequiredDiff.Added {
-							if paramDiff.SchemaDiff.Revision.Properties[changedRequiredPropertyName] == nil {
-								continue
-							}
-							if paramDiff.SchemaDiff.Revision.Properties[changedRequiredPropertyName].Value.ReadOnly {
-								continue
-							}
-
-							if paramDiff.SchemaDiff.Base.Properties[changedRequiredPropertyName] == nil {
-								// new added required properties processed via the new-required-request-header-property check
-								continue
-							}
-
-							baseSource, revisionSource := SchemaAddedItemSources(operationsSources, operationItem, paramDiff.SchemaDiff, "required", changedRequiredPropertyName)
-							result = append(result, opInfo.NewApiChange(
-								RequestHeaderPropertyBecameRequiredId,
-								[]any{paramName, changedRequiredPropertyName},
-								"",
-							).WithSources(baseSource, revisionSource))
-						}
-					}
-
-					checkModifiedPropertiesDiff(
-						paramDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							requiredDiff := propertyDiff.RequiredDiff
-							if requiredDiff == nil {
-								return
-							}
-							for _, changedRequiredPropertyName := range requiredDiff.Added {
-								if propertyDiff.Revision.Properties[changedRequiredPropertyName] == nil {
-									continue
-								}
-								if propertyDiff.Revision.Properties[changedRequiredPropertyName].Value.ReadOnly {
-									continue
-								}
-								propBaseSource, propRevisionSource := SchemaAddedItemSources(operationsSources, operationItem, propertyDiff, "required", changedRequiredPropertyName)
-								result = append(result, opInfo.NewApiChange(
-									RequestHeaderPropertyBecameRequiredId,
-									[]any{paramName, propertyFullName(propertyPath, propertyFullName(propertyName, changedRequiredPropertyName))},
-									"",
-								).WithSources(propBaseSource, propRevisionSource))
-							}
-						})
+				if p.paramDiff.SchemaDiff.Base.Properties[changedRequiredPropertyName] == nil {
+					// new added required properties processed via the new-required-request-header-property check
+					continue
 				}
+
+				baseSource, revisionSource := SchemaAddedItemSources(operationsSources, p.opInfo.methodDiff, p.paramDiff.SchemaDiff, "required", changedRequiredPropertyName)
+				result = append(result, p.opInfo.NewApiChange(
+					RequestHeaderPropertyBecameRequiredId,
+					[]any{p.name, changedRequiredPropertyName},
+					"",
+				).WithSources(baseSource, revisionSource))
 			}
 		}
-	}
+
+		checkModifiedPropertiesDiff(
+			p.paramDiff.SchemaDiff,
+			func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
+				requiredDiff := propertyDiff.RequiredDiff
+				if requiredDiff == nil {
+					return
+				}
+				for _, changedRequiredPropertyName := range requiredDiff.Added {
+					if propertyDiff.Revision.Properties[changedRequiredPropertyName] == nil {
+						continue
+					}
+					if propertyDiff.Revision.Properties[changedRequiredPropertyName].Value.ReadOnly {
+						continue
+					}
+					propBaseSource, propRevisionSource := SchemaAddedItemSources(operationsSources, p.opInfo.methodDiff, propertyDiff, "required", changedRequiredPropertyName)
+					result = append(result, p.opInfo.NewApiChange(
+						RequestHeaderPropertyBecameRequiredId,
+						[]any{p.name, propertyFullName(propertyPath, propertyFullName(propertyName, changedRequiredPropertyName))},
+						"",
+					).WithSources(propBaseSource, propRevisionSource))
+				}
+			})
+	})
 	return result
 }

--- a/checker/check_request_parameter_became_enum.go
+++ b/checker/check_request_parameter_became_enum.go
@@ -10,40 +10,21 @@ const (
 
 func RequestParameterBecameEnumCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedParameters(diffReport, operationsSources, config, func(p paramInfo) {
+		if p.paramDiff.SchemaDiff == nil {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ParametersDiff == nil {
-				continue
-			}
-			if operationItem.ParametersDiff.Modified == nil {
-				continue
-			}
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-			for paramLocation, paramItems := range operationItem.ParametersDiff.Modified {
-				for paramName, paramItem := range paramItems {
-					if paramItem.SchemaDiff == nil {
-						continue
-					}
-					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramItem.SchemaDiff, "enum")
+		baseSource, revisionSource := SchemaFieldSources(operationsSources, p.opInfo.methodDiff, p.paramDiff.SchemaDiff, "enum")
 
-					if enumDiff := paramItem.SchemaDiff.EnumDiff; enumDiff == nil || !enumDiff.EnumAdded {
-						continue
-					}
-
-					result = append(result, opInfo.NewApiChange(
-						RequestParameterBecameEnumId,
-						[]any{paramLocation, paramName},
-						"",
-					).WithSchema(paramItem.SchemaDiff).WithSources(baseSource, revisionSource))
-				}
-			}
+		if enumDiff := p.paramDiff.SchemaDiff.EnumDiff; enumDiff == nil || !enumDiff.EnumAdded {
+			return
 		}
-	}
+
+		result = append(result, p.opInfo.NewApiChange(
+			RequestParameterBecameEnumId,
+			[]any{p.location, p.name},
+			"",
+		).WithSchema(p.paramDiff.SchemaDiff).WithSources(baseSource, revisionSource))
+	})
 	return result
 }

--- a/checker/check_request_parameter_became_nullable.go
+++ b/checker/check_request_parameter_became_nullable.go
@@ -13,54 +13,35 @@ const (
 
 func RequestParameterBecameNullableCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedParameters(diffReport, operationsSources, config, func(p paramInfo) {
+		if p.paramDiff.SchemaDiff == nil {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ParametersDiff == nil {
-				continue
-			}
-			if operationItem.ParametersDiff.Modified == nil {
-				continue
-			}
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-			for paramLocation, paramItems := range operationItem.ParametersDiff.Modified {
-				for paramName, paramItem := range paramItems {
-					if paramItem.SchemaDiff == nil {
-						continue
-					}
 
-					if id := nullabilityChangeId(paramItem.SchemaDiff, RequestParameterBecameNullableId, RequestParameterBecameNotNullableId); id != "" {
-						baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramItem.SchemaDiff, "nullable")
-						result = append(result, opInfo.NewApiChange(
-							id,
-							[]any{paramLocation, paramName},
-							"",
-						).WithSchema(paramItem.SchemaDiff).WithSources(baseSource, revisionSource))
-					}
+		if id := nullabilityChangeId(p.paramDiff.SchemaDiff, RequestParameterBecameNullableId, RequestParameterBecameNotNullableId); id != "" {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, p.opInfo.methodDiff, p.paramDiff.SchemaDiff, "nullable")
+			result = append(result, p.opInfo.NewApiChange(
+				id,
+				[]any{p.location, p.name},
+				"",
+			).WithSchema(p.paramDiff.SchemaDiff).WithSources(baseSource, revisionSource))
+		}
 
-					checkModifiedPropertiesDiff(
-						paramItem.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							if propertyDiff == nil || propertyDiff.Base == nil || propertyDiff.Revision == nil {
-								return
-							}
-							if id := nullabilityChangeId(propertyDiff, RequestParameterPropertyBecameNullableId, RequestParameterPropertyBecameNotNullableId); id != "" {
-								baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "nullable")
-								result = append(result, opInfo.NewApiChange(
-									id,
-									[]any{propertyFullName(propertyPath, propertyName), paramLocation, paramName},
-									"",
-								).WithSchema(propertyDiff).WithSources(baseSource, revisionSource))
-							}
-						})
+		checkModifiedPropertiesDiff(
+			p.paramDiff.SchemaDiff,
+			func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
+				if propertyDiff == nil || propertyDiff.Base == nil || propertyDiff.Revision == nil {
+					return
 				}
-			}
-		}
-	}
+				if id := nullabilityChangeId(propertyDiff, RequestParameterPropertyBecameNullableId, RequestParameterPropertyBecameNotNullableId); id != "" {
+					baseSource, revisionSource := SchemaFieldSources(operationsSources, p.opInfo.methodDiff, propertyDiff, "nullable")
+					result = append(result, p.opInfo.NewApiChange(
+						id,
+						[]any{propertyFullName(propertyPath, propertyName), p.location, p.name},
+						"",
+					).WithSchema(propertyDiff).WithSources(baseSource, revisionSource))
+				}
+			})
+	})
 	return result
 }

--- a/checker/check_request_parameter_deprecation.go
+++ b/checker/check_request_parameter_deprecation.go
@@ -17,97 +17,77 @@ const (
 
 func RequestParameterDeprecationCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
+	walkModifiedParameters(diffReport, operationsSources, config, func(p paramInfo) {
 
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+		if p.paramDiff.DeprecatedDiff == nil {
+			return
 		}
-		for operation, operationDiff := range pathItem.OperationsDiff.Modified {
-			if operationDiff.ParametersDiff == nil {
-				continue
-			}
+		baseSource, revisionSource := SchemaFieldSources(operationsSources, p.opInfo.methodDiff, p.paramDiff.SchemaDiff, "deprecated")
 
-			op := pathItem.Revision.GetOperation(operation)
-			opInfo := newOpInfo(config, op, operationsSources, operation, path)
+		param := p.paramDiff.Revision
 
-			for paramLocation, paramItems := range operationDiff.ParametersDiff.Modified {
-				for paramName, paramItem := range paramItems {
-
-					if paramItem.DeprecatedDiff == nil {
-						continue
-					}
-					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationDiff, paramItem.SchemaDiff, "deprecated")
-
-					param := paramItem.Revision
-
-					if paramItem.DeprecatedDiff.To == nil || paramItem.DeprecatedDiff.To == false {
-						// not breaking changes
-						result = append(result, opInfo.NewApiChange(
-							RequestParameterReactivatedId,
-							[]any{paramLocation, paramName},
-							"",
-						).WithSources(baseSource, revisionSource).WithDetails(formatDeprecationDetails(op.Extensions)))
-						continue
-					}
-
-					stability, err := getStabilityLevel(op.Extensions)
-					if err != nil {
-						// handled in CheckBackwardCompatibility
-						continue
-					}
-
-					deprecationDays := getDeprecationDays(config, stability)
-
-					sunset, ok := getSunset(param.Extensions)
-					if !ok {
-						// if deprecation policy is defined and sunset is missing, it's a breaking change
-						if deprecationDays > 0 {
-							result = append(result, getParameterDeprecatedSunsetMissing(opInfo, param).WithSources(baseSource, revisionSource))
-						} else {
-							// no policy, report deprecation without sunset as INFO
-							result = append(result, opInfo.NewApiChange(
-								RequestParameterDeprecatedId,
-								[]any{paramLocation, paramName},
-								"",
-							).WithSources(baseSource, revisionSource).WithDetails(formatDeprecationDetails(op.Extensions)))
-						}
-						continue
-					}
-
-					date, err := getSunsetDate(sunset)
-					if err != nil {
-						result = append(result, opInfo.NewApiChange(
-							RequestParameterSunsetParseId,
-							[]any{param.In, param.Name, err},
-							"",
-						).WithSources(baseSource, revisionSource))
-						continue
-					}
-
-					days := date.DaysSince(civil.DateOf(time.Now()))
-
-					if days < int(deprecationDays) {
-						result = append(result, opInfo.NewApiChange(
-							RequestParameterSunsetDateTooSmallId,
-							[]any{param.In, param.Name, date, deprecationDays},
-							"",
-						).WithSources(baseSource, revisionSource))
-						continue
-					}
-
-					// not breaking changes
-					result = append(result, opInfo.NewApiChange(
-						RequestParameterDeprecatedId,
-						[]any{paramLocation, paramName},
-						"",
-					).WithSources(baseSource, revisionSource).WithDetails(formatDeprecationDetailsWithSunset(date, op.Extensions)))
-				}
-			}
+		if p.paramDiff.DeprecatedDiff.To == nil || p.paramDiff.DeprecatedDiff.To == false {
+			// not breaking changes
+			result = append(result, p.opInfo.NewApiChange(
+				RequestParameterReactivatedId,
+				[]any{p.location, p.name},
+				"",
+			).WithSources(baseSource, revisionSource).WithDetails(formatDeprecationDetails(p.opInfo.operation.Extensions)))
+			return
 		}
-	}
+
+		stability, err := getStabilityLevel(p.opInfo.operation.Extensions)
+		if err != nil {
+			// handled in CheckBackwardCompatibility
+			return
+		}
+
+		deprecationDays := getDeprecationDays(config, stability)
+
+		sunset, ok := getSunset(param.Extensions)
+		if !ok {
+			// if deprecation policy is defined and sunset is missing, it's a breaking change
+			if deprecationDays > 0 {
+				result = append(result, getParameterDeprecatedSunsetMissing(p.opInfo, param).WithSources(baseSource, revisionSource))
+			} else {
+				// no policy, report deprecation without sunset as INFO
+				result = append(result, p.opInfo.NewApiChange(
+					RequestParameterDeprecatedId,
+					[]any{p.location, p.name},
+					"",
+				).WithSources(baseSource, revisionSource).WithDetails(formatDeprecationDetails(p.opInfo.operation.Extensions)))
+			}
+			return
+		}
+
+		date, err := getSunsetDate(sunset)
+		if err != nil {
+			result = append(result, p.opInfo.NewApiChange(
+				RequestParameterSunsetParseId,
+				[]any{param.In, param.Name, err},
+				"",
+			).WithSources(baseSource, revisionSource))
+			return
+		}
+
+		days := date.DaysSince(civil.DateOf(time.Now()))
+
+		if days < int(deprecationDays) {
+			result = append(result, p.opInfo.NewApiChange(
+				RequestParameterSunsetDateTooSmallId,
+				[]any{param.In, param.Name, date, deprecationDays},
+				"",
+			).WithSources(baseSource, revisionSource))
+			return
+		}
+
+		// not breaking changes
+		result = append(result, p.opInfo.NewApiChange(
+			RequestParameterDeprecatedId,
+			[]any{p.location, p.name},
+			"",
+		).WithSources(baseSource, revisionSource).WithDetails(formatDeprecationDetailsWithSunset(date, p.opInfo.operation.Extensions)))
+	})
 
 	return result
 }

--- a/checker/check_request_parameter_enum_value_updated.go
+++ b/checker/check_request_parameter_enum_value_updated.go
@@ -15,54 +15,35 @@ const (
 
 func RequestParameterEnumValueUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedParameters(diffReport, operationsSources, config, func(p paramInfo) {
+		if p.paramDiff.SchemaDiff == nil {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ParametersDiff == nil {
-				continue
-			}
-			if operationItem.ParametersDiff.Modified == nil {
-				continue
-			}
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-			for paramLocation, paramItems := range operationItem.ParametersDiff.Modified {
-				for paramName, paramItem := range paramItems {
-					if paramItem.SchemaDiff == nil {
-						continue
-					}
 
-					result = append(result, checkParameterEnumDiff(
-						opInfo,
-						paramItem.SchemaDiff.EnumDiff,
-						paramItem.SchemaDiff,
-						RequestParameterEnumValueRemovedId,
-						RequestParameterEnumValueAddedId,
-						func(enumVal any) []any { return []any{enumVal, paramLocation, paramName} },
-					)...)
+		result = append(result, checkParameterEnumDiff(
+			p.opInfo,
+			p.paramDiff.SchemaDiff.EnumDiff,
+			p.paramDiff.SchemaDiff,
+			RequestParameterEnumValueRemovedId,
+			RequestParameterEnumValueAddedId,
+			func(enumVal any) []any { return []any{enumVal, p.location, p.name} },
+		)...)
 
-					checkModifiedPropertiesDiff(
-						paramItem.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							result = append(result, checkParameterEnumDiff(
-								opInfo,
-								propertyDiff.EnumDiff,
-								propertyDiff,
-								RequestParameterPropertyEnumValueRemovedId,
-								RequestParameterPropertyEnumValueAddedId,
-								func(enumVal any) []any {
-									return []any{enumVal, propertyFullName(propertyPath, propertyName), paramLocation, paramName}
-								},
-							)...)
-						})
-				}
-			}
-		}
-	}
+		checkModifiedPropertiesDiff(
+			p.paramDiff.SchemaDiff,
+			func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
+				result = append(result, checkParameterEnumDiff(
+					p.opInfo,
+					propertyDiff.EnumDiff,
+					propertyDiff,
+					RequestParameterPropertyEnumValueRemovedId,
+					RequestParameterPropertyEnumValueAddedId,
+					func(enumVal any) []any {
+						return []any{enumVal, propertyFullName(propertyPath, propertyName), p.location, p.name}
+					},
+				)...)
+			})
+	})
 	return result
 }
 

--- a/checker/check_request_parameter_list_of_types_changed.go
+++ b/checker/check_request_parameter_list_of_types_changed.go
@@ -13,53 +13,35 @@ const (
 
 func RequestParameterListOfTypesChangedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedParameters(diffReport, operationsSources, config, func(p paramInfo) {
+		param := p.paramDiff.Revision
+		if param == nil {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ParametersDiff == nil {
-				continue
-			}
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 
-			// Check modified parameters
-			for _, paramDiffs := range operationItem.ParametersDiff.Modified {
-				for _, paramDiff := range paramDiffs {
-					param := paramDiff.Revision
-					if param == nil {
-						continue
-					}
+		// Check parameter schema
+		changes := checkParameterListOfTypesChange(
+			p.opInfo,
+			p.paramDiff,
+			param,
+		)
+		result = append(result, changes...)
 
-					// Check parameter schema
-					changes := checkParameterListOfTypesChange(
-						opInfo,
-						paramDiff,
+		// Check parameter properties
+		if p.paramDiff.SchemaDiff != nil {
+			checkModifiedPropertiesDiff(
+				p.paramDiff.SchemaDiff,
+				func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
+					changes := checkParameterPropertyListOfTypesChange(
+						p.opInfo,
+						propertyPath,
+						propertyName,
+						propertyDiff,
 						param,
 					)
 					result = append(result, changes...)
-
-					// Check parameter properties
-					if paramDiff.SchemaDiff != nil {
-						checkModifiedPropertiesDiff(
-							paramDiff.SchemaDiff,
-							func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-								changes := checkParameterPropertyListOfTypesChange(
-									opInfo,
-									propertyPath,
-									propertyName,
-									propertyDiff,
-									param,
-								)
-								result = append(result, changes...)
-							})
-					}
-				}
-			}
+				})
 		}
-	}
+	})
 	return result
 }

--- a/checker/check_request_parameter_pattern_added_or_changed.go
+++ b/checker/check_request_parameter_pattern_added_or_changed.go
@@ -15,62 +15,43 @@ const (
 
 func RequestParameterPatternAddedOrChangedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedParameters(diffReport, operationsSources, config, func(p paramInfo) {
+		if p.paramDiff.SchemaDiff == nil {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ParametersDiff == nil {
-				continue
-			}
-			if operationItem.ParametersDiff.Modified == nil {
-				continue
-			}
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-			for paramLocation, paramItems := range operationItem.ParametersDiff.Modified {
-				for paramName, paramItem := range paramItems {
-					if paramItem.SchemaDiff == nil {
-						continue
-					}
-					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramItem.SchemaDiff, "pattern")
-					patternDiff := paramItem.SchemaDiff.PatternDiff
-					if patternDiff == nil {
-						continue
-					}
-
-					if patternDiff.From == "" {
-						result = append(result, opInfo.NewApiChange(
-							RequestParameterPatternAddedId,
-							[]any{patternDiff.To, paramLocation, paramName},
-							PatternAddedCommentId,
-						).WithSchema(paramItem.SchemaDiff).WithSources(nil, revisionSource))
-					} else if patternDiff.To == "" {
-						result = append(result, opInfo.NewApiChange(
-							RequestParameterPatternRemovedId,
-							[]any{patternDiff.From, paramLocation, paramName},
-							"",
-						).WithSchema(paramItem.SchemaDiff).WithSources(baseSource, nil))
-					} else {
-						id := RequestParameterPatternChangedId
-						comment := PatternChangedCommentId
-
-						if patternDiff.To == ".*" {
-							id = RequestParameterPatternGeneralizedId
-							comment = ""
-						}
-
-						result = append(result, opInfo.NewApiChange(
-							id,
-							[]any{paramLocation, paramName, patternDiff.From, patternDiff.To},
-							comment,
-						).WithSchema(paramItem.SchemaDiff).WithSources(baseSource, revisionSource))
-					}
-				}
-			}
+		baseSource, revisionSource := SchemaFieldSources(operationsSources, p.opInfo.methodDiff, p.paramDiff.SchemaDiff, "pattern")
+		patternDiff := p.paramDiff.SchemaDiff.PatternDiff
+		if patternDiff == nil {
+			return
 		}
-	}
+
+		if patternDiff.From == "" {
+			result = append(result, p.opInfo.NewApiChange(
+				RequestParameterPatternAddedId,
+				[]any{patternDiff.To, p.location, p.name},
+				PatternAddedCommentId,
+			).WithSchema(p.paramDiff.SchemaDiff).WithSources(nil, revisionSource))
+		} else if patternDiff.To == "" {
+			result = append(result, p.opInfo.NewApiChange(
+				RequestParameterPatternRemovedId,
+				[]any{patternDiff.From, p.location, p.name},
+				"",
+			).WithSchema(p.paramDiff.SchemaDiff).WithSources(baseSource, nil))
+		} else {
+			id := RequestParameterPatternChangedId
+			comment := PatternChangedCommentId
+
+			if patternDiff.To == ".*" {
+				id = RequestParameterPatternGeneralizedId
+				comment = ""
+			}
+
+			result = append(result, p.opInfo.NewApiChange(
+				id,
+				[]any{p.location, p.name, patternDiff.From, patternDiff.To},
+				comment,
+			).WithSchema(p.paramDiff.SchemaDiff).WithSources(baseSource, revisionSource))
+		}
+	})
 	return result
 }

--- a/checker/check_request_parameter_required_value_updated.go
+++ b/checker/check_request_parameter_required_value_updated.go
@@ -11,43 +11,24 @@ const (
 
 func RequestParameterRequiredValueUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedParameters(diffReport, operationsSources, config, func(p paramInfo) {
+		requiredDiff := p.paramDiff.RequiredDiff
+		if requiredDiff == nil {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ParametersDiff == nil {
-				continue
-			}
-			if operationItem.ParametersDiff.Modified == nil {
-				continue
-			}
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-			for paramLocation, paramItems := range operationItem.ParametersDiff.Modified {
-				for paramName, paramItem := range paramItems {
-					requiredDiff := paramItem.RequiredDiff
-					if requiredDiff == nil {
-						continue
-					}
-					baseSource, revisionSource := parameterFieldSources(operationsSources, operationItem, paramItem, "required")
+		baseSource, revisionSource := parameterFieldSources(operationsSources, p.opInfo.methodDiff, p.paramDiff, "required")
 
-					id := RequestParameterBecomeRequiredId
+		id := RequestParameterBecomeRequiredId
 
-					if requiredDiff.To != true {
-						id = RequestParameterBecomeOptionalId
-					}
-
-					result = append(result, opInfo.NewApiChange(
-						id,
-						[]any{paramLocation, paramName},
-						"",
-					).WithSources(baseSource, revisionSource))
-				}
-			}
+		if requiredDiff.To != true {
+			id = RequestParameterBecomeOptionalId
 		}
-	}
+
+		result = append(result, p.opInfo.NewApiChange(
+			id,
+			[]any{p.location, p.name},
+			"",
+		).WithSources(baseSource, revisionSource))
+	})
 	return result
 }

--- a/checker/check_request_parameter_sunset_changed.go
+++ b/checker/check_request_parameter_sunset_changed.go
@@ -15,95 +15,65 @@ const (
 
 func RequestParameterSunsetChangedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
 
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedParameters(diffReport, operationsSources, config, func(p paramInfo) {
+		baseSource, revisionSource := parameterFieldSources(operationsSources, p.opInfo.methodDiff, p.paramDiff, diff.SunsetExtension)
+
+		paramBase := p.paramDiff.Base
+		paramRevision := p.paramDiff.Revision
+
+		if !paramRevision.Deprecated {
+			return
 		}
-		for operation, operationDiff := range pathItem.OperationsDiff.Modified {
-			opRevision := pathItem.Revision.GetOperation(operation)
-			opBase := pathItem.Base.GetOperation(operation)
 
-			if operationDiff.ParametersDiff == nil {
-				continue
-			}
-
-			for paramLocation, paramItems := range operationDiff.ParametersDiff.Modified {
-				for paramName, paramItem := range paramItems {
-					baseSource, revisionSource := parameterFieldSources(operationsSources, operationDiff, paramItem, diff.SunsetExtension)
-
-					paramBase := paramItem.Base
-					paramRevision := paramItem.Revision
-
-					if !paramRevision.Deprecated {
-						continue
-					}
-
-					if paramItem.ExtensionsDiff == nil {
-						continue
-					}
-
-					if slices.Contains(paramItem.ExtensionsDiff.Deleted, diff.SunsetExtension) {
-						result = append(result, NewApiChange(
-							RequestParameterSunsetDeletedId,
-							config,
-							[]any{paramLocation, paramName},
-							"",
-							operationsSources,
-							opRevision,
-							operation,
-							path,
-						).WithSources(baseSource, revisionSource))
-						continue
-					}
-
-					if _, ok := paramItem.ExtensionsDiff.Modified[diff.SunsetExtension]; !ok {
-						continue
-					}
-
-					date, err := getSunsetDate(paramRevision.Extensions[diff.SunsetExtension])
-					if err != nil {
-						opInfo := newOpInfo(config, opRevision, operationsSources, operation, path)
-						result = append(result, getRequestParameterSunsetParse(opInfo, paramRevision, err).WithSources(nil, revisionSource))
-						continue
-					}
-
-					baseDate, err := getSunsetDate(paramBase.Extensions[diff.SunsetExtension])
-					if err != nil {
-						opInfo := newOpInfo(config, opBase, operationsSources, operation, path)
-						result = append(result, getRequestParameterSunsetParse(opInfo, paramBase, err).WithSources(baseSource, nil))
-						continue
-					}
-
-					days := date.DaysSince(civil.DateOf(time.Now()))
-
-					stability, err := getStabilityLevel(opRevision.Extensions)
-					if err != nil {
-						// handled in CheckBackwardCompatibility
-						continue
-					}
-
-					deprecationDays := getDeprecationDays(config, stability)
-
-					if baseDate.After(date) && days < int(deprecationDays) {
-						result = append(result, NewApiChange(
-							RequestParameterSunsetDateChangedTooSmallId,
-							config,
-							[]any{paramRevision.In, paramRevision.Name, baseDate, date, baseDate, deprecationDays},
-							"",
-							operationsSources,
-							opRevision,
-							operation,
-							path,
-						).WithSources(baseSource, revisionSource))
-					}
-				}
-			}
+		if p.paramDiff.ExtensionsDiff == nil {
+			return
 		}
-	}
+
+		if slices.Contains(p.paramDiff.ExtensionsDiff.Deleted, diff.SunsetExtension) {
+			result = append(result, p.opInfo.NewApiChange(
+				RequestParameterSunsetDeletedId,
+				[]any{p.location, p.name},
+				"",
+			).WithSources(baseSource, revisionSource))
+			return
+		}
+
+		if _, ok := p.paramDiff.ExtensionsDiff.Modified[diff.SunsetExtension]; !ok {
+			return
+		}
+
+		date, err := getSunsetDate(paramRevision.Extensions[diff.SunsetExtension])
+		if err != nil {
+			result = append(result, getRequestParameterSunsetParse(p.opInfo, paramRevision, err).WithSources(nil, revisionSource))
+			return
+		}
+
+		baseDate, err := getSunsetDate(paramBase.Extensions[diff.SunsetExtension])
+		if err != nil {
+			opInfo := newOpInfo(config, p.opInfo.methodDiff.Base, operationsSources, p.opInfo.method, p.opInfo.path)
+			result = append(result, getRequestParameterSunsetParse(opInfo, paramBase, err).WithSources(baseSource, nil))
+			return
+		}
+
+		days := date.DaysSince(civil.DateOf(time.Now()))
+
+		stability, err := getStabilityLevel(p.opInfo.operation.Extensions)
+		if err != nil {
+			// handled in CheckBackwardCompatibility
+			return
+		}
+
+		deprecationDays := getDeprecationDays(config, stability)
+
+		if baseDate.After(date) && days < int(deprecationDays) {
+			result = append(result, p.opInfo.NewApiChange(
+				RequestParameterSunsetDateChangedTooSmallId,
+				[]any{paramRevision.In, paramRevision.Name, baseDate, date, baseDate, deprecationDays},
+				"",
+			).WithSources(baseSource, revisionSource))
+		}
+	})
 
 	return result
 }

--- a/checker/check_request_parameter_x_extensible_enum_value_removed.go
+++ b/checker/check_request_parameter_x_extensible_enum_value_removed.go
@@ -12,72 +12,53 @@ const (
 
 func RequestParameterXExtensibleEnumValueRemovedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedParameters(diffReport, operationsSources, config, func(p paramInfo) {
+		if p.paramDiff.SchemaDiff == nil {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ParametersDiff == nil {
-				continue
-			}
-			if operationItem.ParametersDiff.Modified == nil {
-				continue
-			}
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-			for paramLocation, paramItems := range operationItem.ParametersDiff.Modified {
-				for paramName, paramItem := range paramItems {
-					if paramItem.SchemaDiff == nil {
-						continue
-					}
-					if paramItem.SchemaDiff.ExtensionsDiff == nil {
-						continue
-					}
-					if paramItem.SchemaDiff.ExtensionsDiff.Modified == nil {
-						continue
-					}
-					if paramItem.SchemaDiff.ExtensionsDiff.Modified[diff.XExtensibleEnumExtension] == nil {
-						continue
-					}
-					from, ok := paramItem.SchemaDiff.Base.Extensions[diff.XExtensibleEnumExtension].([]any)
-					if !ok {
-						continue
-					}
-					to, ok := paramItem.SchemaDiff.Revision.Extensions[diff.XExtensibleEnumExtension].([]any)
-					if !ok {
-						continue
-					}
+		if p.paramDiff.SchemaDiff.ExtensionsDiff == nil {
+			return
+		}
+		if p.paramDiff.SchemaDiff.ExtensionsDiff.Modified == nil {
+			return
+		}
+		if p.paramDiff.SchemaDiff.ExtensionsDiff.Modified[diff.XExtensibleEnumExtension] == nil {
+			return
+		}
+		from, ok := p.paramDiff.SchemaDiff.Base.Extensions[diff.XExtensibleEnumExtension].([]any)
+		if !ok {
+			return
+		}
+		to, ok := p.paramDiff.SchemaDiff.Revision.Extensions[diff.XExtensibleEnumExtension].([]any)
+		if !ok {
+			return
+		}
 
-					fromSlice := make([]string, len(from))
-					for i, item := range from {
-						fromSlice[i] = item.(string)
-					}
+		fromSlice := make([]string, len(from))
+		for i, item := range from {
+			fromSlice[i] = item.(string)
+		}
 
-					toSlice := make([]string, len(to))
-					for i, item := range to {
-						toSlice[i] = item.(string)
-					}
+		toSlice := make([]string, len(to))
+		for i, item := range to {
+			toSlice[i] = item.(string)
+		}
 
-					deletedVals := make([]string, 0)
-					for _, fromVal := range fromSlice {
-						if !slices.Contains(toSlice, fromVal) {
-							deletedVals = append(deletedVals, fromVal)
-						}
-					}
-
-					for _, enumVal := range deletedVals {
-						baseSource, revisionSource := SchemaDeletedItemSources(operationsSources, operationItem, paramItem.SchemaDiff, diff.XExtensibleEnumExtension, enumVal)
-						result = append(result, opInfo.NewApiChange(
-							RequestParameterXExtensibleEnumValueRemovedId,
-							[]any{enumVal, paramLocation, paramName},
-							"",
-						).WithSources(baseSource, revisionSource))
-					}
-				}
+		deletedVals := make([]string, 0)
+		for _, fromVal := range fromSlice {
+			if !slices.Contains(toSlice, fromVal) {
+				deletedVals = append(deletedVals, fromVal)
 			}
 		}
-	}
+
+		for _, enumVal := range deletedVals {
+			baseSource, revisionSource := SchemaDeletedItemSources(operationsSources, p.opInfo.methodDiff, p.paramDiff.SchemaDiff, diff.XExtensibleEnumExtension, enumVal)
+			result = append(result, p.opInfo.NewApiChange(
+				RequestParameterXExtensibleEnumValueRemovedId,
+				[]any{enumVal, p.location, p.name},
+				"",
+			).WithSources(baseSource, revisionSource))
+		}
+	})
 	return result
 }

--- a/checker/check_request_parameters_default_value_changed.go
+++ b/checker/check_request_parameters_default_value_changed.go
@@ -12,59 +12,43 @@ const (
 
 func RequestParameterDefaultValueChangedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedParameters(diffReport, operationsSources, config, func(p paramInfo) {
+
+		baseParam := p.paramDiff.Base
+		if baseParam == nil || baseParam.Required {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ParametersDiff == nil {
-				continue
-			}
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
-				for paramName, paramDiff := range paramDiffs {
 
-					baseParam := paramDiff.Base
-					if baseParam == nil || baseParam.Required {
-						continue
-					}
-
-					revisionParam := paramDiff.Revision
-					if revisionParam == nil || revisionParam.Required {
-						continue
-					}
-
-					if paramDiff.SchemaDiff == nil {
-						continue
-					}
-
-					defaultValueDiff := paramDiff.SchemaDiff.DefaultDiff
-					if defaultValueDiff.Empty() {
-						continue
-					}
-
-					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramDiff.SchemaDiff, "default")
-					appendResultItem := func(messageId string, a ...any) {
-						result = append(result, opInfo.NewApiChange(
-							messageId,
-							a,
-							"",
-						).WithSources(baseSource, revisionSource))
-					}
-
-					if defaultValueDiff.From == nil {
-						appendResultItem(RequestParameterDefaultValueAddedId, paramLocation, paramName, defaultValueDiff.To)
-					} else if defaultValueDiff.To == nil {
-						appendResultItem(RequestParameterDefaultValueRemovedId, paramLocation, paramName, defaultValueDiff.From)
-					} else {
-						appendResultItem(RequestParameterDefaultValueChangedId, paramLocation, paramName, defaultValueDiff.From, defaultValueDiff.To)
-					}
-				}
-			}
+		revisionParam := p.paramDiff.Revision
+		if revisionParam == nil || revisionParam.Required {
+			return
 		}
-	}
+
+		if p.paramDiff.SchemaDiff == nil {
+			return
+		}
+
+		defaultValueDiff := p.paramDiff.SchemaDiff.DefaultDiff
+		if defaultValueDiff.Empty() {
+			return
+		}
+
+		baseSource, revisionSource := SchemaFieldSources(operationsSources, p.opInfo.methodDiff, p.paramDiff.SchemaDiff, "default")
+		appendResultItem := func(messageId string, a ...any) {
+			result = append(result, p.opInfo.NewApiChange(
+				messageId,
+				a,
+				"",
+			).WithSources(baseSource, revisionSource))
+		}
+
+		if defaultValueDiff.From == nil {
+			appendResultItem(RequestParameterDefaultValueAddedId, p.location, p.name, defaultValueDiff.To)
+		} else if defaultValueDiff.To == nil {
+			appendResultItem(RequestParameterDefaultValueRemovedId, p.location, p.name, defaultValueDiff.From)
+		} else {
+			appendResultItem(RequestParameterDefaultValueChangedId, p.location, p.name, defaultValueDiff.From, defaultValueDiff.To)
+		}
+	})
 	return result
 }

--- a/checker/check_request_parameters_max_items_updated.go
+++ b/checker/check_request_parameters_max_items_updated.go
@@ -11,53 +11,37 @@ const (
 
 func RequestParameterMaxItemsUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedParameters(diffReport, operationsSources, config, func(p paramInfo) {
+		if p.paramDiff.SchemaDiff == nil {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ParametersDiff == nil {
-				continue
-			}
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
-				for paramName, paramDiff := range paramDiffs {
-					if paramDiff.SchemaDiff == nil {
-						continue
-					}
-					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramDiff.SchemaDiff, "maxItems")
+		baseSource, revisionSource := SchemaFieldSources(operationsSources, p.opInfo.methodDiff, p.paramDiff.SchemaDiff, "maxItems")
 
-					// Check for maxItems on the parameter schema itself (for array parameters)
-					maxItemsDiff := paramDiff.SchemaDiff.MaxItemsDiff
-					if maxItemsDiff == nil && paramDiff.SchemaDiff.ItemsDiff != nil {
-						// Fallback: check for maxItems on the items schema (legacy behavior)
-						maxItemsDiff = paramDiff.SchemaDiff.ItemsDiff.MaxItemsDiff
-					}
-
-					if maxItemsDiff == nil {
-						continue
-					}
-					if maxItemsDiff.From == nil ||
-						maxItemsDiff.To == nil {
-						continue
-					}
-
-					id := RequestParameterMaxItemsDecreasedId
-					if isIncreasedValue(maxItemsDiff) {
-						id = RequestParameterMaxItemsIncreasedId
-					}
-
-					result = append(result, opInfo.NewApiChange(
-						id,
-						[]any{paramLocation, paramName, maxItemsDiff.From, maxItemsDiff.To},
-						"",
-					).WithSources(baseSource, revisionSource))
-				}
-			}
+		// Check for maxItems on the parameter schema itself (for array parameters)
+		maxItemsDiff := p.paramDiff.SchemaDiff.MaxItemsDiff
+		if maxItemsDiff == nil && p.paramDiff.SchemaDiff.ItemsDiff != nil {
+			// Fallback: check for maxItems on the items schema (legacy behavior)
+			maxItemsDiff = p.paramDiff.SchemaDiff.ItemsDiff.MaxItemsDiff
 		}
-	}
+
+		if maxItemsDiff == nil {
+			return
+		}
+		if maxItemsDiff.From == nil ||
+			maxItemsDiff.To == nil {
+			return
+		}
+
+		id := RequestParameterMaxItemsDecreasedId
+		if isIncreasedValue(maxItemsDiff) {
+			id = RequestParameterMaxItemsIncreasedId
+		}
+
+		result = append(result, p.opInfo.NewApiChange(
+			id,
+			[]any{p.location, p.name, maxItemsDiff.From, maxItemsDiff.To},
+			"",
+		).WithSources(baseSource, revisionSource))
+	})
 	return result
 }

--- a/checker/check_request_parameters_max_length_set.go
+++ b/checker/check_request_parameters_max_length_set.go
@@ -10,41 +10,25 @@ const (
 
 func RequestParameterMaxLengthSetCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedParameters(diffReport, operationsSources, config, func(p paramInfo) {
+		if p.paramDiff.SchemaDiff == nil {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ParametersDiff == nil {
-				continue
-			}
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
-				for paramName, paramDiff := range paramDiffs {
-					if paramDiff.SchemaDiff == nil {
-						continue
-					}
-					maxLengthDiff := paramDiff.SchemaDiff.MaxLengthDiff
-					if maxLengthDiff == nil {
-						continue
-					}
-					if maxLengthDiff.From != nil ||
-						maxLengthDiff.To == nil {
-						continue
-					}
+		maxLengthDiff := p.paramDiff.SchemaDiff.MaxLengthDiff
+		if maxLengthDiff == nil {
+			return
+		}
+		if maxLengthDiff.From != nil ||
+			maxLengthDiff.To == nil {
+			return
+		}
 
-					_, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramDiff.SchemaDiff, "maxLength")
-					result = append(result, opInfo.NewApiChange(
-						RequestParameterMaxLengthSetId,
-						[]any{paramLocation, paramName, maxLengthDiff.To},
-						commentId(RequestParameterMaxLengthSetId),
-					).WithSources(nil, revisionSource))
-				}
-			}
-		}
-	}
+		_, revisionSource := SchemaFieldSources(operationsSources, p.opInfo.methodDiff, p.paramDiff.SchemaDiff, "maxLength")
+		result = append(result, p.opInfo.NewApiChange(
+			RequestParameterMaxLengthSetId,
+			[]any{p.location, p.name, maxLengthDiff.To},
+			commentId(RequestParameterMaxLengthSetId),
+		).WithSources(nil, revisionSource))
+	})
 	return result
 }

--- a/checker/check_request_parameters_max_length_updated.go
+++ b/checker/check_request_parameters_max_length_updated.go
@@ -11,46 +11,30 @@ const (
 
 func RequestParameterMaxLengthUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedParameters(diffReport, operationsSources, config, func(p paramInfo) {
+		if p.paramDiff.SchemaDiff == nil {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ParametersDiff == nil {
-				continue
-			}
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
-				for paramName, paramDiff := range paramDiffs {
-					if paramDiff.SchemaDiff == nil {
-						continue
-					}
-					maxLengthDiff := paramDiff.SchemaDiff.MaxLengthDiff
-					if maxLengthDiff == nil {
-						continue
-					}
-					if maxLengthDiff.From == nil ||
-						maxLengthDiff.To == nil {
-						continue
-					}
-
-					id := RequestParameterMaxLengthDecreasedId
-					if !isDecreasedValue(maxLengthDiff) {
-						id = RequestParameterMaxLengthIncreasedId
-					}
-
-					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramDiff.SchemaDiff, "maxLength")
-					result = append(result, opInfo.NewApiChange(
-						id,
-						[]any{paramLocation, paramName, maxLengthDiff.From, maxLengthDiff.To},
-						"",
-					).WithSources(baseSource, revisionSource))
-				}
-			}
+		maxLengthDiff := p.paramDiff.SchemaDiff.MaxLengthDiff
+		if maxLengthDiff == nil {
+			return
 		}
-	}
+		if maxLengthDiff.From == nil ||
+			maxLengthDiff.To == nil {
+			return
+		}
+
+		id := RequestParameterMaxLengthDecreasedId
+		if !isDecreasedValue(maxLengthDiff) {
+			id = RequestParameterMaxLengthIncreasedId
+		}
+
+		baseSource, revisionSource := SchemaFieldSources(operationsSources, p.opInfo.methodDiff, p.paramDiff.SchemaDiff, "maxLength")
+		result = append(result, p.opInfo.NewApiChange(
+			id,
+			[]any{p.location, p.name, maxLengthDiff.From, maxLengthDiff.To},
+			"",
+		).WithSources(baseSource, revisionSource))
+	})
 	return result
 }

--- a/checker/check_request_parameters_max_set.go
+++ b/checker/check_request_parameters_max_set.go
@@ -11,44 +11,28 @@ const (
 
 func RequestParameterMaxSetCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedParameters(diffReport, operationsSources, config, func(p paramInfo) {
+		if p.paramDiff.SchemaDiff == nil {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ParametersDiff == nil {
+		for _, entry := range []struct {
+			diff  *diff.ValueDiff
+			id    string
+			field string
+		}{
+			{p.paramDiff.SchemaDiff.MaxDiff, RequestParameterMaxSetId, "maximum"},
+			{p.paramDiff.SchemaDiff.ExclusiveMaxDiff, RequestParameterExclusiveMaxSetId, "exclusiveMaximum"},
+		} {
+			if entry.diff == nil || entry.diff.From != nil || entry.diff.To == nil {
 				continue
 			}
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
-				for paramName, paramDiff := range paramDiffs {
-					if paramDiff.SchemaDiff == nil {
-						continue
-					}
-					for _, entry := range []struct {
-						diff  *diff.ValueDiff
-						id    string
-						field string
-					}{
-						{paramDiff.SchemaDiff.MaxDiff, RequestParameterMaxSetId, "maximum"},
-						{paramDiff.SchemaDiff.ExclusiveMaxDiff, RequestParameterExclusiveMaxSetId, "exclusiveMaximum"},
-					} {
-						if entry.diff == nil || entry.diff.From != nil || entry.diff.To == nil {
-							continue
-						}
-						_, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramDiff.SchemaDiff, entry.field)
-						result = append(result, opInfo.NewApiChange(
-							entry.id,
-							[]any{paramLocation, paramName, entry.diff.To},
-							commentId(entry.id),
-						).WithSources(nil, revisionSource))
-					}
-				}
-			}
+			_, revisionSource := SchemaFieldSources(operationsSources, p.opInfo.methodDiff, p.paramDiff.SchemaDiff, entry.field)
+			result = append(result, p.opInfo.NewApiChange(
+				entry.id,
+				[]any{p.location, p.name, entry.diff.To},
+				commentId(entry.id),
+			).WithSources(nil, revisionSource))
 		}
-	}
+	})
 	return result
 }

--- a/checker/check_request_parameters_max_updated.go
+++ b/checker/check_request_parameters_max_updated.go
@@ -13,49 +13,33 @@ const (
 
 func RequestParameterMaxUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedParameters(diffReport, operationsSources, config, func(p paramInfo) {
+		if p.paramDiff.SchemaDiff == nil {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ParametersDiff == nil {
+		for _, entry := range []struct {
+			diff        *diff.ValueDiff
+			decreasedId string
+			increasedId string
+			field       string
+		}{
+			{p.paramDiff.SchemaDiff.MaxDiff, RequestParameterMaxDecreasedId, RequestParameterMaxIncreasedId, "maximum"},
+			{p.paramDiff.SchemaDiff.ExclusiveMaxDiff, RequestParameterExclusiveMaxDecreasedId, RequestParameterExclusiveMaxIncreasedId, "exclusiveMaximum"},
+		} {
+			if entry.diff == nil || entry.diff.From == nil || entry.diff.To == nil {
 				continue
 			}
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
-				for paramName, paramDiff := range paramDiffs {
-					if paramDiff.SchemaDiff == nil {
-						continue
-					}
-					for _, entry := range []struct {
-						diff        *diff.ValueDiff
-						decreasedId string
-						increasedId string
-						field       string
-					}{
-						{paramDiff.SchemaDiff.MaxDiff, RequestParameterMaxDecreasedId, RequestParameterMaxIncreasedId, "maximum"},
-						{paramDiff.SchemaDiff.ExclusiveMaxDiff, RequestParameterExclusiveMaxDecreasedId, RequestParameterExclusiveMaxIncreasedId, "exclusiveMaximum"},
-					} {
-						if entry.diff == nil || entry.diff.From == nil || entry.diff.To == nil {
-							continue
-						}
-						id := entry.decreasedId
-						if !isDecreasedValue(entry.diff) {
-							id = entry.increasedId
-						}
-						baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramDiff.SchemaDiff, entry.field)
-						result = append(result, opInfo.NewApiChange(
-							id,
-							[]any{paramLocation, paramName, entry.diff.From, entry.diff.To},
-							"",
-						).WithSources(baseSource, revisionSource))
-					}
-				}
+			id := entry.decreasedId
+			if !isDecreasedValue(entry.diff) {
+				id = entry.increasedId
 			}
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, p.opInfo.methodDiff, p.paramDiff.SchemaDiff, entry.field)
+			result = append(result, p.opInfo.NewApiChange(
+				id,
+				[]any{p.location, p.name, entry.diff.From, entry.diff.To},
+				"",
+			).WithSources(baseSource, revisionSource))
 		}
-	}
+	})
 	return result
 }

--- a/checker/check_request_parameters_min_items_set.go
+++ b/checker/check_request_parameters_min_items_set.go
@@ -10,40 +10,24 @@ const (
 
 func RequestParameterMinItemsSetCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedParameters(diffReport, operationsSources, config, func(p paramInfo) {
+		if p.paramDiff.SchemaDiff == nil {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ParametersDiff == nil {
-				continue
-			}
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
-				for paramName, paramDiff := range paramDiffs {
-					if paramDiff.SchemaDiff == nil {
-						continue
-					}
-					_, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramDiff.SchemaDiff, "minItems")
-					minItemsDiff := paramDiff.SchemaDiff.MinItemsDiff
-					if minItemsDiff == nil {
-						continue
-					}
-					if !uintBoundSet(minItemsDiff) {
-						continue
-					}
+		_, revisionSource := SchemaFieldSources(operationsSources, p.opInfo.methodDiff, p.paramDiff.SchemaDiff, "minItems")
+		minItemsDiff := p.paramDiff.SchemaDiff.MinItemsDiff
+		if minItemsDiff == nil {
+			return
+		}
+		if !uintBoundSet(minItemsDiff) {
+			return
+		}
 
-					result = append(result, opInfo.NewApiChange(
-						RequestParameterMinItemsSetId,
-						[]any{paramLocation, paramName, minItemsDiff.To},
-						commentId(RequestParameterMinItemsSetId),
-					).WithSources(nil, revisionSource))
-				}
-			}
-		}
-	}
+		result = append(result, p.opInfo.NewApiChange(
+			RequestParameterMinItemsSetId,
+			[]any{p.location, p.name, minItemsDiff.To},
+			commentId(RequestParameterMinItemsSetId),
+		).WithSources(nil, revisionSource))
+	})
 	return result
 }

--- a/checker/check_request_parameters_min_items_updated.go
+++ b/checker/check_request_parameters_min_items_updated.go
@@ -11,46 +11,30 @@ const (
 
 func RequestParameterMinItemsUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedParameters(diffReport, operationsSources, config, func(p paramInfo) {
+		if p.paramDiff.SchemaDiff == nil {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ParametersDiff == nil {
-				continue
-			}
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
-				for paramName, paramDiff := range paramDiffs {
-					if paramDiff.SchemaDiff == nil {
-						continue
-					}
-					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramDiff.SchemaDiff, "minItems")
-					minItemsDiff := paramDiff.SchemaDiff.MinItemsDiff
-					if minItemsDiff == nil {
-						continue
-					}
-					if uintBoundSet(minItemsDiff) {
-						// reported by request-parameter-min-items-set
-						continue
-					}
-
-					id := RequestParameterMinItemsIncreasedId
-					if !isIncreasedValue(minItemsDiff) {
-						id = RequestParameterMinItemsDecreasedId
-					}
-
-					result = append(result, opInfo.NewApiChange(
-						id,
-						[]any{paramLocation, paramName, minItemsDiff.From, minItemsDiff.To},
-						"",
-					).WithSources(baseSource, revisionSource))
-				}
-			}
+		baseSource, revisionSource := SchemaFieldSources(operationsSources, p.opInfo.methodDiff, p.paramDiff.SchemaDiff, "minItems")
+		minItemsDiff := p.paramDiff.SchemaDiff.MinItemsDiff
+		if minItemsDiff == nil {
+			return
 		}
-	}
+		if uintBoundSet(minItemsDiff) {
+			// reported by request-parameter-min-items-set
+			return
+		}
+
+		id := RequestParameterMinItemsIncreasedId
+		if !isIncreasedValue(minItemsDiff) {
+			id = RequestParameterMinItemsDecreasedId
+		}
+
+		result = append(result, p.opInfo.NewApiChange(
+			id,
+			[]any{p.location, p.name, minItemsDiff.From, minItemsDiff.To},
+			"",
+		).WithSources(baseSource, revisionSource))
+	})
 	return result
 }

--- a/checker/check_request_parameters_min_length_updated.go
+++ b/checker/check_request_parameters_min_length_updated.go
@@ -11,46 +11,30 @@ const (
 
 func RequestParameterMinLengthUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedParameters(diffReport, operationsSources, config, func(p paramInfo) {
+		if p.paramDiff.SchemaDiff == nil {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ParametersDiff == nil {
-				continue
-			}
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
-				for paramName, paramDiff := range paramDiffs {
-					if paramDiff.SchemaDiff == nil {
-						continue
-					}
-					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramDiff.SchemaDiff, "minLength")
-					minLengthDiff := paramDiff.SchemaDiff.MinLengthDiff
-					if minLengthDiff == nil {
-						continue
-					}
-					if minLengthDiff.From == nil ||
-						minLengthDiff.To == nil {
-						continue
-					}
-
-					id := RequestParameterMinLengthIncreasedId
-					if isDecreasedValue(minLengthDiff) {
-						id = RequestParameterMinLengthDecreasedId
-					}
-
-					result = append(result, opInfo.NewApiChange(
-						id,
-						[]any{paramLocation, paramName, minLengthDiff.From, minLengthDiff.To},
-						"",
-					).WithSources(baseSource, revisionSource))
-				}
-			}
+		baseSource, revisionSource := SchemaFieldSources(operationsSources, p.opInfo.methodDiff, p.paramDiff.SchemaDiff, "minLength")
+		minLengthDiff := p.paramDiff.SchemaDiff.MinLengthDiff
+		if minLengthDiff == nil {
+			return
 		}
-	}
+		if minLengthDiff.From == nil ||
+			minLengthDiff.To == nil {
+			return
+		}
+
+		id := RequestParameterMinLengthIncreasedId
+		if isDecreasedValue(minLengthDiff) {
+			id = RequestParameterMinLengthDecreasedId
+		}
+
+		result = append(result, p.opInfo.NewApiChange(
+			id,
+			[]any{p.location, p.name, minLengthDiff.From, minLengthDiff.To},
+			"",
+		).WithSources(baseSource, revisionSource))
+	})
 	return result
 }

--- a/checker/check_request_parameters_min_set.go
+++ b/checker/check_request_parameters_min_set.go
@@ -11,44 +11,28 @@ const (
 
 func RequestParameterMinSetCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedParameters(diffReport, operationsSources, config, func(p paramInfo) {
+		if p.paramDiff.SchemaDiff == nil {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ParametersDiff == nil {
+		for _, entry := range []struct {
+			diff  *diff.ValueDiff
+			id    string
+			field string
+		}{
+			{p.paramDiff.SchemaDiff.MinDiff, RequestParameterMinSetId, "minimum"},
+			{p.paramDiff.SchemaDiff.ExclusiveMinDiff, RequestParameterExclusiveMinSetId, "exclusiveMinimum"},
+		} {
+			if entry.diff == nil || entry.diff.From != nil || entry.diff.To == nil {
 				continue
 			}
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
-				for paramName, paramDiff := range paramDiffs {
-					if paramDiff.SchemaDiff == nil {
-						continue
-					}
-					for _, entry := range []struct {
-						diff  *diff.ValueDiff
-						id    string
-						field string
-					}{
-						{paramDiff.SchemaDiff.MinDiff, RequestParameterMinSetId, "minimum"},
-						{paramDiff.SchemaDiff.ExclusiveMinDiff, RequestParameterExclusiveMinSetId, "exclusiveMinimum"},
-					} {
-						if entry.diff == nil || entry.diff.From != nil || entry.diff.To == nil {
-							continue
-						}
-						_, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramDiff.SchemaDiff, entry.field)
-						result = append(result, opInfo.NewApiChange(
-							entry.id,
-							[]any{paramLocation, paramName, entry.diff.To},
-							commentId(entry.id),
-						).WithSources(nil, revisionSource))
-					}
-				}
-			}
+			_, revisionSource := SchemaFieldSources(operationsSources, p.opInfo.methodDiff, p.paramDiff.SchemaDiff, entry.field)
+			result = append(result, p.opInfo.NewApiChange(
+				entry.id,
+				[]any{p.location, p.name, entry.diff.To},
+				commentId(entry.id),
+			).WithSources(nil, revisionSource))
 		}
-	}
+	})
 	return result
 }

--- a/checker/check_request_parameters_min_updated.go
+++ b/checker/check_request_parameters_min_updated.go
@@ -13,49 +13,33 @@ const (
 
 func RequestParameterMinUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedParameters(diffReport, operationsSources, config, func(p paramInfo) {
+		if p.paramDiff.SchemaDiff == nil {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ParametersDiff == nil {
+		for _, entry := range []struct {
+			diff        *diff.ValueDiff
+			increasedId string
+			decreasedId string
+			field       string
+		}{
+			{p.paramDiff.SchemaDiff.MinDiff, RequestParameterMinIncreasedId, RequestParameterMinDecreasedId, "minimum"},
+			{p.paramDiff.SchemaDiff.ExclusiveMinDiff, RequestParameterExclusiveMinIncreasedId, RequestParameterExclusiveMinDecreasedId, "exclusiveMinimum"},
+		} {
+			if entry.diff == nil || entry.diff.From == nil || entry.diff.To == nil {
 				continue
 			}
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
-				for paramName, paramDiff := range paramDiffs {
-					if paramDiff.SchemaDiff == nil {
-						continue
-					}
-					for _, entry := range []struct {
-						diff        *diff.ValueDiff
-						increasedId string
-						decreasedId string
-						field       string
-					}{
-						{paramDiff.SchemaDiff.MinDiff, RequestParameterMinIncreasedId, RequestParameterMinDecreasedId, "minimum"},
-						{paramDiff.SchemaDiff.ExclusiveMinDiff, RequestParameterExclusiveMinIncreasedId, RequestParameterExclusiveMinDecreasedId, "exclusiveMinimum"},
-					} {
-						if entry.diff == nil || entry.diff.From == nil || entry.diff.To == nil {
-							continue
-						}
-						id := entry.increasedId
-						if !isIncreasedValue(entry.diff) {
-							id = entry.decreasedId
-						}
-						baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramDiff.SchemaDiff, entry.field)
-						result = append(result, opInfo.NewApiChange(
-							id,
-							[]any{paramLocation, paramName, entry.diff.From, entry.diff.To},
-							"",
-						).WithSources(baseSource, revisionSource))
-					}
-				}
+			id := entry.increasedId
+			if !isIncreasedValue(entry.diff) {
+				id = entry.decreasedId
 			}
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, p.opInfo.methodDiff, p.paramDiff.SchemaDiff, entry.field)
+			result = append(result, p.opInfo.NewApiChange(
+				id,
+				[]any{p.location, p.name, entry.diff.From, entry.diff.To},
+				"",
+			).WithSources(baseSource, revisionSource))
 		}
-	}
+	})
 	return result
 }

--- a/checker/check_request_parameters_type_changed.go
+++ b/checker/check_request_parameters_type_changed.go
@@ -105,82 +105,65 @@ func withoutNull(types []string) []string {
 
 func RequestParameterTypeChangedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedParameters(diffReport, operationsSources, config, func(p paramInfo) {
+		if p.paramDiff.SchemaDiff == nil {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ParametersDiff == nil {
-				continue
-			}
 
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
-				for paramName, paramDiff := range paramDiffs {
-					if paramDiff.SchemaDiff == nil {
-						continue
-					}
+		baseSource, revisionSource := SchemaFieldSources(operationsSources, p.opInfo.methodDiff, p.paramDiff.SchemaDiff, "type")
+		schemaDiff := p.paramDiff.SchemaDiff
+		typeDiff := schemaDiff.TypeDiff
+		formatDiff := schemaDiff.FormatDiff
 
-					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramDiff.SchemaDiff, "type")
-					schemaDiff := paramDiff.SchemaDiff
-					typeDiff := schemaDiff.TypeDiff
-					formatDiff := schemaDiff.FormatDiff
+		if !typeDiff.Empty() || !formatDiff.Empty() {
 
-					if !typeDiff.Empty() || !formatDiff.Empty() {
+			id := RequestParameterTypeGeneralizedId
+			comment := ""
 
-						id := RequestParameterTypeGeneralizedId
-						comment := ""
-
-						// The parameter's own value is serialized as a string on the wire
-						// (query/path/header/cookie), so it is non-strongly-typed: a binary
-						// generalized/changed verdict with stronglyTyped=false. This differs
-						// on purpose from the property-level check below, which cannot tell
-						// how an object parameter is serialized and therefore forks three ways.
-						if typeOrFormatBreaking(typeDiff, formatDiff, false, schemaDiff.Revision.Type) {
-							if isParameterScalarToFormExplodeArray(paramDiff, typeDiff) {
-								// The type change would otherwise be breaking; explain why
-								// widening to a form/explode array is safe so the verdict is
-								// not surprising.
-								comment = RequestParameterTypeFormExplodeArrayCommentId
-							} else {
-								id = RequestParameterTypeChangedId
-							}
-						}
-
-						result = append(result, opInfo.NewApiChange(
-							id,
-							[]any{paramLocation, paramName, getTypeFormatDimension(schemaDiff), getBaseTypeFormat(schemaDiff), getRevisionTypeFormat(schemaDiff)},
-							comment,
-						).WithSchema(schemaDiff).WithSources(baseSource, revisionSource))
-					}
-
-					checkModifiedPropertiesDiff(
-						schemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "type")
-							schemaDiff := propertyDiff
-							typeDiff := schemaDiff.TypeDiff
-							formatDiff := schemaDiff.FormatDiff
-
-							if !typeDiff.Empty() || !formatDiff.Empty() {
-
-								id, comment := checkRequestParameterPropertyTypeChanged(typeDiff, formatDiff, schemaDiff)
-
-								result = append(result, opInfo.NewApiChange(
-									id,
-									[]any{paramLocation, paramName, getTypeFormatDimension(schemaDiff), propertyFullName(propertyPath, propertyName), getBaseTypeFormat(schemaDiff), getRevisionTypeFormat(schemaDiff)},
-									comment,
-								).WithSchema(schemaDiff).WithSources(propBaseSource, propRevisionSource))
-							}
-						})
+			// The parameter's own value is serialized as a string on the wire
+			// (query/path/header/cookie), so it is non-strongly-typed: a binary
+			// generalized/changed verdict with stronglyTyped=false. This differs
+			// on purpose from the property-level check below, which cannot tell
+			// how an object parameter is serialized and therefore forks three ways.
+			if typeOrFormatBreaking(typeDiff, formatDiff, false, schemaDiff.Revision.Type) {
+				if isParameterScalarToFormExplodeArray(p.paramDiff, typeDiff) {
+					// The type change would otherwise be breaking; explain why
+					// widening to a form/explode array is safe so the verdict is
+					// not surprising.
+					comment = RequestParameterTypeFormExplodeArrayCommentId
+				} else {
+					id = RequestParameterTypeChangedId
 				}
 			}
+
+			result = append(result, p.opInfo.NewApiChange(
+				id,
+				[]any{p.location, p.name, getTypeFormatDimension(schemaDiff), getBaseTypeFormat(schemaDiff), getRevisionTypeFormat(schemaDiff)},
+				comment,
+			).WithSchema(schemaDiff).WithSources(baseSource, revisionSource))
 		}
-	}
+
+		checkModifiedPropertiesDiff(
+			schemaDiff,
+			func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
+
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, p.opInfo.methodDiff, propertyDiff, "type")
+				schemaDiff := propertyDiff
+				typeDiff := schemaDiff.TypeDiff
+				formatDiff := schemaDiff.FormatDiff
+
+				if !typeDiff.Empty() || !formatDiff.Empty() {
+
+					id, comment := checkRequestParameterPropertyTypeChanged(typeDiff, formatDiff, schemaDiff)
+
+					result = append(result, p.opInfo.NewApiChange(
+						id,
+						[]any{p.location, p.name, getTypeFormatDimension(schemaDiff), propertyFullName(propertyPath, propertyName), getBaseTypeFormat(schemaDiff), getRevisionTypeFormat(schemaDiff)},
+						comment,
+					).WithSchema(schemaDiff).WithSources(propBaseSource, propRevisionSource))
+				}
+			})
+	})
 	return result
 }
 

--- a/checker/check_response_header_became_nullable.go
+++ b/checker/check_response_header_became_nullable.go
@@ -16,34 +16,15 @@ const (
 // server's output and is safe (info).
 func ResponseHeaderBecameNullableCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedResponseHeaders(diffReport, operationsSources, config, func(h headerInfo) {
+		if id := nullabilityChangeId(h.headerDiff.SchemaDiff, ResponseHeaderBecameNullableId, ResponseHeaderBecameNotNullableId); id != "" {
+			baseSource, revisionSource := headerSources(operationsSources, h.opInfo.methodDiff, h.responseDiff, h.name)
+			result = append(result, h.opInfo.NewApiChange(
+				id,
+				[]any{h.name, h.responseStatus},
+				"",
+			).WithSources(baseSource, revisionSource))
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
-			}
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff.HeadersDiff == nil {
-					continue
-				}
-				for headerName, headerDiff := range responseDiff.HeadersDiff.Modified {
-					if id := nullabilityChangeId(headerDiff.SchemaDiff, ResponseHeaderBecameNullableId, ResponseHeaderBecameNotNullableId); id != "" {
-						baseSource, revisionSource := headerSources(operationsSources, operationItem, responseDiff, headerName)
-						result = append(result, opInfo.NewApiChange(
-							id,
-							[]any{headerName, responseStatus},
-							"",
-						).WithSources(baseSource, revisionSource))
-					}
-				}
-			}
-		}
-	}
+	})
 	return result
 }

--- a/checker/check_response_header_became_optional.go
+++ b/checker/check_response_header_became_optional.go
@@ -10,44 +10,21 @@ const (
 
 func ResponseHeaderBecameOptionalCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedResponseHeaders(diffReport, operationsSources, config, func(h headerInfo) {
+		requiredDiff := h.headerDiff.RequiredDiff
+		if requiredDiff == nil {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil {
-				continue
-			}
-			if operationItem.ResponsesDiff.Modified == nil {
-				continue
-			}
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff.HeadersDiff == nil {
-					continue
-				}
-
-				for headerName, headerDiff := range responseDiff.HeadersDiff.Modified {
-					requiredDiff := headerDiff.RequiredDiff
-					if requiredDiff == nil {
-						continue
-					}
-					if requiredDiff.From != true {
-						continue
-					}
-
-					baseSource, revisionSource := headerSources(operationsSources, operationItem, responseDiff, headerName)
-					result = append(result, opInfo.NewApiChange(
-						ResponseHeaderBecameOptionalId,
-						[]any{headerName, responseStatus},
-						"",
-					).WithSources(baseSource, revisionSource))
-				}
-			}
+		if requiredDiff.From != true {
+			return
 		}
-	}
+
+		baseSource, revisionSource := headerSources(operationsSources, h.opInfo.methodDiff, h.responseDiff, h.name)
+		result = append(result, h.opInfo.NewApiChange(
+			ResponseHeaderBecameOptionalId,
+			[]any{h.name, h.responseStatus},
+			"",
+		).WithSources(baseSource, revisionSource))
+	})
 	return result
 }

--- a/checker/check_response_header_type_changed.go
+++ b/checker/check_response_header_type_changed.go
@@ -28,54 +28,35 @@ const (
 // string/date-time -> integer -- is breaking on the format axis.
 func ResponseHeaderTypeChangedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedResponseHeaders(diffReport, operationsSources, config, func(h headerInfo) {
+		// Only the simple schema serialization (the common case), where
+		// the value is text on the wire and non-strongly-typed. A header
+		// serialized via `content` (e.g. content: application/json)
+		// produces a ContentDiff, not a SchemaDiff, and would be
+		// strongly typed; that is a separate slice, not covered here.
+		schemaDiff := h.headerDiff.SchemaDiff
+		if schemaDiff == nil || schemaDiff.Base == nil || schemaDiff.Revision == nil {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
-			}
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff.HeadersDiff == nil {
-					continue
-				}
-				for headerName, headerDiff := range responseDiff.HeadersDiff.Modified {
-					// Only the simple schema serialization (the common case), where
-					// the value is text on the wire and non-strongly-typed. A header
-					// serialized via `content` (e.g. content: application/json)
-					// produces a ContentDiff, not a SchemaDiff, and would be
-					// strongly typed; that is a separate slice, not covered here.
-					schemaDiff := headerDiff.SchemaDiff
-					if schemaDiff == nil || schemaDiff.Base == nil || schemaDiff.Revision == nil {
-						continue
-					}
-					typeDiff := schemaDiff.TypeDiff
-					formatDiff := schemaDiff.FormatDiff
-					if typeDiff.Empty() && formatDiff.Empty() {
-						continue
-					}
-
-					// A header value is text on the wire, never a strongly typed
-					// media type, so stronglyTyped is false (like a scalar
-					// parameter); the compatible verdict carries a header-specific
-					// comment rather than the shared media-type (XML) one.
-					id, comment := responseTypeChangeId(typeDiff, formatDiff, false, ResponseHeaderTypeCompatibleCommentId, schemaDiff,
-						ResponseHeaderTypeSpecializedId, ResponseHeaderTypeCompatibleId, ResponseHeaderTypeGeneralizedId, ResponseHeaderTypeChangedId)
-
-					baseSource, revisionSource := headerSources(operationsSources, operationItem, responseDiff, headerName)
-					result = append(result, opInfo.NewApiChange(
-						id,
-						[]any{headerName, getTypeFormatDimension(schemaDiff), getBaseTypeFormat(schemaDiff), getRevisionTypeFormat(schemaDiff), responseStatus},
-						comment,
-					).WithSchema(schemaDiff).WithSources(baseSource, revisionSource))
-				}
-			}
+		typeDiff := schemaDiff.TypeDiff
+		formatDiff := schemaDiff.FormatDiff
+		if typeDiff.Empty() && formatDiff.Empty() {
+			return
 		}
-	}
+
+		// A header value is text on the wire, never a strongly typed
+		// media type, so stronglyTyped is false (like a scalar
+		// parameter); the compatible verdict carries a header-specific
+		// comment rather than the shared media-type (XML) one.
+		id, comment := responseTypeChangeId(typeDiff, formatDiff, false, ResponseHeaderTypeCompatibleCommentId, schemaDiff,
+			ResponseHeaderTypeSpecializedId, ResponseHeaderTypeCompatibleId, ResponseHeaderTypeGeneralizedId, ResponseHeaderTypeChangedId)
+
+		baseSource, revisionSource := headerSources(operationsSources, h.opInfo.methodDiff, h.responseDiff, h.name)
+		result = append(result, h.opInfo.NewApiChange(
+			id,
+			[]any{h.name, getTypeFormatDimension(schemaDiff), getBaseTypeFormat(schemaDiff), getRevisionTypeFormat(schemaDiff), h.responseStatus},
+			comment,
+		).WithSchema(schemaDiff).WithSources(baseSource, revisionSource))
+	})
 	return result
 }

--- a/checker/parameter_walker.go
+++ b/checker/parameter_walker.go
@@ -45,6 +45,7 @@ func walkModifiedParameters(diffReport *diff.Diff, operationsSources *diff.Opera
 type headerInfo struct {
 	opInfo         opInfo
 	responseStatus string
+	responseDiff   *diff.ResponseDiff
 	name           string
 	headerDiff     *diff.HeaderDiff
 }
@@ -72,6 +73,7 @@ func walkModifiedResponseHeaders(diffReport *diff.Diff, operationsSources *diff.
 					processor(headerInfo{
 						opInfo:         opInfo,
 						responseStatus: responseStatus,
+						responseDiff:   responseDiff,
 						name:           name,
 						headerDiff:     headerDiff,
 					})


### PR DESCRIPTION
Fixes #1153.

Twenty-four parameter checks and three response-header checks each carried the same hand-rolled walk: 20 to 35 lines of paths → operations → parameters (or → responses → headers) iteration with nil guards before the first line of real work. All of them now receive their context from `walkModifiedParameters` / `walkModifiedResponseHeaders` (introduced in #1191), continuing the walker consolidation of #936, #1121, #1150 and #1151. Net: **minus ~500 lines**, and every future parameter or header check starts from the walker instead of the closest copy-paste.

Notes for review:

- **No behaviour changes.** The full suite passes unmodified — every existing test pins its check's output, which is what makes a mechanical migration of this size reviewable.
- `headerInfo` gains `responseDiff`, which the header checks need for source lookups.
- The deprecation and sunset checks previously built their operation context via `pathItem.Revision.GetOperation(method)`; the walker's `opInfo` carries both sides through the method diff directly, which also holds for OpenAPI 3.2 custom methods, where a fixed-name lookup would not.
- The header-parameter checks' `paramLocation != "header"` filter moves inside the callback.

Built on #1206 (the min-items fix touched two of these files); contains its commit until that merges.