### PR TITLE
Promote the severity law into the rules package

### DIFF
--- a/checker/rule_severity_law_test.go
+++ b/checker/rule_severity_law_test.go
@@ -6,81 +6,14 @@ import (
 	"github.com/oasdiff/oasdiff/checker"
 )
 
-// The severity law: a rule's expected level follows from its declared Effect
-// and Guards and its Direction. TestSeverityLaw enforces that every rule's
-// stored level equals the derived one or appears in severityDeviations with a
-// reason, and that no deviation entry is stale. Severity is thereby one
-// reviewed table plus a ledger of exceptions instead of 558 independent
-// choices.
-//
-// A deviation is either below the law, a milder verdict than the effect
-// implies, or above it. The two are not equally suspect: reporting a breaking
-// change as safe ships it silently, so a milder verdict owes a proof that the
-// change is safe for every consumer that conformed to the old contract, while
-// a harsher one costs a reviewer a glance and needs only a reason. "It is
-// sometimes legitimately required" is a reason to accept a breaking change,
-// not a reason it is not one, and belongs in --severity-levels rather than in
-// the default verdict.
-
-// expectedLevel derives a rule's level from the law.
-func expectedLevel(r checker.BackwardCompatibilityRule) checker.Level {
-	effect := r.Effect
-	direction := r.Direction
-	for _, g := range r.Guards {
-		switch g {
-		case checker.GuardReadOnly:
-			// a readOnly property does not appear in requests
-			if direction == checker.DirectionRequest {
-				effect = checker.EffectNone
-			}
-		case checker.GuardWriteOnly:
-			// a writeOnly property does not appear in responses
-			if direction == checker.DirectionResponse {
-				effect = checker.EffectNone
-			}
-		case checker.GuardNonSuccess:
-			// the responses map does not promise that the server returns
-			// only the statuses it lists
-			effect = checker.EffectNone
-		case checker.GuardSanctioned:
-			// the deprecation contract was honored
-			return checker.INFO
-		case checker.GuardNegotiated:
-			// the client chooses or relies on the variant
-			direction = checker.DirectionRequest
-		}
-	}
-
-	switch effect {
-	case checker.EffectViolation, checker.EffectIncomparable:
-		return checker.ERR
-	case checker.EffectNone:
-		return checker.INFO
-	case checker.EffectUnknown:
-		return checker.WARN
-	case checker.EffectNarrows:
-		if direction == checker.DirectionResponse {
-			return checker.INFO
-		}
-		return checker.ERR
-	case checker.EffectWidens:
-		if direction == checker.DirectionResponse {
-			return checker.ERR
-		}
-		return checker.INFO
-	}
-	return checker.INFO
-}
-
-// severityDeviations records every rule whose stored level deviates from the
-// law, with the reason. An unexplained mismatch and a stale entry both fail
-// TestSeverityLaw.
-var severityDeviations = map[string]string{}
-
+// Every rule's stored level equals the one the severity law derives
+// (rules.DeriveLevel) or appears in severityDeviations with a reason, and no
+// deviation entry is stale. Severity is thereby one reviewed function plus a
+// ledger of exceptions instead of hundreds of independent choices.
 func TestSeverityLaw(t *testing.T) {
 	seen := map[string]bool{}
 	for _, rule := range checker.GetAllRules() {
-		derived := expectedLevel(rule)
+		derived := rule.DerivedLevel()
 		if derived == rule.Level {
 			if _, ok := severityDeviations[rule.Id]; ok {
 				t.Errorf("stale severity deviation: %q\n  the stored level now matches the law; remove the entry", rule.Id)
@@ -101,6 +34,11 @@ func TestSeverityLaw(t *testing.T) {
 		}
 	}
 }
+
+// severityDeviations records every rule whose stored level deviates from the
+// law, with the reason. An unexplained mismatch and a stale entry both fail
+// TestSeverityLaw.
+var severityDeviations = map[string]string{}
 
 func ruleExists(id string) bool {
 	for _, rule := range checker.GetAllRules() {

--- a/checker/rules/derive.go
+++ b/checker/rules/derive.go
@@ -1,0 +1,68 @@
+package rules
+
+// DeriveLevel is the severity law: a rule's level follows from what the
+// change does to the contract (effect), which side of the wire it judges
+// (direction), and the document states that qualify the verdict (guards).
+//
+// The law is asymmetric on purpose. Reporting a breaking change as safe
+// ships it silently, so a milder verdict than the effect implies owes a
+// proof that the change is safe for every consumer that conformed to the
+// old contract, while a harsher one costs a reviewer a glance and needs
+// only a reason. "It is sometimes legitimately required" is a reason to
+// accept a breaking change, not a reason it is not one, and belongs in
+// --severity-levels rather than in the default verdict.
+//
+// The guards are applied first, then the effect and direction decide:
+// narrowing breaks request consumers, widening breaks response consumers,
+// an incomparable change breaks both, and an unknown one is a warning.
+func DeriveLevel(effect Effect, direction Direction, guards ...Guard) Level {
+	for _, g := range guards {
+		switch g {
+		case GuardReadOnly:
+			// a readOnly property does not appear in requests
+			if direction == DirectionRequest {
+				effect = EffectNone
+			}
+		case GuardWriteOnly:
+			// a writeOnly property does not appear in responses
+			if direction == DirectionResponse {
+				effect = EffectNone
+			}
+		case GuardNonSuccess:
+			// the responses map does not promise that the server returns
+			// only the statuses it lists
+			effect = EffectNone
+		case GuardSanctioned:
+			// the deprecation contract was honored
+			return INFO
+		case GuardNegotiated:
+			// the client chooses or relies on the variant
+			direction = DirectionRequest
+		}
+	}
+
+	switch effect {
+	case EffectViolation, EffectIncomparable:
+		return ERR
+	case EffectNone:
+		return INFO
+	case EffectUnknown:
+		return WARN
+	case EffectNarrows:
+		if direction == DirectionResponse {
+			return INFO
+		}
+		return ERR
+	case EffectWidens:
+		if direction == DirectionResponse {
+			return ERR
+		}
+		return INFO
+	}
+	return INFO
+}
+
+// DerivedLevel applies the severity law to the rule's own metadata.
+func (r Rule) DerivedLevel() Level {
+	return DeriveLevel(r.Effect, r.Direction, r.Guards...)
+}

--- a/checker/rules/derive.go
+++ b/checker/rules/derive.go
@@ -11,11 +11,15 @@ package rules
 // only a reason. "It is sometimes legitimately required" is a reason to
 // accept a breaking change, not a reason it is not one, and belongs in
 // --severity-levels rather than in the default verdict.
-//
-// The guards are applied first, then the effect and direction decide:
-// narrowing breaks request consumers, widening breaks response consumers,
-// an incomparable change breaks both, and an unknown one is a warning.
 func DeriveLevel(effect Effect, direction Direction, guards ...Guard) Level {
+	effect, direction = applyGuards(effect, direction, guards)
+	return levelOf(effect, direction)
+}
+
+// applyGuards requalifies the effect and direction by the document states
+// the guards name: a guard either nullifies the effect on the side it
+// speaks about or changes which side the change is judged on.
+func applyGuards(effect Effect, direction Direction, guards []Guard) (Effect, Direction) {
 	for _, g := range guards {
 		switch g {
 		case GuardReadOnly:
@@ -34,13 +38,19 @@ func DeriveLevel(effect Effect, direction Direction, guards ...Guard) Level {
 			effect = EffectNone
 		case GuardSanctioned:
 			// the deprecation contract was honored
-			return INFO
+			effect = EffectNone
 		case GuardNegotiated:
 			// the client chooses or relies on the variant
 			direction = DirectionRequest
 		}
 	}
+	return effect, direction
+}
 
+// levelOf maps effect and direction to a level: narrowing breaks request
+// consumers, widening breaks response consumers, an incomparable change
+// breaks both, and an unknown one is a warning.
+func levelOf(effect Effect, direction Direction) Level {
 	switch effect {
 	case EffectViolation, EffectIncomparable:
 		return ERR

--- a/checker/rules/derive.go
+++ b/checker/rules/derive.go
@@ -71,8 +71,3 @@ func levelOf(effect Effect, direction Direction) Level {
 	}
 	return INFO
 }
-
-// DerivedLevel applies the severity law to the rule's own metadata.
-func (r Rule) DerivedLevel() Level {
-	return DeriveLevel(r.Effect, r.Direction, r.Guards...)
-}

--- a/checker/rules/derive_test.go
+++ b/checker/rules/derive_test.go
@@ -1,0 +1,71 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/oasdiff/oasdiff/checker/rules"
+	"github.com/stretchr/testify/require"
+)
+
+// The effect and direction cells of the law, with no guards: narrowing
+// breaks request consumers, widening breaks response consumers, an
+// incomparable change breaks both, an unknown one warns, and a violation is
+// an error on either side.
+func TestDeriveLevel(t *testing.T) {
+	for _, tc := range []struct {
+		effect    rules.Effect
+		direction rules.Direction
+		level     rules.Level
+	}{
+		{rules.EffectNarrows, rules.DirectionRequest, rules.ERR},
+		{rules.EffectNarrows, rules.DirectionResponse, rules.INFO},
+		{rules.EffectWidens, rules.DirectionRequest, rules.INFO},
+		{rules.EffectWidens, rules.DirectionResponse, rules.ERR},
+		{rules.EffectIncomparable, rules.DirectionRequest, rules.ERR},
+		{rules.EffectIncomparable, rules.DirectionResponse, rules.ERR},
+		{rules.EffectViolation, rules.DirectionRequest, rules.ERR},
+		{rules.EffectViolation, rules.DirectionResponse, rules.ERR},
+		{rules.EffectUnknown, rules.DirectionRequest, rules.WARN},
+		{rules.EffectUnknown, rules.DirectionResponse, rules.WARN},
+		{rules.EffectNone, rules.DirectionRequest, rules.INFO},
+		{rules.EffectNone, rules.DirectionResponse, rules.INFO},
+		{rules.EffectNarrows, rules.DirectionNone, rules.ERR},
+		{rules.EffectWidens, rules.DirectionNone, rules.INFO},
+	} {
+		require.Equal(t, tc.level, rules.DeriveLevel(tc.effect, tc.direction),
+			"effect=%s direction=%s", tc.effect, tc.direction)
+	}
+}
+
+// A guard nullifies or requalifies the effect only on the side it speaks
+// about: readOnly removes a property from requests, writeOnly from
+// responses, and on the other side each leaves the verdict alone.
+func TestDeriveLevelGuards(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		effect    rules.Effect
+		direction rules.Direction
+		guard     rules.Guard
+		level     rules.Level
+	}{
+		{"readOnly nullifies a request narrowing", rules.EffectNarrows, rules.DirectionRequest, rules.GuardReadOnly, rules.INFO},
+		{"readOnly leaves a response widening breaking", rules.EffectWidens, rules.DirectionResponse, rules.GuardReadOnly, rules.ERR},
+		{"writeOnly nullifies a response widening", rules.EffectWidens, rules.DirectionResponse, rules.GuardWriteOnly, rules.INFO},
+		{"writeOnly leaves a request narrowing breaking", rules.EffectNarrows, rules.DirectionRequest, rules.GuardWriteOnly, rules.ERR},
+		{"non-success nullifies on either side", rules.EffectWidens, rules.DirectionResponse, rules.GuardNonSuccess, rules.INFO},
+		{"sanctioned is info even for a violation", rules.EffectViolation, rules.DirectionRequest, rules.GuardSanctioned, rules.INFO},
+		{"negotiated gives a response narrowing request polarity", rules.EffectNarrows, rules.DirectionResponse, rules.GuardNegotiated, rules.ERR},
+		{"negotiated makes a response widening safe", rules.EffectWidens, rules.DirectionResponse, rules.GuardNegotiated, rules.INFO},
+	} {
+		require.Equal(t, tc.level, rules.DeriveLevel(tc.effect, tc.direction, tc.guard), tc.name)
+	}
+}
+
+func TestDerivedLevel(t *testing.T) {
+	r := rules.Rule{
+		Effect:    rules.EffectNarrows,
+		Direction: rules.DirectionRequest,
+		Guards:    []rules.Guard{rules.GuardReadOnly},
+	}
+	require.Equal(t, rules.INFO, r.DerivedLevel())
+}

--- a/checker/rules/derive_test.go
+++ b/checker/rules/derive_test.go
@@ -60,12 +60,3 @@ func TestDeriveLevelGuards(t *testing.T) {
 		require.Equal(t, tc.level, rules.DeriveLevel(tc.effect, tc.direction, tc.guard), tc.name)
 	}
 }
-
-func TestDerivedLevel(t *testing.T) {
-	r := rules.Rule{
-		Effect:    rules.EffectNarrows,
-		Direction: rules.DirectionRequest,
-		Guards:    []rules.Guard{rules.GuardReadOnly},
-	}
-	require.Equal(t, rules.INFO, r.DerivedLevel())
-}

--- a/checker/rules/rule.go
+++ b/checker/rules/rule.go
@@ -44,3 +44,8 @@ func (r Rule) Actions() []metaschema.Action {
 	slices.Sort(actions)
 	return actions
 }
+
+// DerivedLevel applies the severity law to the rule's own metadata.
+func (r Rule) DerivedLevel() Level {
+	return DeriveLevel(r.Effect, r.Direction, r.Guards...)
+}

--- a/checker/rules/rule_test.go
+++ b/checker/rules/rule_test.go
@@ -1,0 +1,17 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/oasdiff/oasdiff/checker/rules"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDerivedLevel(t *testing.T) {
+	r := rules.Rule{
+		Effect:    rules.EffectNarrows,
+		Direction: rules.DirectionRequest,
+		Guards:    []rules.Guard{rules.GuardReadOnly},
+	}
+	require.Equal(t, rules.INFO, r.DerivedLevel())
+}


### PR DESCRIPTION
## What

Moves the severity-law derivation out of `rule_severity_law_test.go` into `checker/rules` as public API:

- `rules.DeriveLevel(effect, direction, guards...)` — the law itself: guards apply first (readOnly/writeOnly/non-success nullify the effect on the side they speak about, sanctioned resolves to info, negotiated gives the change request polarity), then effect and direction decide.
- `rules.Rule.DerivedLevel()` — the law applied to a rule's own metadata, promoted onto `BackwardCompatibilityRule` via the embedded `Rule`.

`TestSeverityLaw` keeps only the enforcement: every stored level equals the derived one or has a deviation-ledger entry (the ledger remains empty). The law gains direct unit tests per effect, direction, and guard cell, so its behavior is pinned independently of what the registry happens to contain.

## Why

The derivation had four pending consumers and lived where only one could reach it: the runtime needs it to apply context guards per change (#1211), `explain`-style output wants to show why a level is what it is (#1197), witness generation wants the same table (#1201), and the test needs it as before. No behavior changes in this PR; it is the shared prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDvUFsg5nu1NBWQffErGDw