### PR TITLE
flatten: recursive schemas under an allOf overlay serialize again

### DIFF
--- a/data/allof/circular-overlay.yaml
+++ b/data/allof/circular-overlay.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.3
+info:
+  title: recursive schema referenced from an allOf overlay
+  version: "1"
+paths:
+  /x:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                filters:
+                  type: array
+                  items:
+                    allOf:
+                      - $ref: "#/components/schemas/Node"
+                      - type: object
+                        properties:
+                          filters:
+                            type: array
+                            items:
+                              $ref: "#/components/schemas/Node"
+      responses:
+        "200":
+          description: ok
+components:
+  schemas:
+    Node:
+      description: recursive filter tree
+      type: object
+      properties:
+        filters:
+          type: array
+          items:
+            $ref: "#/components/schemas/Node"

--- a/flatten/allof/merge_allof.go
+++ b/flatten/allof/merge_allof.go
@@ -701,28 +701,39 @@ func resolveNumberRange(schema *openapi3.Schema, collection *SchemaCollection) *
 	return schema
 }
 
-func resolveItems(state *state, schema *openapi3.Schema, collection *SchemaCollection) (*openapi3.Schema, error) {
-
-	items := openapi3.SchemaRefs{}
-	for _, sref := range collection.Items {
+// mergeSubschemas merges sibling subschemas into one: nil entries are
+// dropped, duplicates of one schema merge to that schema with its $ref
+// intact, and only a genuinely mixed set is flattened into a fresh schema.
+// Reusing the lone schema keeps a recursive $ref serializable, where a
+// fresh ref-less node whose value the in-flight guard points at an
+// ancestor is a cycle the marshaler cannot terminate.
+func mergeSubschemas(state *state, refs openapi3.SchemaRefs) (*openapi3.SchemaRef, error) {
+	subschemas := openapi3.SchemaRefs{}
+	for _, sref := range refs {
 		if sref != nil {
-			items = append(items, sref)
+			subschemas = append(subschemas, sref)
 		}
 	}
-	if len(items) == 0 {
-		schema.Items = nil
-		return schema, nil
+	subschemas = dedupSchemaRefsByValue(subschemas)
+	if len(subschemas) == 0 {
+		return nil, nil
 	}
-	if len(items) == 1 {
-		schema.Items = items[0]
-		return schema, nil
+	if len(subschemas) == 1 {
+		return subschemas[0], nil
 	}
 	result := openapi3.NewSchemaRef("", openapi3.NewSchema())
-	err := flattenSchemas(state, result, items)
+	if err := flattenSchemas(state, result, subschemas); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func resolveItems(state *state, schema *openapi3.Schema, collection *SchemaCollection) (*openapi3.Schema, error) {
+	items, err := mergeSubschemas(state, collection.Items)
 	if err != nil {
 		return nil, err
 	}
-	schema.Items = result
+	schema.Items = items
 	return schema, nil
 }
 
@@ -738,26 +749,11 @@ func resolveItems(state *state, schema *openapi3.Schema, collection *SchemaColle
 // Documented in docs/ALLOF.md.
 func resolveContains(state *state, schema *openapi3.Schema, collection *SchemaCollection) (*openapi3.Schema, error) {
 
-	contains := openapi3.SchemaRefs{}
-	for _, sref := range collection.Contains {
-		if sref != nil {
-			contains = append(contains, sref)
-		}
-	}
-	if len(contains) == 0 {
-		schema.Contains = nil
-		return schema, nil
-	}
-	if len(contains) == 1 {
-		schema.Contains = contains[0]
-		return schema, nil
-	}
-	result := openapi3.NewSchemaRef("", openapi3.NewSchema())
-	err := flattenSchemas(state, result, contains)
+	merged, err := mergeSubschemas(state, collection.Contains)
 	if err != nil {
 		return nil, err
 	}
-	schema.Contains = result
+	schema.Contains = merged
 	return schema, nil
 }
 
@@ -772,26 +768,11 @@ func resolveContains(state *state, schema *openapi3.Schema, collection *SchemaCo
 // faithful.
 func resolvePropertyNames(state *state, schema *openapi3.Schema, collection *SchemaCollection) (*openapi3.Schema, error) {
 
-	names := openapi3.SchemaRefs{}
-	for _, sref := range collection.PropertyNames {
-		if sref != nil {
-			names = append(names, sref)
-		}
-	}
-	if len(names) == 0 {
-		schema.PropertyNames = nil
-		return schema, nil
-	}
-	if len(names) == 1 {
-		schema.PropertyNames = names[0]
-		return schema, nil
-	}
-	result := openapi3.NewSchemaRef("", openapi3.NewSchema())
-	err := flattenSchemas(state, result, names)
+	merged, err := mergeSubschemas(state, collection.PropertyNames)
 	if err != nil {
 		return nil, err
 	}
-	schema.PropertyNames = result
+	schema.PropertyNames = merged
 	return schema, nil
 }
 
@@ -892,16 +873,9 @@ func resolveNonFalseAdditionalProps(state *state, schema *openapi3.Schema, colle
 		}
 	}
 
-	var schemaRef *openapi3.SchemaRef
-	if len(additionalSchemas) == 1 {
-		schemaRef = additionalSchemas[0]
-	} else if len(additionalSchemas) > 1 {
-		result := openapi3.NewSchemaRef("", openapi3.NewSchema())
-		err := flattenSchemas(state, result, additionalSchemas)
-		if err != nil {
-			return nil, err
-		}
-		schemaRef = result
+	schemaRef, err := mergeSubschemas(state, additionalSchemas)
+	if err != nil {
+		return nil, err
 	}
 	schema.AdditionalProperties.Has = nil
 	schema.AdditionalProperties.Schema = schemaRef
@@ -979,12 +953,11 @@ func mergeProps(state *state, schema *openapi3.Schema, collection *SchemaCollect
 
 	result := make(openapi3.Schemas)
 	for prop, schemas := range propsToSchemasMap {
-		flattened := openapi3.NewSchemaRef("", openapi3.NewSchema())
-		err := flattenSchemas(state, flattened, schemas)
+		merged, err := mergeSubschemas(state, schemas)
 		if err != nil {
 			return nil, err
 		}
-		result[prop] = flattened
+		result[prop] = merged
 	}
 
 	if len(result) == 0 {

--- a/flatten/allof/merge_allof_spec.go
+++ b/flatten/allof/merge_allof_spec.go
@@ -1,6 +1,8 @@
 package allof
 
 import (
+	"reflect"
+
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
@@ -18,7 +20,53 @@ func MergeSpec(spec *openapi3.T) (*openapi3.T, error) {
 		// into it updates every use. Assigning s.Value would update only
 		// this reference and leave the rest unmerged.
 		*s.Value = *m
+		// The copy leaves the subtree's self-references aimed at the object
+		// Merge returned rather than the one just written into: a recursive
+		// schema's one-object cycle becomes a two-object cycle, and later
+		// attachment points then see two distinct originals for one schema,
+		// which the merge cache cannot unify.
+		redirectSchemaRefs(reflect.ValueOf(s.Value), m, s.Value, map[*openapi3.Schema]bool{})
 		return openapi3.SkipSubtree
 	})
 	return spec, err
+}
+
+// redirectSchemaRefs walks every SchemaRef reachable from v and points those
+// whose Value is from at to instead. The traversal is type-driven so a new
+// schema field carrying subschemas is covered without being listed here.
+func redirectSchemaRefs(v reflect.Value, from, to *openapi3.Schema, seen map[*openapi3.Schema]bool) {
+	switch v.Kind() {
+	case reflect.Pointer:
+		if v.IsNil() {
+			return
+		}
+		if ref, ok := v.Interface().(*openapi3.SchemaRef); ok {
+			if ref.Value == from {
+				ref.Value = to
+			}
+			redirectSchemaRefs(reflect.ValueOf(ref.Value), from, to, seen)
+			return
+		}
+		if schema, ok := v.Interface().(*openapi3.Schema); ok {
+			if schema == nil || seen[schema] {
+				return
+			}
+			seen[schema] = true
+		}
+		redirectSchemaRefs(v.Elem(), from, to, seen)
+	case reflect.Slice:
+		for i := range v.Len() {
+			redirectSchemaRefs(v.Index(i), from, to, seen)
+		}
+	case reflect.Map:
+		for _, key := range v.MapKeys() {
+			redirectSchemaRefs(v.MapIndex(key), from, to, seen)
+		}
+	case reflect.Struct:
+		for i := range v.NumField() {
+			if v.Type().Field(i).IsExported() {
+				redirectSchemaRefs(v.Field(i), from, to, seen)
+			}
+		}
+	}
 }

--- a/flatten/allof/merge_allof_spec_test.go
+++ b/flatten/allof/merge_allof_spec_test.go
@@ -109,3 +109,22 @@ func TestMergeSpec_SchemaReachedThroughRef(t *testing.T) {
 	require.Contains(t, used.Properties, "id")
 	require.Contains(t, used.Properties, "name")
 }
+
+// Merging `allOf: [$ref Node, <inline overlay whose items is $ref Node>]`,
+// where Node is recursive, used to point the merged items at the merged
+// allOf node itself with no $ref, a cycle the marshaler follows forever:
+// `oasdiff flatten` crashed with a stack overflow. Both branches' items
+// merge to the same schema, so the merge must reuse it, $ref intact.
+func Test_MergeSpec_RecursiveOverlaySerializes(t *testing.T) {
+	spec, err := load.NewSpecInfo(openapi3.NewLoader(), load.NewSource("../../data/allof/circular-overlay.yaml"), load.WithFlattenAllOf())
+	require.NoError(t, err)
+
+	merged := spec.Spec.Paths.Value("/x").Post.RequestBody.Value.Content["application/json"].
+		Schema.Value.Properties["filters"].Value.Items.Value
+	require.Empty(t, merged.AllOf)
+	require.Equal(t, "#/components/schemas/Node",
+		merged.Properties["filters"].Value.Items.Ref)
+
+	_, err = spec.Spec.MarshalJSON()
+	require.NoError(t, err)
+}

--- a/flatten/allof/merge_allof_spec_test.go
+++ b/flatten/allof/merge_allof_spec_test.go
@@ -111,10 +111,9 @@ func TestMergeSpec_SchemaReachedThroughRef(t *testing.T) {
 }
 
 // Merging `allOf: [$ref Node, <inline overlay whose items is $ref Node>]`,
-// where Node is recursive, used to point the merged items at the merged
-// allOf node itself with no $ref, a cycle the marshaler follows forever:
-// `oasdiff flatten` crashed with a stack overflow. Both branches' items
-// merge to the same schema, so the merge must reuse it, $ref intact.
+// where Node is recursive: both branches' items merge to the same schema,
+// so the merge must reuse it, $ref intact, and the flattened spec must
+// marshal.
 func Test_MergeSpec_RecursiveOverlaySerializes(t *testing.T) {
 	spec, err := load.NewSpecInfo(openapi3.NewLoader(), load.NewSource("../../data/allof/circular-overlay.yaml"), load.WithFlattenAllOf())
 	require.NoError(t, err)

--- a/flatten/allof/merge_allof_test.go
+++ b/flatten/allof/merge_allof_test.go
@@ -2977,7 +2977,9 @@ func TestMerge_PropertyNames_AllUnset(t *testing.T) {
 
 // Cycle through Properties — the user-reported reproducer in #890.
 // Tree-node-shaped schema where Properties["child"] points back to the
-// same *Schema. The same node appears twice under allOf.
+// same *Schema. The same node appears twice under allOf: the child set
+// dedups to one schema, so the merge yields that schema itself, with
+// its own cycle intact.
 func TestMerge_Cycle_PropertiesSameNodeTwice(t *testing.T) {
 	node := &openapi3.Schema{Type: &openapi3.Types{"object"}}
 	node.Properties = openapi3.Schemas{
@@ -2992,10 +2994,9 @@ func TestMerge_Cycle_PropertiesSameNodeTwice(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.NotNil(t, merged.Properties["child"])
-	// Cycle preserved in the merged output: child points back to the
-	// merged result Value.
-	require.Same(t, merged, merged.Properties["child"].Value)
+	child := merged.Properties["child"]
+	require.NotNil(t, child)
+	require.Same(t, child.Value, child.Value.Properties["child"].Value)
 }
 
 // Cycle through Properties — two distinct cyclic *Schema pointers


### PR DESCRIPTION
## Repro

```sh
oasdiff flatten data/allof/circular-overlay.yaml
```

crashed with `fatal error: stack overflow` (found while verifying #1231, which fixed the same fixture's crash on the *diff* path; the flatten path crashes in `SchemaRef.MarshalJSON` instead).

## Two compounding defects

**1. MergeSpec's write-back breaks self-referential identity.** `*s.Value = *m` copies the merged contents into the shared original object so every `$ref` sees the merge, but the merged subtree's self-references still point at the object `Merge` returned. A recursive schema's one-object cycle becomes a two-object cycle. Later attachment points then meet two distinct "originals" for one schema, and the per-attachment merge cache cannot unify them (confirmed by pointer tracing: two `$ref: Node` sites arrived at the items merge with different values). Fixed by `redirectSchemaRefs`: after the copy, walk the subtree and point references at the written-back object. The walk is reflection-driven, so a new subschema-bearing field is covered without being listed.

**2. A subschema set that dedups to one schema was flattened anyway.** `resolveItems` and friends only short-circuited on `len == 1` by pointer, so two `$ref: Node` siblings (same value, distinct SchemaRef wrappers) went into `flattenSchemas`, whose in-flight cycle guard pointed the fresh ref-less result at an ancestor: a cycle with no `$ref`, which the marshaler follows until the stack overflows. The new `mergeSubschemas` dedups by value first and reuses the lone schema, `$ref` intact, at every subschema merge site (items, contains, propertyNames, additionalProperties, properties — the last had no single-schema shortcut at all).

## Result

The merged reproducer now inlines the combined shape once, with its recursion expressed as `$ref: Node` — serializable, and visible to the diff's ref-based circular guard, so `breaking --flatten-allof` on this fixture no longer overflows even without #1231's in-flight guard.

#1231 remains necessary alongside this: an allOf over **two distinct** recursive components still merges to a ref-less cycle (the combined node has no component name a `$ref` could use), and only the in-flight diff guard keeps `breaking --flatten-allof` alive on that shape. Serializing that case in `oasdiff flatten` needs a synthetic hoisted component and is left to a follow-up issue.

One pinned identity moves deliberately: the #890 test asserted that merging `allOf: [node, node]` re-anchors the cycle onto the merged root. Merging a set that dedups to one schema now yields that schema itself, cycle intact (X ∧ X = X); the test asserts the preserved cycle instead.

Regression test: `Test_MergeSpec_RecursiveOverlaySerializes` (merged shape, preserved `$ref`, and a successful marshal of the whole spec). Full suite and lint pass.