### PR TITLE
docs: minContains/maxContains set and unset coverage

### DIFF
--- a/docs/OPENAPI-31.md
+++ b/docs/OPENAPI-31.md
@@ -39,7 +39,7 @@ Changes are detected for all 3.1-specific fields:
 - **exclusiveMinimum/exclusiveMaximum**: increased/decreased/set for request body/properties/parameters and response body/properties
 - **prefixItems**: added/removed for request and response
 - **if/then/else**: added/removed for request and response
-- **contains/minContains/maxContains**: added/removed/increased/decreased
+- **contains/minContains/maxContains**: added/removed/increased/decreased, and set/unset for the bounds, at body, property, parameter, and response-header level
 - **dependentRequired**: added/removed/changed
 - **dependentSchemas**: added/removed
 - **patternProperties**: added/removed


### PR DESCRIPTION
The 3.1 coverage list predated #1215/#1219: minContains and maxContains now have set/unset checks at body, property, parameter, and response-header scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDvUFsg5nu1NBWQffErGDw