### PR TITLE
diff: cycle-guard cuts make a result path-specific; stop caching it

### DIFF
--- a/data/circular-two-edges-components1.yaml
+++ b/data/circular-two-edges-components1.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.3
+info:
+  title: Recursive schema demo
+  version: 1.0.0
+components:
+  schemas:
+    Token:
+      type: object
+      properties:
+        name:
+          type: string
+        parent:
+          $ref: '#/components/schemas/Token'
+        sub_tokens:
+          description: Collection of child tokens
+          type: array
+          items:
+            $ref: '#/components/schemas/Token'

--- a/data/circular-two-edges-components2.yaml
+++ b/data/circular-two-edges-components2.yaml
@@ -1,0 +1,20 @@
+openapi: 3.0.3
+info:
+  title: Recursive schema demo
+  version: 1.0.0
+components:
+  schemas:
+    Token:
+      type: object
+      properties:
+        name:
+          type: string
+        index:
+          type: integer
+        parent:
+          $ref: '#/components/schemas/Token'
+        sub_tokens:
+          description: Collection of child tokens, ordered by index
+          type: array
+          items:
+            $ref: '#/components/schemas/Token'

--- a/data/circular-two-edges1.yaml
+++ b/data/circular-two-edges1.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.3
+info:
+  title: Recursive schema demo
+  version: 1.0.0
+paths:
+  /tokens:
+    get:
+      operationId: listTokens
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Token'
+components:
+  schemas:
+    Token:
+      type: object
+      properties:
+        name:
+          type: string
+        parent:
+          $ref: '#/components/schemas/Token'
+        sub_tokens:
+          description: Collection of child tokens
+          type: array
+          items:
+            $ref: '#/components/schemas/Token'

--- a/data/circular-two-edges2.yaml
+++ b/data/circular-two-edges2.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.3
+info:
+  title: Recursive schema demo
+  version: 1.0.0
+paths:
+  /tokens:
+    get:
+      operationId: listTokens
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Token'
+components:
+  schemas:
+    Token:
+      type: object
+      properties:
+        name:
+          type: string
+        index:
+          type: integer
+        parent:
+          $ref: '#/components/schemas/Token'
+        sub_tokens:
+          description: Collection of child tokens, ordered by index
+          type: array
+          items:
+            $ref: '#/components/schemas/Token'

--- a/diff/circular_determinism_test.go
+++ b/diff/circular_determinism_test.go
@@ -12,17 +12,20 @@ import (
 // Token cycles through two edges, parent and sub_tokens.items. Where each
 // edge's walk is cut depends on the ancestors on its path, so a cut-affected
 // diff holds for its own path only; reusing it for the same pair on another
-// path hands one edge the other's answer, and which edge wins follows the
-// map iteration order over properties, changing the output between runs
-// (#1230). Each edge must carry its own one-level diff, identically on
-// every run.
+// path hands one edge the other's answer (#1230). Two fixture pairs cover
+// the two ways that goes wrong: with Token only reachable ref-less from
+// components, the two edges race on the map iteration order over properties
+// and the output changes between runs; with a paths $ref to Token as well,
+// the paths entry computes the edge pairs under its own visited set first,
+// and reusing those cuts truncates both edges of the components entry.
+// Each edge must carry its own one-level diff, identically on every run.
 func TestCircularTwoEdges_Deterministic(t *testing.T) {
-	get := func() (*diff.Diff, []byte) {
+	get := func(base, revision string) (*diff.Diff, []byte) {
 		t.Helper()
 		loader := openapi3.NewLoader()
-		s1, err := loader.LoadFromFile("../data/circular-two-edges1.yaml")
+		s1, err := loader.LoadFromFile(base)
 		require.NoError(t, err)
-		s2, err := loader.LoadFromFile("../data/circular-two-edges2.yaml")
+		s2, err := loader.LoadFromFile(revision)
 		require.NoError(t, err)
 		d, err := diff.Get(diff.NewConfig(), s1, s2)
 		require.NoError(t, err)
@@ -33,16 +36,20 @@ func TestCircularTwoEdges_Deterministic(t *testing.T) {
 		return d, append(paths, components...)
 	}
 
-	d, first := get()
-	edges := d.ComponentsDiff.SchemasDiff.Modified["Token"].PropertiesDiff.Modified
-	for _, edge := range []string{"parent", "sub_tokens"} {
-		require.NotNil(t, edges[edge], "the %s cycle edge must carry its own diff", edge)
-	}
-	require.Contains(t, edges["parent"].PropertiesDiff.Added, "index")
-	require.Contains(t, edges["sub_tokens"].ItemsDiff.PropertiesDiff.Added, "index")
+	for _, fixture := range []string{"../data/circular-two-edges", "../data/circular-two-edges-components"} {
+		base, revision := fixture+"1.yaml", fixture+"2.yaml"
 
-	for range 9 {
-		_, next := get()
-		require.Equal(t, string(first), string(next), "identical inputs must produce identical output")
+		d, first := get(base, revision)
+		edges := d.ComponentsDiff.SchemasDiff.Modified["Token"].PropertiesDiff.Modified
+		for _, edge := range []string{"parent", "sub_tokens"} {
+			require.NotNil(t, edges[edge], "%s: the %s cycle edge must carry its own diff", fixture, edge)
+		}
+		require.Contains(t, edges["parent"].PropertiesDiff.Added, "index", fixture)
+		require.Contains(t, edges["sub_tokens"].ItemsDiff.PropertiesDiff.Added, "index", fixture)
+
+		for range 9 {
+			_, next := get(base, revision)
+			require.Equal(t, string(first), string(next), "%s: identical inputs must produce identical output", fixture)
+		}
 	}
 }

--- a/diff/circular_determinism_test.go
+++ b/diff/circular_determinism_test.go
@@ -1,0 +1,48 @@
+package diff_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/oasdiff/diff"
+	"github.com/stretchr/testify/require"
+)
+
+// Token cycles through two edges, parent and sub_tokens.items. Where each
+// edge's walk is cut depends on the ancestors on its path, so a cut-affected
+// diff holds for its own path only; reusing it for the same pair on another
+// path hands one edge the other's answer, and which edge wins follows the
+// map iteration order over properties, changing the output between runs
+// (#1230). Each edge must carry its own one-level diff, identically on
+// every run.
+func TestCircularTwoEdges_Deterministic(t *testing.T) {
+	get := func() (*diff.Diff, []byte) {
+		t.Helper()
+		loader := openapi3.NewLoader()
+		s1, err := loader.LoadFromFile("../data/circular-two-edges1.yaml")
+		require.NoError(t, err)
+		s2, err := loader.LoadFromFile("../data/circular-two-edges2.yaml")
+		require.NoError(t, err)
+		d, err := diff.Get(diff.NewConfig(), s1, s2)
+		require.NoError(t, err)
+		paths, err := json.Marshal(d.PathsDiff)
+		require.NoError(t, err)
+		components, err := json.Marshal(d.ComponentsDiff)
+		require.NoError(t, err)
+		return d, append(paths, components...)
+	}
+
+	d, first := get()
+	edges := d.ComponentsDiff.SchemasDiff.Modified["Token"].PropertiesDiff.Modified
+	for _, edge := range []string{"parent", "sub_tokens"} {
+		require.NotNil(t, edges[edge], "the %s cycle edge must carry its own diff", edge)
+	}
+	require.Contains(t, edges["parent"].PropertiesDiff.Added, "index")
+	require.Contains(t, edges["sub_tokens"].ItemsDiff.PropertiesDiff.Added, "index")
+
+	for range 9 {
+		_, next := get()
+		require.Equal(t, string(first), string(next), "identical inputs must produce identical output")
+	}
+}

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -737,11 +737,23 @@ func TestCircularSchema_Diff(t *testing.T) {
 	s2, err := loader.LoadFromFile("../data/circular2.yaml")
 	require.NoError(t, err)
 
-	_, err = diff.Get(diff.NewConfig(), s1, s2)
+	dd, err := diff.Get(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 
-	// TODO: fix circular checks and re-enable this test
-	// require.True(t, dd.SchemasDiff.Modified["circular1"].PropertiesDiff.Modified["children"].ItemsDiff.CircularRefDiff)
+	// entered through its $ref, the walk is already inside circular1, so
+	// the revision's items $ref cycles where the base's inline items does
+	// not: a reported difference
+	respItems := dd.PathsDiff.Modified["/test"].OperationsDiff.Modified["POST"].
+		ResponsesDiff.Modified["200"].ContentDiff.MediaTypeModified["application/json"].
+		SchemaDiff.PropertiesDiff.Modified["children"].ItemsDiff
+	require.True(t, respItems.CircularRefDiff)
+
+	// entered ref-less from components, no ancestor is comparing circular1
+	// yet, so the same pair unrolls one level instead
+	compItems := dd.ComponentsDiff.SchemasDiff.Modified["circular1"].
+		PropertiesDiff.Modified["children"].ItemsDiff
+	require.False(t, compItems.CircularRefDiff)
+	require.Contains(t, compItems.PropertiesDiff.Added, "children")
 }
 
 func TestCircularSchemaRefs(t *testing.T) {

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -776,6 +776,57 @@ func TestCircularSchemaRefs(t *testing.T) {
 	require.Contains(t, dd.ComponentsDiff.SchemasDiff.Modified, "circular6")
 }
 
+// namedCyclicDoc builds a spec whose request body is a $ref to a schema
+// whose child property refers back to it through the same $ref.
+func namedCyclicDoc(name string) *openapi3.T {
+	ref := "#/components/schemas/" + name
+	node := &openapi3.Schema{Type: &openapi3.Types{"object"}}
+	node.Properties = openapi3.Schemas{
+		"child": &openapi3.SchemaRef{Ref: ref, Value: node},
+	}
+	return &openapi3.T{
+		OpenAPI: "3.0.3",
+		Info:    &openapi3.Info{Title: "t", Version: "1"},
+		Paths: openapi3.NewPaths(openapi3.WithPath("/x", &openapi3.PathItem{
+			Post: &openapi3.Operation{
+				RequestBody: &openapi3.RequestBodyRef{Value: &openapi3.RequestBody{
+					Content: openapi3.Content{"application/json": &openapi3.MediaType{
+						Schema: &openapi3.SchemaRef{Ref: ref, Value: node},
+					}},
+				}},
+				Responses: openapi3.NewResponses(openapi3.WithStatus(200, &openapi3.ResponseRef{
+					Value: &openapi3.Response{Description: new("ok")},
+				})),
+			},
+		})),
+	}
+}
+
+// Both sides cycle, through different ref names: the cycles are not known
+// to be the same schema, so the mismatch is a reported difference.
+func TestCircularSchema_RenamedCycle(t *testing.T) {
+	d, err := diff.Get(diff.NewConfig(), namedCyclicDoc("NodeA"), namedCyclicDoc("NodeB"))
+	require.NoError(t, err)
+
+	child := d.PathsDiff.Modified["/x"].OperationsDiff.Modified["POST"].
+		RequestBodyDiff.ContentDiff.MediaTypeModified["application/json"].
+		SchemaDiff.PropertiesDiff.Modified["child"]
+	require.True(t, child.CircularRefDiff)
+}
+
+// Both sides cycle through the same ref name: the cut adds nothing beyond
+// the comparison already underway, so identical specs diff to empty.
+func TestCircularSchema_SameCycleNoDiff(t *testing.T) {
+	s1, err := openapi3.NewLoader().LoadFromFile("../data/circular-two-edges1.yaml")
+	require.NoError(t, err)
+	s2, err := openapi3.NewLoader().LoadFromFile("../data/circular-two-edges1.yaml")
+	require.NoError(t, err)
+
+	d, err := diff.Get(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	require.True(t, d.Empty())
+}
+
 func TestCallbacks(t *testing.T) {
 	loader := openapi3.NewLoader()
 

--- a/diff/schema_circular_refs.go
+++ b/diff/schema_circular_refs.go
@@ -12,6 +12,12 @@ const (
 	circularRefStatusNoDiff
 )
 
+// getCircularRefsDiff compares how the two sides cycle when a $ref already
+// being compared higher up the walk is reached again: one side cycling where
+// the other does not, or cycling through a different name, is a reported
+// difference (CircularRefDiff); the same name on both sides adds nothing
+// beyond the comparison already underway. The verdict depends on the visited
+// sets, so callers must not reuse a diff computed under it for another path.
 func getCircularRefsDiff(visited1, visited2 map[string]struct{}, schema1, schema2 *openapi3.SchemaRef) circularRefStatus {
 
 	if schema1 == nil || schema2 == nil ||

--- a/diff/schema_diff.go
+++ b/diff/schema_diff.go
@@ -113,16 +113,18 @@ func getSchemaDiff(config *Config, state *state, schema1, schema2 *openapi3.Sche
 	// circular-ref guard does: report no diff at the re-entry point.
 	pair := schemaPair{schema1, schema2}
 	if _, ok := state.inFlight[pair]; ok {
-		// this no-diff answer holds only while the frame above is computing
-		// the pair: count the cut so no result built on it is cached
+		// the no-diff answer stands in for the pair's computation already in
+		// progress; count the cut: a diff whose computation includes it is
+		// not cached
 		state.cuts++
 		return nil, nil
 	}
 	state.inFlight[pair] = struct{}{}
 	defer delete(state.inFlight, pair)
 
-	// a cut anywhere below makes the result depend on this path, not on the
-	// pair alone; the counter comparison detects it at any depth
+	// a diff whose computation includes a cut depends on the path that led
+	// here, not on the pair alone; comparing the count detects a cut at any
+	// depth
 	cutsBefore := state.cuts
 	diff, err := getSchemaDiffInternal(config, state, schema1, schema2)
 	if err != nil {
@@ -167,8 +169,9 @@ func getSchemaDiffInternal(config *Config, state *state, schema1, schema2 *opena
 	}
 
 	if status := getCircularRefsDiff(state.visitedSchemasBase, state.visitedSchemasRevision, schema1, schema2); status != circularRefStatusNone {
-		// the verdict reads the visited sets, so it holds for this path only:
-		// count the cut so no result built on it is cached
+		// the verdict reads the visited sets, so it holds only for the path
+		// that led here; count the cut: a diff whose computation includes it
+		// is not cached
 		state.cuts++
 		switch status {
 		case circularRefStatusDiff:

--- a/diff/schema_diff.go
+++ b/diff/schema_diff.go
@@ -113,12 +113,16 @@ func getSchemaDiff(config *Config, state *state, schema1, schema2 *openapi3.Sche
 	// circular-ref guard does: report no diff at the re-entry point.
 	pair := schemaPair{schema1, schema2}
 	if _, ok := state.inFlight[pair]; ok {
+		// this no-diff answer holds only while the frame above is computing
+		// the pair: count the cut so no result built on it is cached
 		state.cuts++
 		return nil, nil
 	}
 	state.inFlight[pair] = struct{}{}
 	defer delete(state.inFlight, pair)
 
+	// a cut anywhere below makes the result depend on this path, not on the
+	// pair alone; the counter comparison detects it at any depth
 	cutsBefore := state.cuts
 	diff, err := getSchemaDiffInternal(config, state, schema1, schema2)
 	if err != nil {
@@ -129,6 +133,8 @@ func getSchemaDiff(config *Config, state *state, schema1, schema2 *openapi3.Sche
 		diff = nil
 	}
 
+	// no cut fired: the diff is a function of the pair alone and can be
+	// reused on any path
 	if state.cuts == cutsBefore {
 		state.cache[pair] = diff
 	}
@@ -161,6 +167,8 @@ func getSchemaDiffInternal(config *Config, state *state, schema1, schema2 *opena
 	}
 
 	if status := getCircularRefsDiff(state.visitedSchemasBase, state.visitedSchemasRevision, schema1, schema2); status != circularRefStatusNone {
+		// the verdict reads the visited sets, so it holds for this path only:
+		// count the cut so no result built on it is cached
 		state.cuts++
 		switch status {
 		case circularRefStatusDiff:

--- a/diff/schema_diff.go
+++ b/diff/schema_diff.go
@@ -113,11 +113,13 @@ func getSchemaDiff(config *Config, state *state, schema1, schema2 *openapi3.Sche
 	// circular-ref guard does: report no diff at the re-entry point.
 	pair := schemaPair{schema1, schema2}
 	if _, ok := state.inFlight[pair]; ok {
+		state.cuts++
 		return nil, nil
 	}
 	state.inFlight[pair] = struct{}{}
 	defer delete(state.inFlight, pair)
 
+	cutsBefore := state.cuts
 	diff, err := getSchemaDiffInternal(config, state, schema1, schema2)
 	if err != nil {
 		return nil, err
@@ -127,7 +129,9 @@ func getSchemaDiff(config *Config, state *state, schema1, schema2 *openapi3.Sche
 		diff = nil
 	}
 
-	state.cache[schemaPair{schema1, schema2}] = diff
+	if state.cuts == cutsBefore {
+		state.cache[pair] = diff
+	}
 	return diff, nil
 }
 
@@ -157,6 +161,7 @@ func getSchemaDiffInternal(config *Config, state *state, schema1, schema2 *opena
 	}
 
 	if status := getCircularRefsDiff(state.visitedSchemasBase, state.visitedSchemasRevision, schema1, schema2); status != circularRefStatusNone {
+		state.cuts++
 		switch status {
 		case circularRefStatusDiff:
 			result.CircularRefDiff = true

--- a/diff/state.go
+++ b/diff/state.go
@@ -6,13 +6,8 @@ type state struct {
 	cache                  schemaDiffCache
 	inFlight               map[schemaPair]struct{}
 
-	// cuts counts the cycle-guard cuts taken so far. A cut's verdict
-	// depends on which ancestors are on the path, so a diff computed while
-	// a cut fires beneath it holds for its own path only: getSchemaDiff
-	// caches a pair's diff only when no cut fired during its computation.
-	// Caching such a diff replays one path's answer at every other use of
-	// the pair, and which path computes first follows the map iteration
-	// order over properties, so the output differs between runs (#1230).
+	// when a cycle is detected, the cut count is incremented so that diffs
+	// computed above the cut are not cached.
 	cuts int
 }
 

--- a/diff/state.go
+++ b/diff/state.go
@@ -6,8 +6,8 @@ type state struct {
 	cache                  schemaDiffCache
 	inFlight               map[schemaPair]struct{}
 
-	// when a cycle is detected, the cut count is incremented so that diffs
-	// computed above the cut are not cached.
+	// when a cycle is detected, the cut count is incremented; a diff whose
+	// computation included a cut is not cached.
 	cuts int
 }
 

--- a/diff/state.go
+++ b/diff/state.go
@@ -5,6 +5,15 @@ type state struct {
 	visitedSchemasRevision map[string]struct{}
 	cache                  schemaDiffCache
 	inFlight               map[schemaPair]struct{}
+
+	// cuts counts the cycle-guard cuts taken so far. A cut's verdict
+	// depends on which ancestors are on the path, so a diff computed while
+	// a cut fires beneath it holds for its own path only: getSchemaDiff
+	// caches a pair's diff only when no cut fired during its computation.
+	// Caching such a diff replays one path's answer at every other use of
+	// the pair, and which path computes first follows the map iteration
+	// order over properties, so the output differs between runs (#1230).
+	cuts int
 }
 
 func newState() *state {

--- a/report/report.go
+++ b/report/report.go
@@ -390,7 +390,7 @@ func (r *report) printSchema(d *diff.SchemaDiff) {
 
 	r.printConditional(d.SchemaAdded, "Schema added")
 	r.printConditional(d.SchemaDeleted, "Schema deleted")
-	r.printConditional(d.CircularRefDiff, "Schema circular referecnce changed")
+	r.printConditional(d.CircularRefDiff, "Schema circular reference changed")
 
 	if !d.ExtensionsDiff.Empty() {
 		r.print("Extensions changed")


### PR DESCRIPTION
Fixes #1230. Closes #1235.

## The bug (#1230)

`oasdiff diff --format json` was nondeterministic on schemas with more than one reference cycle: identical inputs produced two different outputs at random. Reproduced with the issue's fixture (18/12-ish split over 30 runs on main).

Root cause: a cycle guard's verdict depends on which ancestors are on the walk's path (the visited refs, the in-flight pairs). A diff computed while a cut fires beneath it therefore holds for its own path only, but the schema-diff cache stored it keyed by schema pair alone. The same pair reached on another path replayed the first path's answer, and which path computes first follows Go's randomized map iteration over `properties`: with two cycle edges through one schema, one edge randomly received the other's cut, which is exactly the "one edge gets the unrolling" in the report.

## The fix

`getSchemaDiff` counts guard cuts and caches a pair's diff only when no cut fired during its computation. Cut-affected (cyclic) subtrees are recomputed per path; acyclic schemas cache exactly as before.

After the fix, the issue's reproducer is 30/30 byte-identical, and the output is also more complete: each cycle edge carries its own one-level diff instead of one edge being silently truncated by the other's cached cut.

## Pinning the verdict (#1235)

With the output deterministic, `CircularRefDiff` is now asserted by tests for the first time:

- `TestCircularSchema_Diff` replaces its disabled TODO assertion: at a site entered through a $ref (the walk is already inside the schema), a base-inline vs revision-$ref mismatch reports `circularRef: true`; at a site entered ref-less (components), the same pair unrolls one level instead. Both are correct per-path answers, now stable per site.
- `TestCircularTwoEdges_Deterministic` pins the #1230 fixture: both edges carry their own diff, and ten runs marshal identically.

Also: the text report's spelling of the verdict is fixed ("referecnce"), and `getCircularRefsDiff` gains a doc comment stating that its verdict is path-dependent and must not be reused across paths.

Note: trivial conflict expected with #1236 in `diff/state.go` (whichever merges second rebases in seconds).

Full suite and lint pass.