### PR TITLE
checker: surface scanner read errors in ignore and severity-level files

### DIFF
--- a/checker/ignore.go
+++ b/checker/ignore.go
@@ -49,6 +49,9 @@ func ProcessIgnoredBackwardCompatibilityErrors(level Level, errs Changes, ignore
 			}
 		}
 	}
+	if err := ignoreScanner.Err(); err != nil {
+		return nil, err
+	}
 
 	for errIndex, err := range errs {
 		if !ignoredErrs[errIndex] {

--- a/checker/ignore_test.go
+++ b/checker/ignore_test.go
@@ -1,6 +1,10 @@
 package checker_test
 
 import (
+	"bufio"
+	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/oasdiff/oasdiff/checker"
@@ -66,4 +70,15 @@ func TestIgnoreComponent(t *testing.T) {
 	ignored, err := checker.ProcessIgnoredBackwardCompatibilityErrors(checker.INFO, errs, "../data/ignore-err-example.txt", checker.NewDefaultLocalizer())
 	require.NoError(t, err)
 	require.Equal(t, len(errs)-2, len(ignored))
+}
+
+// A line longer than the scanner's token limit makes the read fail after
+// Scan returns; the failure must surface, not silently drop ignore lines.
+func TestIgnore_ReadError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ignore.txt")
+	require.NoError(t, os.WriteFile(path, bytes.Repeat([]byte("x"), bufio.MaxScanTokenSize+1), 0o644))
+
+	errs, err := checker.ProcessIgnoredBackwardCompatibilityErrors(checker.ERR, checker.Changes{}, path, checker.NewDefaultLocalizer())
+	require.Nil(t, errs)
+	require.ErrorIs(t, err, bufio.ErrTooLong)
 }

--- a/checker/level.go
+++ b/checker/level.go
@@ -70,5 +70,9 @@ func GetSeverityLevels(source io.Reader) (map[string]Level, error) {
 		result[id] = level
 	}
 
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
 	return result, nil
 }

--- a/checker/level_test.go
+++ b/checker/level_test.go
@@ -1,8 +1,10 @@
 package checker_test
 
 import (
+	"errors"
 	"strings"
 	"testing"
+	"testing/iotest"
 
 	"github.com/TwiN/go-color"
 	"github.com/oasdiff/oasdiff/checker"
@@ -62,4 +64,10 @@ func TestGetSeverityLevels_Duplicate(t *testing.T) {
 	m, err := checker.GetSeverityLevels(strings.NewReader("request-parameter-enum-value-added info\nrequest-parameter-enum-value-added warn"))
 	require.Equal(t, map[string]checker.Level{"request-parameter-enum-value-added": checker.WARN}, m)
 	require.NoError(t, err)
+}
+
+func TestGetSeverityLevels_ReadError(t *testing.T) {
+	m, err := checker.GetSeverityLevels(iotest.ErrReader(errors.New("read failed")))
+	require.Nil(t, m)
+	require.EqualError(t, err, "read failed")
 }


### PR DESCRIPTION
`bufio.Scanner` reports a failed read only through `Err()` after the scan loop. `ProcessIgnoredBackwardCompatibilityErrors` and `GetSeverityLevels` never checked it, so a read failure silently behaved as if the unread lines were absent: ignore entries or severity overrides past the failure point were dropped without any signal.

Both loops now return the error.

Tests fail a read each way: `GetSeverityLevels` through an erroring reader (`iotest.ErrReader`), and the ignore path through a file whose line exceeds the scanner's token limit (`bufio.ErrTooLong`). Both fail without the fix and pass with it.