### PR TITLE
Guards in the checks output and tag vocabulary

### DIFF
--- a/checker/metaschema/action.go
+++ b/checker/metaschema/action.go
@@ -14,3 +14,6 @@ const (
 	ActionIncrease Action = "increase" // an ordered value grows
 	ActionDecrease Action = "decrease" // an ordered value shrinks
 )
+
+// Actions lists every action, in declaration order.
+var Actions = []Action{ActionAdd, ActionRemove, ActionSet, ActionUnset, ActionChange, ActionIncrease, ActionDecrease}

--- a/checker/metaschema/claim.go
+++ b/checker/metaschema/claim.go
@@ -13,15 +13,13 @@ type Claim struct {
 	Actions []Action
 }
 
-var validActions = map[Action]bool{
-	ActionAdd:      true,
-	ActionRemove:   true,
-	ActionSet:      true,
-	ActionUnset:    true,
-	ActionChange:   true,
-	ActionIncrease: true,
-	ActionDecrease: true,
-}
+var validActions = func() map[Action]bool {
+	m := make(map[Action]bool, len(Actions))
+	for _, a := range Actions {
+		m[a] = true
+	}
+	return m
+}()
 
 // ParseClaim parses "pattern:action[,action...]", e.g.
 // "paths.*.*.requestBody.content.*.schema.maxLength:decrease,unset".

--- a/checker/rules/guard.go
+++ b/checker/rules/guard.go
@@ -38,3 +38,6 @@ const (
 	// not, the reverse of plain response polarity.
 	GuardNegotiated Guard = "negotiated"
 )
+
+// Guards lists every guard, in declaration order.
+var Guards = []Guard{GuardReadOnly, GuardWriteOnly, GuardSanctioned, GuardNonSuccess, GuardHasDefault, GuardNegotiated}

--- a/checker/rules/taxonomy.go
+++ b/checker/rules/taxonomy.go
@@ -109,3 +109,6 @@ func (k Kind) String() string {
 		return "none"
 	}
 }
+
+// Kinds lists every kind, in declaration order.
+var Kinds = []Kind{KindExistence, KindRequiredness, KindMutability, KindType, KindConstraints, KindValues, KindStructure, KindLifecycle}

--- a/formatters/checks.go
+++ b/formatters/checks.go
@@ -18,6 +18,7 @@ type Check struct {
 	Kind        string   `json:"kind,omitempty" yaml:"kind,omitempty"`
 	Actions     []string `json:"actions,omitempty" yaml:"actions,omitempty"`
 	Effect      string   `json:"effect,omitempty" yaml:"effect,omitempty"`
+	Guards      []string `json:"guards,omitempty" yaml:"guards,omitempty"`
 	Locations   []string `json:"locations,omitempty" yaml:"locations,omitempty"`
 	Description string   `json:"description,omitempty" yaml:"description,omitempty"`
 	Mitigation  string   `json:"mitigation,omitempty" yaml:"mitigation,omitempty"`

--- a/formatters/format_text.go
+++ b/formatters/format_text.go
@@ -91,9 +91,9 @@ func (f TEXTFormatter) RenderChecks(checks Checks, opts RenderOpts) ([]byte, err
 	result := bytes.NewBuffer(nil)
 
 	w := tabwriter.NewWriter(result, 1, 1, 1, ' ', 0)
-	_, _ = fmt.Fprintln(w, "ID\tDESCRIPTION\tLEVEL")
+	_, _ = fmt.Fprintln(w, "ID\tDESCRIPTION\tLEVEL\tGUARDS")
 	for _, check := range checks {
-		_, _ = fmt.Fprintln(w, check.Id+"\t"+f.Localizer(check.Description)+"\t"+check.Level)
+		_, _ = fmt.Fprintln(w, check.Id+"\t"+f.Localizer(check.Description)+"\t"+check.Level+"\t"+strings.Join(check.Guards, ","))
 	}
 	_ = w.Flush()
 

--- a/formatters/format_text_test.go
+++ b/formatters/format_text_test.go
@@ -39,12 +39,13 @@ func TestTextFormatter_RenderChecks(t *testing.T) {
 			Id:          "change_id",
 			Level:       "info",
 			Description: "This is a breaking change.",
+			Guards:      []string{"read-only"},
 		},
 	}
 
 	out, err := textFormatter.RenderChecks(checks, formatters.NewRenderOpts())
 	require.NoError(t, err)
-	require.Equal(t, string(out), "ID        DESCRIPTION                LEVEL\nchange_id This is a breaking change. info\n")
+	require.Equal(t, string(out), "ID        DESCRIPTION                LEVEL GUARDS\nchange_id This is a breaking change. info  read-only\n")
 }
 
 func TestTextFormatter_RenderChangelog_EmptyChangesDifferentSpecs(t *testing.T) {

--- a/internal/checks_changelog.go
+++ b/internal/checks_changelog.go
@@ -92,6 +92,7 @@ func outputChangelogRules(stdout io.Writer, flags *Flags, rules []checker.Backwa
 			Kind:        rule.Kind.String(),
 			Actions:     actionStrings(rule.Actions()),
 			Effect:      rule.Effect.String(),
+			Guards:      guardStrings(rule.Guards),
 			Locations:   rule.Locations,
 			Description: localizer(rule.Description),
 			Mitigation:  mitigation,
@@ -151,6 +152,12 @@ var changelogTagDimensions = []tagDimension[checker.BackwardCompatibilityRule]{
 			return value == rule.Kind.String()
 		},
 	},
+	{
+		values: []string{"read-only", "write-only", "sanctioned", "non-success", "has-default", "negotiated"},
+		match: func(value string, rule checker.BackwardCompatibilityRule) bool {
+			return slices.Contains(rule.Guards, checker.Guard(value))
+		},
+	},
 }
 
 func GetChangelogTags() []string {
@@ -159,6 +166,14 @@ func GetChangelogTags() []string {
 
 func matchChangelogTags(tags []string, rule checker.BackwardCompatibilityRule) bool {
 	return matchTagDimensions(tags, changelogTagDimensions, rule)
+}
+
+func guardStrings(guards []checker.Guard) []string {
+	strs := make([]string, len(guards))
+	for i, g := range guards {
+		strs[i] = string(g)
+	}
+	return strs
 }
 
 func actionStrings(actions []metaschema.Action) []string {

--- a/internal/checks_changelog.go
+++ b/internal/checks_changelog.go
@@ -8,6 +8,7 @@ import (
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/checker/localizations"
 	"github.com/oasdiff/oasdiff/checker/metaschema"
+	"github.com/oasdiff/oasdiff/checker/rules"
 	"github.com/oasdiff/oasdiff/formatters"
 	"github.com/spf13/cobra"
 )
@@ -117,47 +118,65 @@ func outputChangelogRules(stdout io.Writer, flags *Flags, rules []checker.Backwa
 // effect (the rule's verdict), area, and kind.
 var changelogTagDimensions = []tagDimension[checker.BackwardCompatibilityRule]{
 	{
-		values: []string{"request", "response"},
+		// the two wire directions; DirectionNone is deliberately not offered,
+		// since its rules are selected by their kind (lifecycle) or area
+		values: []string{checker.DirectionRequest.String(), checker.DirectionResponse.String()},
 		match: func(value string, rule checker.BackwardCompatibilityRule) bool {
 			return value == rule.Direction.String()
 		},
 	},
 	{
-		values: []string{"add", "remove", "change", "increase", "decrease", "set", "unset"},
+		values: actionStrings(metaschema.Actions),
 		match: func(value string, rule checker.BackwardCompatibilityRule) bool {
 			return slices.Contains(rule.Actions(), metaschema.Action(value))
 		},
 	},
 	{
-		values: []string{"widens", "narrows"},
+		// only the two ordered effects; the others (incomparable, unknown,
+		// none, violation) would collide with other dimensions' vocabulary or
+		// add little as filters
+		values: []string{checker.EffectWidens.String(), checker.EffectNarrows.String()},
 		match: func(value string, rule checker.BackwardCompatibilityRule) bool {
-			switch value {
-			case "widens":
-				return rule.Effect == checker.EffectWidens
-			case "narrows":
-				return rule.Effect == checker.EffectNarrows
-			}
-			return false
+			return value == rule.Effect.String()
 		},
 	},
 	{
-		values: []string{"schema", "parameters", "requestBody", "responses", "paths", "headers", "security", "tags", "components"},
+		// the areas with rules; AreaInfo, AreaServers and AreaNone are
+		// deliberately not offered
+		values: areaStrings(rules.AreaSchema, rules.AreaParameters, rules.AreaRequestBody, rules.AreaResponses,
+			rules.AreaPaths, rules.AreaHeaders, rules.AreaSecurity, rules.AreaTags, rules.AreaComponents),
 		match: func(value string, rule checker.BackwardCompatibilityRule) bool {
 			return value == rule.Area.String()
 		},
 	},
 	{
-		values: []string{"existence", "requiredness", "mutability", "type", "constraints", "values", "structure", "lifecycle"},
+		values: kindStrings(rules.Kinds),
 		match: func(value string, rule checker.BackwardCompatibilityRule) bool {
 			return value == rule.Kind.String()
 		},
 	},
 	{
-		values: []string{"read-only", "write-only", "sanctioned", "non-success", "has-default", "negotiated"},
+		values: guardStrings(rules.Guards),
 		match: func(value string, rule checker.BackwardCompatibilityRule) bool {
 			return slices.Contains(rule.Guards, checker.Guard(value))
 		},
 	},
+}
+
+func areaStrings(areas ...rules.Area) []string {
+	strs := make([]string, len(areas))
+	for i, a := range areas {
+		strs[i] = a.String()
+	}
+	return strs
+}
+
+func kindStrings(kinds []rules.Kind) []string {
+	strs := make([]string, len(kinds))
+	for i, k := range kinds {
+		strs[i] = k.String()
+	}
+	return strs
 }
 
 func GetChangelogTags() []string {

--- a/internal/checks_changelog_test.go
+++ b/internal/checks_changelog_test.go
@@ -76,3 +76,26 @@ func TestTags_OrWithinDimension(t *testing.T) {
 	require.True(t, sawRequest, "OR within the direction dimension must include request rows")
 	require.True(t, sawResponse, "OR within the direction dimension must include response rows")
 }
+
+// Guards are output and queryable: --tags read-only selects exactly the rules
+// declaring the guard, each row carries its guards, and the id naming
+// convention stops being load-bearing for the audit.
+func Test_ChecksChangelogGuards(t *testing.T) {
+	var stdout bytes.Buffer
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog --format json --tags read-only"), &stdout, io.Discard))
+
+	var checks []map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &checks))
+	require.NotEmpty(t, checks)
+	for _, check := range checks {
+		require.Contains(t, check["guards"], "read-only", check["id"])
+	}
+}
+
+// The text format renders the guards column.
+func Test_ChecksChangelogGuardsTextColumn(t *testing.T) {
+	var stdout bytes.Buffer
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog --tags sanctioned"), &stdout, io.Discard))
+	require.Contains(t, stdout.String(), "GUARDS")
+	require.Contains(t, stdout.String(), "sanctioned")
+}

--- a/internal/viper_test.go
+++ b/internal/viper_test.go
@@ -142,7 +142,7 @@ func TestViper_InvalidTags(t *testing.T) {
 
 	cmd := cobra.Command{}
 
-	require.EqualError(t, internal.RunViper(&cmd, v), "failed to load config file: invalid tags \"invalid\", allowed values: request, response, add, remove, change, increase, decrease, set, unset, widens, narrows, schema, parameters, requestBody, responses, paths, headers, security, tags, components, existence, requiredness, mutability, type, constraints, values, structure, lifecycle, read-only, write-only, sanctioned, non-success, has-default, negotiated")
+	require.EqualError(t, internal.RunViper(&cmd, v), "failed to load config file: invalid tags \"invalid\", allowed values: request, response, add, remove, set, unset, change, increase, decrease, widens, narrows, schema, parameters, requestBody, responses, paths, headers, security, tags, components, existence, requiredness, mutability, type, constraints, values, structure, lifecycle, read-only, write-only, sanctioned, non-success, has-default, negotiated")
 }
 
 func TestViper_ValidTags(t *testing.T) {

--- a/internal/viper_test.go
+++ b/internal/viper_test.go
@@ -142,7 +142,7 @@ func TestViper_InvalidTags(t *testing.T) {
 
 	cmd := cobra.Command{}
 
-	require.EqualError(t, internal.RunViper(&cmd, v), "failed to load config file: invalid tags \"invalid\", allowed values: request, response, add, remove, change, increase, decrease, set, unset, widens, narrows, schema, parameters, requestBody, responses, paths, headers, security, tags, components, existence, requiredness, mutability, type, constraints, values, structure, lifecycle")
+	require.EqualError(t, internal.RunViper(&cmd, v), "failed to load config file: invalid tags \"invalid\", allowed values: request, response, add, remove, change, increase, decrease, set, unset, widens, narrows, schema, parameters, requestBody, responses, paths, headers, security, tags, components, existence, requiredness, mutability, type, constraints, values, structure, lifecycle, read-only, write-only, sanctioned, non-success, has-default, negotiated")
 }
 
 func TestViper_ValidTags(t *testing.T) {


### PR DESCRIPTION
Closes #1210. `oasdiff checks changelog` now exposes guards everywhere its other dimensions appear:

- **json/yaml**: a `guards` list on each row (omitted when empty), so downstream consumers, the oasdiff.com catalog and the published change model included, see the same field.
- **text**: a GUARDS column.
- **--tags**: the six guard values join the vocabulary, so `--tags read-only` selects the guard family directly and the audit the issue describes is one query. The vocabulary-driven test (every tag selects at least one rule) covers the new dimension automatically; dedicated tests pin the json field, the tag filter, and the text column.

This also completes the two-level story from #1213: the catalog can now say which checks derive their verdicts through guards, without the id naming convention being load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDvUFsg5nu1NBWQffErGDw