### PR TITLE
flatten: name the cycles the in-flight guard anchors

### DIFF
--- a/data/allof/two-recursive-branches.yaml
+++ b/data/allof/two-recursive-branches.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.3
+info: {title: two distinct recursive branches, version: "1"}
+paths:
+  /x:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                tree:
+                  allOf:
+                    - $ref: "#/components/schemas/NodeA"
+                    - $ref: "#/components/schemas/NodeB"
+      responses:
+        "200": {description: ok}
+components:
+  schemas:
+    NodeA:
+      type: object
+      properties:
+        child:
+          $ref: "#/components/schemas/NodeA"
+    NodeB:
+      type: object
+      properties:
+        child:
+          $ref: "#/components/schemas/NodeB"

--- a/flatten/allof/merge_allof.go
+++ b/flatten/allof/merge_allof.go
@@ -100,6 +100,10 @@ func newState() *state {
 	}
 }
 
+// Merge flattens the allOf chains of a single schema and its subtree. A
+// recursive input whose cycle has no name merges to an in-memory cycle with
+// no $ref, which does not marshal; MergeSpec, which flattens a whole
+// document, additionally names such cycles.
 func Merge(schema openapi3.SchemaRef) (*openapi3.Schema, error) {
 	merged, _, err := mergeWithAnchors(schema)
 	return merged, err

--- a/flatten/allof/merge_allof.go
+++ b/flatten/allof/merge_allof.go
@@ -83,6 +83,12 @@ type state struct {
 	// to that result Value, which breaks recursion through cyclic
 	// Properties / Items / Contains / PropertyNames sub-schemas (#890).
 	flattening map[*openapi3.Schema]*openapi3.Schema
+
+	// anchored records the SchemaRefs the in-flight guard pointed at a
+	// result being populated further up. Such an edge carries no $ref, so a
+	// cycle through it has no serialized form until the target is named;
+	// MergeSpec names the targets (nameAnchoredCycles).
+	anchored []*openapi3.SchemaRef
 }
 
 func newState() *state {
@@ -95,24 +101,27 @@ func newState() *state {
 }
 
 func Merge(schema openapi3.SchemaRef) (*openapi3.Schema, error) {
+	merged, _, err := mergeWithAnchors(schema)
+	return merged, err
+}
+
+// mergeWithAnchors is Merge, also reporting the ref-less back-edges the
+// in-flight guard created, so a spec-level caller can name their targets.
+func mergeWithAnchors(schema openapi3.SchemaRef) (*openapi3.Schema, []*openapi3.SchemaRef, error) {
 	state := newState()
 	result, err := mergeInternal(state, &schema)
 	if err != nil {
-		return nil, err
-	}
-
-	if len(state.circularAllOf) == 0 {
-		return result.Value, nil
+		return nil, nil, err
 	}
 
 	for _, schema := range state.circularAllOf {
 		err := mergeCircularAllOf(state, schema)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
-	return result.Value, nil
+	return result.Value, state.anchored, nil
 }
 
 func mergeCircularAllOf(state *state, baseSchemaRef *openapi3.SchemaRef) error {
@@ -439,6 +448,7 @@ func flattenSchemas(state *state, result *openapi3.SchemaRef, schemas []*openapi
 		}
 		if inFlight, ok := state.flattening[s.Value]; ok {
 			result.Value = inFlight
+			state.anchored = append(state.anchored, result)
 			return nil
 		}
 	}

--- a/flatten/allof/merge_allof_spec.go
+++ b/flatten/allof/merge_allof_spec.go
@@ -1,7 +1,9 @@
 package allof
 
 import (
+	"fmt"
 	"reflect"
+	"slices"
 
 	"github.com/getkin/kin-openapi/openapi3"
 )
@@ -11,11 +13,13 @@ import (
 // cycle tracking), so the walk hands it each attachment point once and skips
 // descent.
 func MergeSpec(spec *openapi3.T) (*openapi3.T, error) {
+	var anchored []*openapi3.SchemaRef
 	err := spec.WalkSchemas(func(_ string, s *openapi3.SchemaRef) error {
-		m, err := Merge(*s)
+		m, edges, err := mergeWithAnchors(*s)
 		if err != nil {
 			return err
 		}
+		anchored = append(anchored, edges...)
 		// Every $ref to this schema shares one Value, so writing the merge
 		// into it updates every use. Assigning s.Value would update only
 		// this reference and leave the rest unmerged.
@@ -28,7 +32,65 @@ func MergeSpec(spec *openapi3.T) (*openapi3.T, error) {
 		redirectSchemaRefs(reflect.ValueOf(s.Value), m, s.Value, map[*openapi3.Schema]bool{})
 		return openapi3.SkipSubtree
 	})
-	return spec, err
+	if err != nil {
+		return spec, err
+	}
+	nameAnchoredCycles(spec, anchored)
+	return spec, nil
+}
+
+// nameAnchoredCycles gives every anchored back-edge a $ref. The edge's value
+// is right (a cycle in the input is a cycle in the merged output), but the
+// edge carries no $ref, and a ref-less cycle has no serialized form. A target
+// that is a named component gets that name; an anonymous target is hoisted
+// into components.schemas under a generated name. Names are assigned in the
+// document's walk order, which is deterministic, so identical inputs name
+// identical targets.
+func nameAnchoredCycles(spec *openapi3.T, anchored []*openapi3.SchemaRef) {
+	if len(anchored) == 0 {
+		return
+	}
+
+	nameByValue := map[*openapi3.Schema]string{}
+	if spec.Components != nil {
+		for name, ref := range spec.Components.Schemas {
+			if ref != nil && ref.Value != nil {
+				nameByValue[ref.Value] = name
+			}
+		}
+	}
+
+	walkOrder := map[*openapi3.Schema]int{}
+	_ = spec.WalkSchemas(func(_ string, s *openapi3.SchemaRef) error {
+		walkOrder[s.Value] = len(walkOrder)
+		return nil
+	})
+	slices.SortStableFunc(anchored, func(a, b *openapi3.SchemaRef) int {
+		return walkOrder[a.Value] - walkOrder[b.Value]
+	})
+
+	next := 1
+	for _, edge := range anchored {
+		name, ok := nameByValue[edge.Value]
+		if !ok {
+			for {
+				name = fmt.Sprintf("AllOfMerged%d", next)
+				next++
+				if spec.Components == nil || spec.Components.Schemas[name] == nil {
+					break
+				}
+			}
+			if spec.Components == nil {
+				spec.Components = &openapi3.Components{}
+			}
+			if spec.Components.Schemas == nil {
+				spec.Components.Schemas = openapi3.Schemas{}
+			}
+			spec.Components.Schemas[name] = openapi3.NewSchemaRef("", edge.Value)
+			nameByValue[edge.Value] = name
+		}
+		edge.Ref = "#/components/schemas/" + name
+	}
 }
 
 // redirectSchemaRefs walks every SchemaRef reachable from v and points those

--- a/flatten/allof/merge_allof_spec_test.go
+++ b/flatten/allof/merge_allof_spec_test.go
@@ -127,3 +127,32 @@ func Test_MergeSpec_RecursiveOverlaySerializes(t *testing.T) {
 	_, err = spec.Spec.MarshalJSON()
 	require.NoError(t, err)
 }
+
+// An allOf over two distinct recursive components merges to a node whose
+// recursion the in-flight guard anchored without a $ref; the anchor's value
+// is right but a ref-less cycle has no serialized form. MergeSpec names the
+// anchored target, hoisting it into components, so the merged spec marshals
+// and the name is stable across runs.
+func Test_MergeSpec_TwoRecursiveBranchesSerializes(t *testing.T) {
+	loadMerged := func() *openapi3.T {
+		spec, err := load.NewSpecInfo(openapi3.NewLoader(), load.NewSource("../../data/allof/two-recursive-branches.yaml"), load.WithFlattenAllOf())
+		require.NoError(t, err)
+		return spec.Spec
+	}
+	merged := loadMerged()
+
+	tree := merged.Paths.Value("/x").Post.RequestBody.Value.Content["application/json"].
+		Schema.Value.Properties["tree"]
+	require.Empty(t, tree.Value.AllOf)
+
+	child := tree.Value.Properties["child"]
+	require.Equal(t, "#/components/schemas/AllOfMerged1", child.Ref)
+	require.Same(t, tree.Value, child.Value)
+	require.Same(t, tree.Value, merged.Components.Schemas["AllOfMerged1"].Value)
+
+	first, err := merged.MarshalJSON()
+	require.NoError(t, err)
+	second, err := loadMerged().MarshalJSON()
+	require.NoError(t, err)
+	require.Equal(t, string(first), string(second))
+}


### PR DESCRIPTION
Closes the limitation documented in #1233: an allOf over **two distinct** recursive components still crashed `oasdiff flatten` with a stack overflow.

## Why this shape resisted #1233

`allOf: [$ref NodeA, $ref NodeB]`, each recursive, merges a child set with two *distinct* schemas — no lone schema to reuse — so `flattenSchemas` must run, and its in-flight guard anchors the recursive edge at the result being built. The anchor's **value is semantically right**: the merged node's recursion is the merged node itself (merge(A,B) recursively equals merge(A,B)). What's wrong is only the **representation**: the merged node is anonymous, the edge carries no `$ref`, and a ref-less cycle has no serialized form.

## The fix: give the anchor a name

- The merge records every edge the in-flight guard anchors (`state.anchored`).
- `MergeSpec` then names each target: a target that is already a named component gets that component's `$ref`; an anonymous target is **hoisted** into `components.schemas` under a generated `AllOfMergedN` name, and the edge becomes a `$ref` to it.
- Names are assigned in the document's deterministic walk order — not in the merge's map-iteration order — so identical inputs produce identical output (the #1230 lesson applied preemptively).

The fixture now flattens to:

```yaml
components:
  schemas:
    AllOfMerged1:            # hoisted merged node
      type: object
      properties:
        child:
          $ref: '#/components/schemas/AllOfMerged1'
```

with the inline occurrence referencing it, and NodeA/NodeB untouched.

Scope note: the naming pass runs in `MergeSpec` (it needs the components map); the schema-level `Merge` API is unchanged and can still produce in-memory ref-less cycles for library callers, which the diff's in-flight guard (#1231) handles.

Regression test asserts the hoisted name, the shared identity between the inline node and the component, a successful marshal of the whole document, and byte-identical output across two loads. Full suite and lint pass; `breaking --flatten-allof` on the shape stays green as before.