### PR TITLE
validate: flag mutability flags no side can ever see

### DIFF
--- a/data/validate/read-only-only-in-requests.yaml
+++ b/data/validate/read-only-only-in-requests.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /items:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  readOnly: true
+      responses:
+        '200':
+          description: OK

--- a/data/validate/write-only-only-in-responses.yaml
+++ b/data/validate/write-only-only-in-responses.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  secret:
+                    type: string
+                    writeOnly: true

--- a/internal/validate_test.go
+++ b/internal/validate_test.go
@@ -542,3 +542,32 @@ func Test_ValidateCmd_InvalidSecuritySchemes(t *testing.T) {
 	require.Contains(t, out, "[security-scheme-http-scheme-invalid]")
 	require.Contains(t, out, "[security-scheme-apikey-in-invalid]")
 }
+
+// The fixture's `readOnly: true` is on line 16; the finding pins the flag
+// itself, not the property or the schema.
+func Test_ValidateCmd_ReadOnlyOnlyInRequests(t *testing.T) {
+	var stdout bytes.Buffer
+	require.Equal(t, 1, internal.Run(cmdToArgs("oasdiff validate -f yaml --fail-on INFO ../data/validate/read-only-only-in-requests.yaml"), &stdout, io.Discard))
+
+	var findings []map[string]any
+	require.NoError(t, yaml.Unmarshal(stdout.Bytes(), &findings))
+	require.Len(t, findings, 1)
+	require.Equal(t, "read-only-property-only-in-requests", findings[0]["id"])
+	src := findings[0]["source"].(map[string]any)
+	require.Equal(t, 16, src["line"], "should pin the readOnly flag line")
+	require.Equal(t, 19, src["column"])
+}
+
+// The mirror: `writeOnly: true` on line 18 of the response-only fixture.
+func Test_ValidateCmd_WriteOnlyOnlyInResponses(t *testing.T) {
+	var stdout bytes.Buffer
+	require.Equal(t, 1, internal.Run(cmdToArgs("oasdiff validate -f yaml --fail-on INFO ../data/validate/write-only-only-in-responses.yaml"), &stdout, io.Discard))
+
+	var findings []map[string]any
+	require.NoError(t, yaml.Unmarshal(stdout.Bytes(), &findings))
+	require.Len(t, findings, 1)
+	require.Equal(t, "write-only-property-only-in-responses", findings[0]["id"])
+	src := findings[0]["source"].(map[string]any)
+	require.Equal(t, 18, src["line"], "should pin the writeOnly flag line")
+	require.Equal(t, 21, src["column"])
+}

--- a/validate/lint_mutability_reachability.go
+++ b/validate/lint_mutability_reachability.go
@@ -1,0 +1,192 @@
+package validate
+
+import (
+	"fmt"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/oasdiff/checker"
+	"github.com/oasdiff/oasdiff/formatters"
+)
+
+// ReadOnlyOnlyInRequestsID flags a readOnly property whose schema is
+// reachable only from request bodies and parameters. A readOnly property
+// never appears in a request, so in a schema no response uses it declares a
+// property that can never appear anywhere: either the flag or the schema's
+// usage is wrong. WriteOnlyOnlyInResponsesID is the mirror for writeOnly
+// properties in schemas no request uses. Valid OpenAPI, oasdiff-native
+// SHOULD-level lints; the flags also drive the changelog's read-only and
+// write-only verdicts, so a wrong flag silently mutes breaking-change
+// detection for the property.
+const (
+	ReadOnlyOnlyInRequestsID   = "read-only-property-only-in-requests"
+	WriteOnlyOnlyInResponsesID = "write-only-property-only-in-responses"
+)
+
+// lintMutabilityReachability reports, at WARN, every readOnly property
+// reachable only from the request side and every writeOnly property
+// reachable only from the response side. Reachability is computed from the
+// operations (including webhooks and callbacks) by schema identity, which
+// resolved $refs share, so a component schema used by both sides clears
+// its properties wherever they are reported.
+func lintMutabilityReachability(spec *openapi3.T, source string) formatters.Findings {
+	requestReachable := map[*openapi3.Schema]bool{}
+	responseReachable := map[*openapi3.Schema]bool{}
+
+	if spec.Paths != nil {
+		for _, pathItem := range spec.Paths.Map() {
+			markPathItem(pathItem, requestReachable, responseReachable)
+		}
+	}
+	for _, pathItem := range spec.Webhooks {
+		markPathItem(pathItem, requestReachable, responseReachable)
+	}
+
+	var findings formatters.Findings
+	_ = spec.WalkSchemas(func(jsonPointer string, ref *openapi3.SchemaRef) error {
+		for name, prop := range ref.Value.Properties {
+			p := prop.Value
+			if p == nil {
+				continue
+			}
+			if p.ReadOnly && requestReachable[p] && !responseReachable[p] {
+				findings = append(findings, newMutabilityReachabilityFinding(
+					ReadOnlyOnlyInRequestsID,
+					fmt.Sprintf("readOnly property %q is only reachable from the request side, where a readOnly property never appears; either the flag or the schema's usage is wrong", name),
+					jsonPointer+"/properties/"+name, name, p, "readOnly", source))
+			}
+			if p.WriteOnly && responseReachable[p] && !requestReachable[p] {
+				findings = append(findings, newMutabilityReachabilityFinding(
+					WriteOnlyOnlyInResponsesID,
+					fmt.Sprintf("writeOnly property %q is only reachable from the response side, where a writeOnly property never appears; either the flag or the schema's usage is wrong", name),
+					jsonPointer+"/properties/"+name, name, p, "writeOnly", source))
+			}
+		}
+		return nil
+	})
+	return findings
+}
+
+func markPathItem(pathItem *openapi3.PathItem, request, response map[*openapi3.Schema]bool) {
+	if pathItem == nil {
+		return
+	}
+	for _, param := range pathItem.Parameters {
+		markParameter(param, request)
+	}
+	for _, op := range pathItem.Operations() {
+		markOperation(op, request, response)
+	}
+}
+
+func markOperation(op *openapi3.Operation, request, response map[*openapi3.Schema]bool) {
+	if op == nil {
+		return
+	}
+	for _, param := range op.Parameters {
+		markParameter(param, request)
+	}
+	if op.RequestBody != nil && op.RequestBody.Value != nil {
+		markContent(op.RequestBody.Value.Content, request)
+	}
+	if op.Responses != nil {
+		for _, resp := range op.Responses.Map() {
+			if resp == nil || resp.Value == nil {
+				continue
+			}
+			markContent(resp.Value.Content, response)
+			for _, header := range resp.Value.Headers {
+				if header == nil || header.Value == nil {
+					continue
+				}
+				markSchema(header.Value.Schema, response)
+				markContent(header.Value.Content, response)
+			}
+		}
+	}
+	for _, callback := range op.Callbacks {
+		if callback == nil || callback.Value == nil {
+			continue
+		}
+		for _, pathItem := range callback.Value.Map() {
+			markPathItem(pathItem, request, response)
+		}
+	}
+}
+
+func markParameter(param *openapi3.ParameterRef, request map[*openapi3.Schema]bool) {
+	if param == nil || param.Value == nil {
+		return
+	}
+	markSchema(param.Value.Schema, request)
+	markContent(param.Value.Content, request)
+}
+
+func markContent(content openapi3.Content, set map[*openapi3.Schema]bool) {
+	for _, mediaType := range content {
+		if mediaType == nil {
+			continue
+		}
+		markSchema(mediaType.Schema, set)
+	}
+}
+
+// markSchema marks the schema and every sub-schema reachable from it. The
+// set doubles as the cycle guard: a marked schema's subtree is already
+// marked.
+func markSchema(ref *openapi3.SchemaRef, set map[*openapi3.Schema]bool) {
+	if ref == nil || ref.Value == nil || set[ref.Value] {
+		return
+	}
+	s := ref.Value
+	set[s] = true
+
+	for _, prop := range s.Properties {
+		markSchema(prop, set)
+	}
+	for _, sub := range s.AllOf {
+		markSchema(sub, set)
+	}
+	for _, sub := range s.AnyOf {
+		markSchema(sub, set)
+	}
+	for _, sub := range s.OneOf {
+		markSchema(sub, set)
+	}
+	for _, sub := range s.PrefixItems {
+		markSchema(sub, set)
+	}
+	for _, sub := range s.PatternProperties {
+		markSchema(sub, set)
+	}
+	for _, sub := range s.DependentSchemas {
+		markSchema(sub, set)
+	}
+	markSchema(s.Items, set)
+	markSchema(s.Not, set)
+	markSchema(s.Contains, set)
+	markSchema(s.PropertyNames, set)
+	markSchema(s.If, set)
+	markSchema(s.Then, set)
+	markSchema(s.Else, set)
+	markSchema(s.ContentSchema, set)
+	markSchema(s.AdditionalProperties.Schema, set)
+	markSchema(s.UnevaluatedItems.Schema, set)
+	markSchema(s.UnevaluatedProperties.Schema, set)
+}
+
+func newMutabilityReachabilityFinding(id, text, section, name string, prop *openapi3.Schema, field, source string) formatters.Finding {
+	line, column := schemaFieldLocation(prop, field)
+	f := formatters.Finding{
+		Id:      id,
+		Text:    text,
+		Level:   RuleLevel(id),
+		Section: section,
+		Source: formatters.Source{
+			File:   source,
+			Line:   line,
+			Column: column,
+		},
+	}
+	f.Fingerprint = checker.ComputeFingerprint(f.Id, "", section, []any{name})
+	return f
+}

--- a/validate/lint_mutability_reachability_test.go
+++ b/validate/lint_mutability_reachability_test.go
@@ -155,3 +155,88 @@ paths:
 	require.Len(t, findings, 1)
 	require.Equal(t, ReadOnlyOnlyInRequestsID, findings[0].Id)
 }
+
+// Reachability crosses component indirections: the operation references a
+// components.requestBodies entry, whose schema references one component
+// schema, which nests another holding the readOnly property. All resolved
+// refs share schema identity, so the marking reaches the leaf and the
+// finding reports at its definition.
+func TestLint_ReadOnlyThroughComponentChain(t *testing.T) {
+	spec := mustLoad(t, `
+openapi: 3.0.0
+info: { title: t, version: "1" }
+paths:
+  /items:
+    post:
+      requestBody:
+        $ref: '#/components/requestBodies/CreateItem'
+      responses: { "200": { description: ok } }
+components:
+  requestBodies:
+    CreateItem:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Item'
+  schemas:
+    Item:
+      type: object
+      properties:
+        meta:
+          $ref: '#/components/schemas/Meta'
+    Meta:
+      type: object
+      properties:
+        id:
+          type: string
+          readOnly: true
+`)
+	findings := lintMutabilityReachability(spec, "spec.yaml")
+	require.Len(t, findings, 1)
+	require.Equal(t, ReadOnlyOnlyInRequestsID, findings[0].Id)
+	require.Contains(t, findings[0].Text, `"id"`)
+}
+
+// The same chain with the leaf also referenced from a components.responses
+// entry that an operation uses: the shared definition clears everywhere.
+func TestLint_ComponentChainSharedWithResponse(t *testing.T) {
+	spec := mustLoad(t, `
+openapi: 3.0.0
+info: { title: t, version: "1" }
+paths:
+  /items:
+    post:
+      requestBody:
+        $ref: '#/components/requestBodies/CreateItem'
+      responses:
+        "200":
+          $ref: '#/components/responses/ItemResponse'
+components:
+  requestBodies:
+    CreateItem:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Item'
+  responses:
+    ItemResponse:
+      description: ok
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Meta'
+  schemas:
+    Item:
+      type: object
+      properties:
+        meta:
+          $ref: '#/components/schemas/Meta'
+    Meta:
+      type: object
+      properties:
+        id:
+          type: string
+          readOnly: true
+`)
+	require.Empty(t, lintMutabilityReachability(spec, "spec.yaml"))
+}

--- a/validate/lint_mutability_reachability_test.go
+++ b/validate/lint_mutability_reachability_test.go
@@ -1,0 +1,157 @@
+package validate
+
+import (
+	"testing"
+
+	"github.com/oasdiff/oasdiff/checker"
+	"github.com/stretchr/testify/require"
+)
+
+const requestOnlyReadOnlySpec = `
+openapi: 3.0.0
+info: { title: t, version: "1" }
+paths:
+  /items:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Item'
+      responses: { "200": { description: ok } }
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        id:
+          type: string
+          readOnly: true
+`
+
+func TestLint_ReadOnlyOnlyInRequests(t *testing.T) {
+	findings := lintMutabilityReachability(mustLoad(t, requestOnlyReadOnlySpec), "spec.yaml")
+	require.Len(t, findings, 1)
+	require.Equal(t, ReadOnlyOnlyInRequestsID, findings[0].Id)
+	require.Equal(t, checker.WARN, findings[0].Level)
+	require.Contains(t, findings[0].Text, `"id"`)
+}
+
+// The same component referenced by a response as well clears the finding:
+// the readOnly property has a side where it appears.
+func TestLint_ReadOnlySharedWithResponse(t *testing.T) {
+	spec := mustLoad(t, `
+openapi: 3.0.0
+info: { title: t, version: "1" }
+paths:
+  /items:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Item'
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Item'
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        id:
+          type: string
+          readOnly: true
+`)
+	require.Empty(t, lintMutabilityReachability(spec, "spec.yaml"))
+}
+
+// The mirror: a writeOnly property in a schema only responses use.
+func TestLint_WriteOnlyOnlyInResponses(t *testing.T) {
+	spec := mustLoad(t, `
+openapi: 3.0.0
+info: { title: t, version: "1" }
+paths:
+  /items:
+    get:
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  secret:
+                    type: string
+                    writeOnly: true
+`)
+	findings := lintMutabilityReachability(spec, "spec.yaml")
+	require.Len(t, findings, 1)
+	require.Equal(t, WriteOnlyOnlyInResponsesID, findings[0].Id)
+}
+
+// A readOnly property in a response-only schema is the flag used as
+// intended; nothing to report. An orphan component is not reported either:
+// reachable from nowhere is not reachable only from requests.
+func TestLint_ReadOnlyUsedAsIntended(t *testing.T) {
+	spec := mustLoad(t, `
+openapi: 3.0.0
+info: { title: t, version: "1" }
+paths:
+  /items:
+    get:
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Item'
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        id:
+          type: string
+          readOnly: true
+    Orphan:
+      type: object
+      properties:
+        stale:
+          type: string
+          readOnly: true
+`)
+	require.Empty(t, lintMutabilityReachability(spec, "spec.yaml"))
+}
+
+// Reachability descends into sub-schemas: a readOnly property nested under
+// an allOf branch of a request-only schema is found.
+func TestLint_ReadOnlyNestedUnderAllOf(t *testing.T) {
+	spec := mustLoad(t, `
+openapi: 3.0.0
+info: { title: t, version: "1" }
+paths:
+  /items:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+                - type: object
+                  properties:
+                    id:
+                      type: string
+                      readOnly: true
+      responses: { "200": { description: ok } }
+`)
+	findings := lintMutabilityReachability(spec, "spec.yaml")
+	require.Len(t, findings, 1)
+	require.Equal(t, ReadOnlyOnlyInRequestsID, findings[0].Id)
+}

--- a/validate/rule_descriptions.go
+++ b/validate/rule_descriptions.go
@@ -86,7 +86,9 @@ var ruleDescriptions = map[string]string{
 	"const-not-in-enum":                     "const is not one of the enum values, so no value can validate",
 	"duplicate-enum-value":                  "enum lists the same value more than once",
 	"type-format-mismatch":                  "format belongs to a different type and is ignored",
+	"read-only-property-only-in-requests":   "a readOnly property is only reachable from the request side, where it never appears",
 	"required-with-default":                 "a required parameter or property also has a default, which is never used",
+	"write-only-property-only-in-responses": "a writeOnly property is only reachable from the response side, where it never appears",
 	"ambiguous-parameter-serialization":     "parameter type mixes a structured type with a scalar, so its serialization is ambiguous",
 
 	// Examples and links

--- a/validate/rule_ids.go
+++ b/validate/rule_ids.go
@@ -90,6 +90,7 @@ var ruleIDs = []string{
 	"prefix-items-field-for-3-1-plus",
 	"property-names-field-for-3-1-plus",
 	"query-field-for-3-2-plus",
+	"read-only-property-only-in-requests",
 	"read-only-write-only-mutually-exclusive",
 	"request-body-content-required",
 	"required-with-default",
@@ -122,6 +123,7 @@ var ruleIDs = []string{
 	"value-or-external-value-required",
 	"webhook-nil",
 	"webhooks-field-for-3-1-plus",
+	"write-only-property-only-in-responses",
 }
 
 // nativeRuleIDs are the ids validate emits that do not come from kin: the
@@ -141,6 +143,8 @@ var nativeRuleIDs = []string{
 	MinContainsExceedsMaxContainsID,
 	EnumEmptyID,
 	ConstNotInEnumID,
+	ReadOnlyOnlyInRequestsID,
+	WriteOnlyOnlyInResponsesID,
 	unknownValidationID,
 }
 

--- a/validate/rule_levels.go
+++ b/validate/rule_levels.go
@@ -27,6 +27,12 @@ var ruleLevels = map[string]checker.Level{
 	// A default, unlike an example, is consumed at runtime by some tooling, so
 	// a mismatch there is a real risk.
 	"default-violates-schema": checker.WARN,
+	// A wrong readOnly/writeOnly flag is probably a mistake, and since the
+	// changelog derives verdicts from these flags, a wrong one silently
+	// mutes breaking-change detection for the property. Warning, not error:
+	// a schema can legitimately be request-only today and shared tomorrow.
+	"read-only-property-only-in-requests":   checker.WARN,
+	"write-only-property-only-in-responses": checker.WARN,
 	// Fields alongside a $ref are silently ignored in 3.0 rather than breaking
 	// the spec; the author's intent is lost, not the document.
 	"extra-sibling-fields": checker.WARN,

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -51,6 +51,7 @@ func Validate(spec *openapi3.T, source string) formatters.Findings {
 	findings = append(findings, lintRequiredWithDefault(spec, source)...)
 	findings = append(findings, lintTypeFormatMismatch(spec, source)...)
 	findings = append(findings, lintSchemaConstraints(spec, source)...)
+	findings = append(findings, lintMutabilityReachability(spec, source)...)
 	return findings
 }
 


### PR DESCRIPTION
Closes #1214.

Two new WARN-level lints in `oasdiff validate`:

- **read-only-property-only-in-requests**: a `readOnly` property whose schema is reachable only from the request side (request bodies and parameters). A readOnly property never appears in a request, so nothing can ever carry it; either the flag or the schema's usage is wrong.
- **write-only-property-only-in-responses**: the mirror, for `writeOnly` properties in schemas only responses use.

Reachability is computed from the operations (webhooks and callbacks included) by schema identity, which resolved $refs share, so a component schema used by both sides clears its properties wherever they are reported; findings are emitted during WalkSchemas, so locations and $ref dedup follow the existing lint conventions. Warning rather than error, as the issue proposed: a schema can legitimately be request-only today and shared tomorrow, and an orphan component is deliberately not flagged (reachable from nowhere is not reachable only from requests).

The stake beyond tidiness: since #1213 the changelog derives its read-only/write-only verdicts from these flags, so a mistaken flag silently downgrades breaking-change detection for that property. This lint is the guard for that guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDvUFsg5nu1NBWQffErGDw