### PR TITLE
Report read-only and write-only property changes through the guard instead of skipping

### DIFF
--- a/checker/check_request_property_list_of_types_changed.go
+++ b/checker/check_request_property_list_of_types_changed.go
@@ -28,7 +28,7 @@ func RequestPropertyListOfTypesChangedCheck(diffReport *diff.Diff, operationsSou
 
 		// Property-level
 		info.walkProperties(func(p propertyInfo) {
-			if p.propertyDiff.Revision == nil || p.propertyDiff.Revision.ReadOnly {
+			if p.propertyDiff.Revision == nil {
 				return
 			}
 			result = append(result, checkPropertyListOfTypesChange(

--- a/checker/check_request_property_max_items_set.go
+++ b/checker/check_request_property_max_items_set.go
@@ -28,9 +28,6 @@ func RequestPropertyMaxItemsSetCheck(diffReport *diff.Diff, operationsSources *d
 			if maxItemsDiff == nil || maxItemsDiff.From != nil || maxItemsDiff.To == nil {
 				return
 			}
-			if p.propertyDiff.Revision.ReadOnly {
-				return
-			}
 
 			_, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "maxItems")
 			result = append(result, p.newChange(

--- a/checker/check_request_property_max_length_set.go
+++ b/checker/check_request_property_max_length_set.go
@@ -28,9 +28,6 @@ func RequestPropertyMaxLengthSetCheck(diffReport *diff.Diff, operationsSources *
 			if maxLengthDiff == nil || maxLengthDiff.From != nil || maxLengthDiff.To == nil {
 				return
 			}
-			if p.propertyDiff.Revision.ReadOnly {
-				return
-			}
 
 			_, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "maxLength")
 			result = append(result, p.newChange(

--- a/checker/check_request_property_max_properties_set.go
+++ b/checker/check_request_property_max_properties_set.go
@@ -28,9 +28,6 @@ func RequestPropertyMaxPropertiesSetCheck(diffReport *diff.Diff, operationsSourc
 			if maxPropertiesDiff == nil || maxPropertiesDiff.From != nil || maxPropertiesDiff.To == nil {
 				return
 			}
-			if p.propertyDiff.Revision.ReadOnly {
-				return
-			}
 
 			_, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "maxProperties")
 			result = append(result, p.newChange(

--- a/checker/check_request_property_max_set.go
+++ b/checker/check_request_property_max_set.go
@@ -37,9 +37,6 @@ func RequestPropertyMaxSetCheck(diffReport *diff.Diff, operationsSources *diff.O
 		}
 
 		info.walkProperties(func(p propertyInfo) {
-			if p.propertyDiff.Revision.ReadOnly {
-				return
-			}
 			propName := propertyFullName(p.propertyPath, p.propertyName)
 
 			if maxDiff := p.propertyDiff.MaxDiff; maxDiff != nil &&

--- a/checker/check_request_property_min_items_increased.go
+++ b/checker/check_request_property_min_items_increased.go
@@ -28,9 +28,6 @@ func RequestPropertyMinItemsIncreasedCheck(diffReport *diff.Diff, operationsSour
 			if minItemsDiff == nil || uintBoundSet(minItemsDiff) {
 				return
 			}
-			if p.propertyDiff.Revision.ReadOnly {
-				return
-			}
 			if !isIncreasedValue(minItemsDiff) {
 				return
 			}

--- a/checker/check_request_property_min_items_set.go
+++ b/checker/check_request_property_min_items_set.go
@@ -27,9 +27,6 @@ func RequestPropertyMinItemsSetCheck(diffReport *diff.Diff, operationsSources *d
 			if !uintBoundSet(minItemsDiff) {
 				return
 			}
-			if p.propertyDiff.Revision.ReadOnly {
-				return
-			}
 
 			_, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "minItems")
 			result = append(result, p.newChange(

--- a/checker/check_request_property_min_properties_increased.go
+++ b/checker/check_request_property_min_properties_increased.go
@@ -28,9 +28,6 @@ func RequestPropertyMinPropertiesIncreasedCheck(diffReport *diff.Diff, operation
 			if minPropertiesDiff == nil || minPropertiesDiff.From == nil || minPropertiesDiff.To == nil {
 				return
 			}
-			if p.propertyDiff.Revision.ReadOnly {
-				return
-			}
 			if !isIncreasedValue(minPropertiesDiff) {
 				return
 			}

--- a/checker/check_request_property_min_set.go
+++ b/checker/check_request_property_min_set.go
@@ -37,9 +37,6 @@ func RequestPropertyMinSetCheck(diffReport *diff.Diff, operationsSources *diff.O
 		}
 
 		info.walkProperties(func(p propertyInfo) {
-			if p.propertyDiff.Revision.ReadOnly {
-				return
-			}
 			propName := propertyFullName(p.propertyPath, p.propertyName)
 
 			if minDiff := p.propertyDiff.MinDiff; minDiff != nil &&

--- a/checker/check_request_property_multiple_of_updated.go
+++ b/checker/check_request_property_multiple_of_updated.go
@@ -74,10 +74,6 @@ func RequestPropertyMultipleOfUpdatedCheck(diffReport *diff.Diff, operationsSour
 			if multipleOfDiff == nil {
 				return
 			}
-			// narrowing a read-only property does not affect requests
-			if p.propertyDiff.Revision.ReadOnly && multipleOfDiff.To != nil {
-				return
-			}
 
 			propName := propertyFullName(p.propertyPath, p.propertyName)
 			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "multipleOf")

--- a/checker/check_request_property_type_changed.go
+++ b/checker/check_request_property_type_changed.go
@@ -55,9 +55,6 @@ func RequestPropertyTypeChangedCheck(diffReport *diff.Diff, operationsSources *d
 			if p.propertyDiff.Revision == nil {
 				return
 			}
-			if p.propertyDiff.Revision.ReadOnly {
-				return
-			}
 
 			propSchemaDiff := p.propertyDiff
 			propTypeDiff := propSchemaDiff.TypeDiff

--- a/checker/check_request_property_type_changed_test.go
+++ b/checker/check_request_property_type_changed_test.go
@@ -302,7 +302,8 @@ func TestRequestPropertyTypeChangedNoSchemaDiff(t *testing.T) {
 	require.Len(t, errs, 0)
 }
 
-// no changes when property is read-only
+// a type change on a read-only request property cannot invalidate a request:
+// the read-only guard reports it at info with a comment naming the reason.
 func TestRequestPropertyTypeChangedReadOnlyProperty(t *testing.T) {
 	s1, err := open("../data/checker/request_property_type_changed_base.yaml")
 	require.NoError(t, err)
@@ -316,8 +317,10 @@ func TestRequestPropertyTypeChangedReadOnlyProperty(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 
-	errs := checker.RequestPropertyTypeChangedCheck(d, osm, &checker.Config{})
-	require.Len(t, errs, 0)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyTypeChangedCheck), d, osm, checker.INFO)
+	change := requireChange(t, errs, checker.RequestPropertyTypeChangedId)
+	require.Equal(t, checker.INFO, change.GetLevel())
+	require.Contains(t, change.GetComment(checker.NewDefaultLocalizer()), "read-only")
 }
 
 // setRequestBodyType sets the request body schema type on the /test POST.

--- a/checker/check_request_property_unique_items_updated.go
+++ b/checker/check_request_property_unique_items_updated.go
@@ -42,9 +42,6 @@ func RequestPropertyUniqueItemsUpdatedCheck(diffReport *diff.Diff, operationsSou
 			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "uniqueItems")
 
 			if uniqueItemsDiff.To == true {
-				if p.propertyDiff.Revision.ReadOnly {
-					return
-				}
 				result = append(result, p.newChange(
 					RequestPropertyUniqueItemsSetId,
 					[]any{propName},

--- a/checker/check_request_property_x_extensible_enum_value_removed.go
+++ b/checker/check_request_property_x_extensible_enum_value_removed.go
@@ -50,9 +50,6 @@ func RequestPropertyXExtensibleEnumValueRemovedCheck(diffReport *diff.Diff, oper
 				}
 			}
 
-			if p.propertyDiff.Revision.ReadOnly {
-				return
-			}
 			for _, enumVal := range deletedVals {
 				baseSource, revisionSource := SchemaDeletedItemSources(operationsSources, info.operationItem, p.propertyDiff, diff.XExtensibleEnumExtension, enumVal)
 				result = append(result, p.newChange(

--- a/checker/check_response_property_max_increased.go
+++ b/checker/check_response_property_max_increased.go
@@ -35,9 +35,6 @@ func ResponsePropertyMaxIncreasedCheck(diffReport *diff.Diff, operationsSources 
 		}
 
 		info.walkProperties(func(p propertyInfo) {
-			if p.propertyDiff.Revision.WriteOnly {
-				return
-			}
 			propName := propertyFullName(p.propertyPath, p.propertyName)
 
 			if maxDiff := p.propertyDiff.MaxDiff; maxDiff != nil &&

--- a/checker/check_response_property_max_items_increased.go
+++ b/checker/check_response_property_max_items_increased.go
@@ -38,10 +38,6 @@ func ResponsePropertyMaxItemsIncreasedCheck(diffReport *diff.Diff, operationsSou
 				return
 			}
 
-			if p.propertyDiff.Revision.WriteOnly {
-				return
-			}
-
 			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "maxItems")
 			result = append(result, p.newChange(
 				ResponsePropertyMaxItemsIncreasedId,

--- a/checker/check_response_property_max_length_increased.go
+++ b/checker/check_response_property_max_length_increased.go
@@ -38,10 +38,6 @@ func ResponsePropertyMaxLengthIncreasedCheck(diffReport *diff.Diff, operationsSo
 				return
 			}
 
-			if p.propertyDiff.Revision.WriteOnly {
-				return
-			}
-
 			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "maxLength")
 			result = append(result, p.newChange(
 				ResponsePropertyMaxLengthIncreasedId,

--- a/checker/check_response_property_max_length_unset.go
+++ b/checker/check_response_property_max_length_unset.go
@@ -28,9 +28,6 @@ func ResponsePropertyMaxLengthUnsetCheck(diffReport *diff.Diff, operationsSource
 			if maxLengthDiff == nil || maxLengthDiff.To != nil || maxLengthDiff.From == nil {
 				return
 			}
-			if p.propertyDiff.Revision.WriteOnly {
-				return
-			}
 
 			propBaseSource, _ := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "maxLength")
 			result = append(result, p.newChange(

--- a/checker/check_response_property_max_properties_increased.go
+++ b/checker/check_response_property_max_properties_increased.go
@@ -38,10 +38,6 @@ func ResponsePropertyMaxPropertiesIncreasedCheck(diffReport *diff.Diff, operatio
 				return
 			}
 
-			if p.propertyDiff.Revision.WriteOnly {
-				return
-			}
-
 			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "maxProperties")
 			result = append(result, p.newChange(
 				ResponsePropertyMaxPropertiesIncreasedId,

--- a/checker/check_response_property_min_decreased.go
+++ b/checker/check_response_property_min_decreased.go
@@ -35,9 +35,6 @@ func ResponsePropertyMinDecreasedCheck(diffReport *diff.Diff, operationsSources 
 		}
 
 		info.walkProperties(func(p propertyInfo) {
-			if p.propertyDiff.Revision.WriteOnly {
-				return
-			}
 			propName := propertyFullName(p.propertyPath, p.propertyName)
 
 			if minDiff := p.propertyDiff.MinDiff; minDiff != nil &&

--- a/checker/check_response_property_min_items_decreased.go
+++ b/checker/check_response_property_min_items_decreased.go
@@ -31,9 +31,6 @@ func ResponsePropertyMinItemsDecreasedCheck(diffReport *diff.Diff, operationsSou
 			if !isDecreasedValue(minItemsDiff) {
 				return
 			}
-			if p.propertyDiff.Revision.WriteOnly {
-				return
-			}
 
 			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "minItems")
 			result = append(result, p.newChange(

--- a/checker/check_response_property_min_items_unset.go
+++ b/checker/check_response_property_min_items_unset.go
@@ -27,9 +27,6 @@ func ResponsePropertyMinItemsUnsetCheck(diffReport *diff.Diff, operationsSources
 			if !uintBoundUnset(minItemsDiff) {
 				return
 			}
-			if p.propertyDiff.Revision.WriteOnly {
-				return
-			}
 
 			propBaseSource, _ := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "minItems")
 			result = append(result, p.newChange(

--- a/checker/check_response_property_min_length_decreased.go
+++ b/checker/check_response_property_min_length_decreased.go
@@ -31,9 +31,6 @@ func ResponsePropertyMinLengthDecreasedCheck(diffReport *diff.Diff, operationsSo
 			if !isDecreasedValue(minLengthDiff) {
 				return
 			}
-			if p.propertyDiff.Revision.WriteOnly {
-				return
-			}
 
 			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "minLength")
 			result = append(result, p.newChange(

--- a/checker/check_response_property_min_properties_decreased.go
+++ b/checker/check_response_property_min_properties_decreased.go
@@ -31,9 +31,6 @@ func ResponsePropertyMinPropertiesDecreasedCheck(diffReport *diff.Diff, operatio
 			if !isDecreasedValue(minPropertiesDiff) {
 				return
 			}
-			if p.propertyDiff.Revision.WriteOnly {
-				return
-			}
 
 			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "minProperties")
 			result = append(result, p.newChange(

--- a/checker/check_response_property_multiple_of_updated.go
+++ b/checker/check_response_property_multiple_of_updated.go
@@ -46,9 +46,6 @@ func ResponsePropertyMultipleOfUpdatedCheck(diffReport *diff.Diff, operationsSou
 			if multipleOfDiff == nil || multipleOfDiff.From == nil {
 				return
 			}
-			if p.propertyDiff.Revision.WriteOnly {
-				return
-			}
 
 			propName := propertyFullName(p.propertyPath, p.propertyName)
 			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "multipleOf")

--- a/checker/check_response_property_unique_items_unset.go
+++ b/checker/check_response_property_unique_items_unset.go
@@ -28,9 +28,6 @@ func ResponsePropertyUniqueItemsUnsetCheck(diffReport *diff.Diff, operationsSour
 			if uniqueItemsDiff == nil || uniqueItemsDiff.To != false {
 				return
 			}
-			if p.propertyDiff.Revision.WriteOnly {
-				return
-			}
 
 			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "uniqueItems")
 			result = append(result, p.newChange(


### PR DESCRIPTION
## What

Removes the ~25 per-check skips of the form:

```go
if p.propertyDiff.Revision.ReadOnly {
    return
}
```

(and the write-only mirrors on response checks). These predate #1213. Back then, skipping was a defensible way to avoid a false error; now it is an inconsistency: checks covered by the guard pass report a change on a read-only property at **info with a comment naming the reason**, while these checks reported **nothing at all**, purely depending on when the check was written.

With the skips gone, every such change flows through the shared creation site, the guard derives info, and the whole family behaves the same way. No check gains any read-only logic; the deletions are the entire change.

- The two entangled conditions are preserved minus the skip: `list_of_types_changed` keeps its nil-Revision guard, and `multiple_of_updated` loses its read-only special case comment along with the branch.
- The checks that emit dedicated `request-read-only-property-*` / `response-write-only-property-*` ids are untouched; those ids remain published and law-consistent.

## Behavior change

Changes that were previously invisible (for example, setting `maxLength` on a read-only request property, or increasing `maximum` on a write-only response property) now appear in the changelog at info with the explanatory comment. No error/warning-level output changes.

One test pinned the old silent behavior (`TestRequestPropertyTypeChangedReadOnlyProperty`) and now pins the corrected verdict: info with the read-only comment, through the full pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDvUFsg5nu1NBWQffErGDw