### PR TITLE
Added and deleted properties under allOf carry the disclaimer

### DIFF
--- a/checker/check_new_requried_request_header_property.go
+++ b/checker/check_new_requried_request_header_property.go
@@ -20,7 +20,7 @@ func NewRequiredRequestHeaderPropertyCheck(diffReport *diff.Diff, operationsSour
 		baseSource, revisionSource := ParameterSources(operationsSources, p.opInfo.methodDiff, p.paramDiff)
 		checkAddedPropertiesDiff(
 			p.paramDiff.SchemaDiff,
-			func(propertyPath string, newPropertyName string, newProperty *openapi3.Schema, parent *diff.SchemaDiff) {
+			func(propertyPath string, newPropertyName string, newProperty *openapi3.Schema, parent *diff.SchemaDiff, underAllOf bool) {
 				if newProperty.ReadOnly {
 					return
 				}
@@ -32,7 +32,7 @@ func NewRequiredRequestHeaderPropertyCheck(diffReport *diff.Diff, operationsSour
 					NewRequiredRequestHeaderPropertyId,
 					[]any{p.name, propertyFullName(propertyPath, newPropertyName)},
 					"",
-				).WithSources(baseSource, revisionSource))
+				).WithDisclaimers(allOfDisclaimers(underAllOf, nil)).WithSources(baseSource, revisionSource))
 			})
 	})
 	return result

--- a/checker/check_request_property_updated.go
+++ b/checker/check_request_property_updated.go
@@ -56,7 +56,7 @@ func RequestPropertyUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.
 		// which delegates to checkModifiedPropertiesDiff. Used directly here.
 		checkDeletedPropertiesDiff(
 			info.schemaDiff,
-			func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff) {
+			func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff, underAllOf bool) {
 				if propertyItem.ReadOnly {
 					return
 				}
@@ -74,12 +74,12 @@ func RequestPropertyUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.
 					RequestPropertyRemovedId,
 					[]any{propertyFullName(propertyPath, propertyName)},
 					"",
-				).WithSchema(parent).WithSources(baseSource, nil))
+				).WithSchema(parent).WithDisclaimers(allOfDisclaimers(underAllOf, nil)).WithSources(baseSource, nil))
 			})
 
 		checkAddedPropertiesDiff(
 			info.schemaDiff,
-			func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff) {
+			func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff, underAllOf bool) {
 				if propertyItem.ReadOnly {
 					return
 				}
@@ -93,20 +93,20 @@ func RequestPropertyUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.
 							NewRequiredRequestPropertyId,
 							[]any{propName},
 							"",
-						).WithSchema(parent).WithSources(nil, revisionSource))
+						).WithSchema(parent).WithDisclaimers(allOfDisclaimers(underAllOf, nil)).WithSources(nil, revisionSource))
 					} else {
 						result = append(result, info.newChange(
 							NewRequiredRequestPropertyWithDefaultId,
 							[]any{propName},
 							RequiredRequestPropertyWithDefaultCommentId,
-						).WithSchema(parent).WithSources(nil, revisionSource))
+						).WithSchema(parent).WithDisclaimers(allOfDisclaimers(underAllOf, nil)).WithSources(nil, revisionSource))
 					}
 				} else {
 					result = append(result, info.newChange(
 						NewOptionalRequestPropertyId,
 						[]any{propName},
 						"",
-					).WithSchema(parent).WithSources(nil, revisionSource))
+					).WithSchema(parent).WithDisclaimers(allOfDisclaimers(underAllOf, nil)).WithSources(nil, revisionSource))
 				}
 			})
 	})

--- a/checker/check_request_property_updated_test.go
+++ b/checker/check_request_property_updated_test.go
@@ -226,3 +226,23 @@ func TestRequestProperty_AllOfBranchExistenceCarriesDisclaimer(t *testing.T) {
 		require.Contains(t, change.GetComment(localizer), "--flatten-allof", id)
 	}
 }
+
+// A keyword change beside an unchanged allOf is as doubtful as one inside a
+// changed branch: the node's effective schema is still the unflattened
+// merge, so an unchanged branch may already guarantee what the keyword
+// seems to narrow. The disclaimer keys on the allOf's presence in the
+// schemas, not on the allOf having changed.
+func TestRequestProperty_UnchangedAllOfSiblingCarriesDisclaimer(t *testing.T) {
+	s1, err := open("../data/checker/allof_unchanged_sibling_base.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/checker/allof_unchanged_sibling_revision.yaml")
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	changes := checker.CheckBackwardCompatibilityUntilLevel(allChecksConfig(), d, osm, checker.INFO)
+
+	change := requireChange(t, changes, checker.RequestPropertyMaxLengthDecreasedId)
+	require.Equal(t, checker.WARN, change.GetLevel())
+	require.Contains(t, change.GetComment(checker.NewDefaultLocalizer()), "--flatten-allof")
+}

--- a/checker/check_request_property_updated_test.go
+++ b/checker/check_request_property_updated_test.go
@@ -219,7 +219,7 @@ func TestRequestProperty_AllOfBranchExistenceCarriesDisclaimer(t *testing.T) {
 	for _, id := range []string{
 		checker.NewRequiredRequestPropertyId,
 		checker.RequestPropertyRemovedId,
-		"request-property-type-changed",
+		checker.RequestPropertyTypeChangedId,
 	} {
 		change := requireChange(t, changes, id)
 		require.Equal(t, checker.WARN, change.GetLevel(), id)

--- a/checker/check_request_property_updated_test.go
+++ b/checker/check_request_property_updated_test.go
@@ -200,3 +200,29 @@ func TestRequestPropertyOneOfWrappedOriginalPreserved(t *testing.T) {
 	require.Equal(t, checker.WARN, change.GetLevel())
 	require.NotEmpty(t, change.GetComment(checker.NewDefaultLocalizer()))
 }
+
+// A property added or deleted inside an unflattened allOf branch is as
+// doubtful as a modified one: another branch may still guarantee what this
+// one dropped. All three now carry the all-of-not-flattened disclaimer and
+// cap to warning, where previously only the modified property did (#1152).
+func TestRequestProperty_AllOfBranchExistenceCarriesDisclaimer(t *testing.T) {
+	s1, err := open("../data/checker/allof_property_existence_base.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/checker/allof_property_existence_revision.yaml")
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	changes := checker.CheckBackwardCompatibilityUntilLevel(allChecksConfig(), d, osm, checker.INFO)
+
+	localizer := checker.NewDefaultLocalizer()
+	for _, id := range []string{
+		checker.NewRequiredRequestPropertyId,
+		checker.RequestPropertyRemovedId,
+		"request-property-type-changed",
+	} {
+		change := requireChange(t, changes, id)
+		require.Equal(t, checker.WARN, change.GetLevel(), id)
+		require.Contains(t, change.GetComment(localizer), "--flatten-allof", id)
+	}
+}

--- a/checker/check_response_optional_property_updated.go
+++ b/checker/check_response_optional_property_updated.go
@@ -24,7 +24,7 @@ func ResponseOptionalPropertyUpdatedCheck(diffReport *diff.Diff, operationsSourc
 		// directly inside the walker callback.
 		checkDeletedPropertiesDiff(
 			info.schemaDiff,
-			func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff) {
+			func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff, underAllOf bool) {
 				if slices.Contains(parent.Base.Required, propertyName) {
 					// covered by response-required-property-removed
 					return
@@ -47,12 +47,12 @@ func ResponseOptionalPropertyUpdatedCheck(diffReport *diff.Diff, operationsSourc
 					id,
 					[]any{propertyFullName(propertyPath, propertyName), info.responseStatus},
 					"",
-				).WithSchema(parent).WithSources(baseSource, nil))
+				).WithSchema(parent).WithDisclaimers(allOfDisclaimers(underAllOf, nil)).WithSources(baseSource, nil))
 			})
 
 		checkAddedPropertiesDiff(
 			info.schemaDiff,
-			func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff) {
+			func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff, underAllOf bool) {
 				if slices.Contains(parent.Revision.Required, propertyName) {
 					// covered by response-required-property-added
 					return
@@ -66,7 +66,7 @@ func ResponseOptionalPropertyUpdatedCheck(diffReport *diff.Diff, operationsSourc
 					id,
 					[]any{propertyFullName(propertyPath, propertyName), info.responseStatus},
 					"",
-				).WithSchema(parent).WithSources(nil, revisionSource))
+				).WithSchema(parent).WithDisclaimers(allOfDisclaimers(underAllOf, nil)).WithSources(nil, revisionSource))
 			})
 	})
 

--- a/checker/check_response_required_property_updated.go
+++ b/checker/check_response_required_property_updated.go
@@ -44,7 +44,7 @@ func ResponseRequiredPropertyUpdatedCheck(diffReport *diff.Diff, operationsSourc
 		// delegates to checkModifiedPropertiesDiff. Used directly here.
 		checkDeletedPropertiesDiff(
 			info.schemaDiff,
-			func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff) {
+			func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff, underAllOf bool) {
 				id := ResponseRequiredPropertyRemovedId
 				if propertyItem.WriteOnly {
 					id = ResponseRequiredWriteOnlyPropertyRemovedId
@@ -68,11 +68,11 @@ func ResponseRequiredPropertyUpdatedCheck(diffReport *diff.Diff, operationsSourc
 					id,
 					[]any{propertyFullName(propertyPath, propertyName), info.responseStatus},
 					"",
-				).WithSchema(parent).WithSources(baseSource, nil))
+				).WithSchema(parent).WithDisclaimers(allOfDisclaimers(underAllOf, nil)).WithSources(baseSource, nil))
 			})
 		checkAddedPropertiesDiff(
 			info.schemaDiff,
-			func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff) {
+			func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff, underAllOf bool) {
 				id := ResponseRequiredPropertyAddedId
 				if propertyItem.WriteOnly {
 					id = ResponseRequiredWriteOnlyPropertyAddedId
@@ -87,7 +87,7 @@ func ResponseRequiredPropertyUpdatedCheck(diffReport *diff.Diff, operationsSourc
 					id,
 					[]any{propertyFullName(propertyPath, propertyName), info.responseStatus},
 					"",
-				).WithSchema(parent).WithSources(nil, revisionSource))
+				).WithSchema(parent).WithDisclaimers(allOfDisclaimers(underAllOf, nil)).WithSources(nil, revisionSource))
 			})
 	})
 

--- a/checker/media_type_walker.go
+++ b/checker/media_type_walker.go
@@ -1,6 +1,8 @@
 package checker
 
 import (
+	"github.com/getkin/kin-openapi/openapi3"
+
 	"github.com/oasdiff/oasdiff/diff"
 )
 
@@ -43,16 +45,21 @@ func (info mediaTypeInfo) newChange(id string, args []any, comment string) ApiCh
 
 // allOfDisclaimers determines whether a change is under an allOf branch or has an allOf itself, and returns the appropriate disclaimers.
 // Two ways underAllOf is true:
-// 1. The walk is under an allOf branch, so the change is in a sub-schema that is not flattened.
-// 2. The schemaDiff has an AllOfDiff, meaning the schema itself has an 	 that changed.
+//  1. The walk is under an allOf branch, so the change is in a sub-schema that is not flattened.
+//  2. The schema itself has an allOf, changed or not: its effective contract is the unflattened
+//     merge, so an unchanged branch may already guarantee what a keyword change beside it seems to alter.
 func allOfDisclaimers(underAllOf bool, schemaDiff *diff.SchemaDiff) []Disclaimer {
-	if schemaDiff != nil && !schemaDiff.AllOfDiff.Empty() {
+	if schemaDiff != nil && (schemaHasAllOf(schemaDiff.Base) || schemaHasAllOf(schemaDiff.Revision)) {
 		underAllOf = true
 	}
 	if !underAllOf {
 		return nil
 	}
 	return []Disclaimer{DisclaimerAllOfNotFlattened}
+}
+
+func schemaHasAllOf(schema *openapi3.Schema) bool {
+	return schema != nil && len(schema.AllOf) > 0
 }
 
 // walkProperties invokes processor for every modified property under

--- a/checker/media_type_walker.go
+++ b/checker/media_type_walker.go
@@ -44,9 +44,9 @@ func (info mediaTypeInfo) newChange(id string, args []any, comment string) ApiCh
 // allOfDisclaimers determines whether a change is under an allOf branch or has an allOf itself, and returns the appropriate disclaimers.
 // Two ways underAllOf is true:
 // 1. The walk is under an allOf branch, so the change is in a sub-schema that is not flattened.
-// 2. The schemaDiff has an AllOfDiff, meaning the schema itself has an allOf that changed.
+// 2. The schemaDiff has an AllOfDiff, meaning the schema itself has an 	 that changed.
 func allOfDisclaimers(underAllOf bool, schemaDiff *diff.SchemaDiff) []Disclaimer {
-	if schemaDiff != nil && schemaDiff.AllOfDiff != nil {
+	if schemaDiff != nil && !schemaDiff.AllOfDiff.Empty() {
 		underAllOf = true
 	}
 	if !underAllOf {

--- a/checker/media_type_walker.go
+++ b/checker/media_type_walker.go
@@ -41,12 +41,10 @@ func (info mediaTypeInfo) newChange(id string, args []any, comment string) ApiCh
 		WithDisclaimers(allOfDisclaimers(false, info.schemaDiff))
 }
 
-// allOfDisclaimers reports the conditions that hold for a change at this
-// location, doubtful in either of two ways: the node sits inside an allOf
-// branch (underAllOf, tracked by the walk), or the node's own allOf changed
-// (schemaDiff), since its effective schema is the unmerged combination. An
-// allOf surviving into the diff is itself the evidence: had the branches
-// been flattened, there would be none left to compare.
+// allOfDisclaimers determines whether a change is under an allOf branch or has an allOf itself, and returns the appropriate disclaimers.
+// Two ways underAllOf is true:
+// 1. The walk is under an allOf branch, so the change is in a sub-schema that is not flattened.
+// 2. The schemaDiff has an AllOfDiff, meaning the schema itself has an allOf that changed.
 func allOfDisclaimers(underAllOf bool, schemaDiff *diff.SchemaDiff) []Disclaimer {
 	if schemaDiff != nil && schemaDiff.AllOfDiff != nil {
 		underAllOf = true

--- a/checker/media_type_walker.go
+++ b/checker/media_type_walker.go
@@ -46,8 +46,7 @@ func (info mediaTypeInfo) newChange(id string, args []any, comment string) ApiCh
 // allOfDisclaimers determines whether a change is under an allOf branch or has an allOf itself, and returns the appropriate disclaimers.
 // Two ways underAllOf is true:
 //  1. The walk is under an allOf branch, so the change is in a sub-schema that is not flattened.
-//  2. The schema itself has an allOf, changed or not: its effective contract is the unflattened
-//     merge, so an unchanged branch may already guarantee what a keyword change beside it seems to alter.
+//  2. The schema itself has an allOf
 func allOfDisclaimers(underAllOf bool, schemaDiff *diff.SchemaDiff) []Disclaimer {
 	if schemaDiff != nil && (schemaHasAllOf(schemaDiff.Base) || schemaHasAllOf(schemaDiff.Revision)) {
 		underAllOf = true

--- a/checker/media_type_walker.go
+++ b/checker/media_type_walker.go
@@ -42,8 +42,11 @@ func (info mediaTypeInfo) newChange(id string, args []any, comment string) ApiCh
 }
 
 // allOfDisclaimers reports the conditions that hold for a change at this
-// location. An allOf surviving into the diff is itself the evidence: had the
-// branches been flattened, there would be none left to compare.
+// location, doubtful in either of two ways: the node sits inside an allOf
+// branch (underAllOf, tracked by the walk), or the node's own allOf changed
+// (schemaDiff), since its effective schema is the unmerged combination. An
+// allOf surviving into the diff is itself the evidence: had the branches
+// been flattened, there would be none left to compare.
 func allOfDisclaimers(underAllOf bool, schemaDiff *diff.SchemaDiff) []Disclaimer {
 	if schemaDiff != nil && schemaDiff.AllOfDiff != nil {
 		underAllOf = true

--- a/checker/subschema_walk.go
+++ b/checker/subschema_walk.go
@@ -15,7 +15,7 @@ type subschemaWalk struct {
 	enter func(propertyPath string, propertyName string, schemaDiff *diff.SchemaDiff, parentDiff *diff.SchemaDiff, underAllOf bool)
 	// properties is called for a node's own properties, after its name is
 	// appended, so the path already names the node they belong to.
-	properties func(propertyPath string, schemaDiff *diff.SchemaDiff)
+	properties func(propertyPath string, schemaDiff *diff.SchemaDiff, underAllOf bool)
 }
 
 func (w subschemaWalk) walk(propertyPath string, propertyName string, schemaDiff *diff.SchemaDiff, parentDiff *diff.SchemaDiff, underAllOf bool) {
@@ -51,7 +51,7 @@ func (w subschemaWalk) walk(propertyPath string, propertyName string, schemaDiff
 
 	if schemaDiff.PropertiesDiff != nil {
 		if w.properties != nil {
-			w.properties(propertyPath, schemaDiff)
+			w.properties(propertyPath, schemaDiff, underAllOf)
 		}
 		for name, v := range schemaDiff.PropertiesDiff.Modified {
 			w.walk(propertyPath, name, v, schemaDiff, underAllOf)
@@ -128,26 +128,26 @@ func checkModifiedPropertiesDiff(schemaDiff *diff.SchemaDiff, processor func(pro
 	}}.walk("", "", schemaDiff, nil, false)
 }
 
-func checkAddedPropertiesDiff(schemaDiff *diff.SchemaDiff, processor func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, propertyParentDiff *diff.SchemaDiff)) {
+func checkAddedPropertiesDiff(schemaDiff *diff.SchemaDiff, processor func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, propertyParentDiff *diff.SchemaDiff, underAllOf bool)) {
 	if schemaDiff == nil {
 		return
 	}
 
-	subschemaWalk{properties: func(propertyPath string, sd *diff.SchemaDiff) {
+	subschemaWalk{properties: func(propertyPath string, sd *diff.SchemaDiff, underAllOf bool) {
 		for _, name := range sd.PropertiesDiff.Added {
-			processor(propertyPath, name, sd.Revision.Properties[name].Value, sd)
+			processor(propertyPath, name, sd.Revision.Properties[name].Value, sd, underAllOf)
 		}
 	}}.walk("", "", schemaDiff, nil, false)
 }
 
-func checkDeletedPropertiesDiff(schemaDiff *diff.SchemaDiff, processor func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, propertyParentDiff *diff.SchemaDiff)) {
+func checkDeletedPropertiesDiff(schemaDiff *diff.SchemaDiff, processor func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, propertyParentDiff *diff.SchemaDiff, underAllOf bool)) {
 	if schemaDiff == nil {
 		return
 	}
 
-	subschemaWalk{properties: func(propertyPath string, sd *diff.SchemaDiff) {
+	subschemaWalk{properties: func(propertyPath string, sd *diff.SchemaDiff, underAllOf bool) {
 		for _, name := range sd.PropertiesDiff.Deleted {
-			processor(propertyPath, name, sd.Base.Properties[name].Value, sd)
+			processor(propertyPath, name, sd.Base.Properties[name].Value, sd, underAllOf)
 		}
 	}}.walk("", "", schemaDiff, nil, false)
 }

--- a/data/checker/allof_property_existence_base.yaml
+++ b/data/checker/allof_property_existence_base.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /items:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                wrapper:
+                  allOf:
+                    - type: object
+                      properties:
+                        keep:
+                          type: string
+                    - type: object
+                      properties:
+                        other:
+                          type: string
+                        drop:
+                          type: string
+      responses:
+        '200':
+          description: OK

--- a/data/checker/allof_property_existence_revision.yaml
+++ b/data/checker/allof_property_existence_revision.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /items:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                wrapper:
+                  allOf:
+                    - type: object
+                      properties:
+                        keep:
+                          type: string
+                    - type: object
+                      required: [added]
+                      properties:
+                        other:
+                          type: integer
+                        added:
+                          type: string
+      responses:
+        '200':
+          description: OK

--- a/data/checker/allof_unchanged_sibling_base.yaml
+++ b/data/checker/allof_unchanged_sibling_base.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /items:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                wrapper:
+                  maxLength: 10
+                  allOf:
+                    - type: object
+                      properties:
+                        keep:
+                          type: string
+      responses:
+        '200':
+          description: OK

--- a/data/checker/allof_unchanged_sibling_revision.yaml
+++ b/data/checker/allof_unchanged_sibling_revision.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /items:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                wrapper:
+                  maxLength: 5
+                  allOf:
+                    - type: object
+                      properties:
+                        keep:
+                          type: string
+      responses:
+        '200':
+          description: OK


### PR DESCRIPTION
Closes #1152, and closes the adjacent gap found while reviewing it. Two fixes to the all-of-not-flattened disclaimer, one per signal:

## Added and deleted properties carry the disclaimer

A property **modified** inside an unflattened allOf branch carried the disclaimer and capped to warning; a property **added or deleted** in the same branch reported at its declared level with no disclaimer. As the issue put it, the difference was not a decision, it followed from which traversal the check happened to use: the subschema walk tracked `underAllOf` for its `enter` hook (modified properties) but not its `properties` hook (added/deleted).

The `properties` hook now receives `underAllOf` like the `enter` hook does; the four checks built on it (request property added/removed, response required and optional property added/removed, new required request header property) attach the disclaimer at emission, and `capByDisclaimers` does the rest. The issue's repro now reports `new-required-request-property` at warning with the flatten-allof comment, matching its modified sibling. The test pins all three shapes in a single branch: an added required property, a deleted property, and a type change.

## The node signal keys on the allOf's presence, not on it having changed

A keyword change beside an **unchanged** allOf carried no disclaimer: the signal tested `AllOfDiff`, which the diff normalizes away when the branches are equal, while the doubt comes from the allOf existing at all, since the node's effective contract is the unflattened merge and an unchanged branch may already guarantee what the keyword seems to alter. The signal now reads the schemas (allOf present on either side), which subsumes the changed case, so nothing previously disclaimed is lost. Pinned by `TestRequestProperty_UnchangedAllOfSiblingCarriesDisclaimer`: `maxLength` tightened beside an untouched allOf reports at warning with the comment.

The **containment** signal needs no such fix, structurally: an unchanged branch never enters the diff, so the walk never visits it and no finding can originate inside one.

## Fixture note

The diff's branch matcher pairs branches by similarity, so the #1152 fixture confines every edit to one branch, as the issue's repro does; editing both branches makes the diff report wholesale branch replacement instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDvUFsg5nu1NBWQffErGDw