### PR TITLE
flatten: a mixed cycle set keeps its non-cyclic siblings

### DIFF
--- a/data/allof/mixed-cycle-branch.yaml
+++ b/data/allof/mixed-cycle-branch.yaml
@@ -1,0 +1,30 @@
+openapi: 3.0.3
+info: {title: t, version: "1"}
+paths:
+  /x:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                tree:
+                  allOf:
+                    - $ref: "#/components/schemas/NodeA"
+                    - type: object
+                      properties:
+                        child:
+                          $ref: "#/components/schemas/Plain"
+      responses:
+        "200": {description: ok}
+components:
+  schemas:
+    NodeA:
+      type: object
+      properties:
+        child: {$ref: "#/components/schemas/NodeA"}
+    Plain:
+      type: object
+      properties:
+        leaf: {type: string}

--- a/flatten/allof/merge_allof.go
+++ b/flatten/allof/merge_allof.go
@@ -441,20 +441,49 @@ func flattenSchemas(state *state, result *openapi3.SchemaRef, schemas []*openapi
 	// trims work the cycle guard would otherwise have to do.
 	schemas = dedupSchemaRefsByValue(schemas)
 
-	// Tier 2: cycle guard. If any input schema is already being
-	// flattened higher in the call stack, point our result Value at
-	// that in-flight Value and return — the cyclic Properties / Items
-	// / Contains / PropertyNames link in the input is preserved as a
-	// cyclic link in the merged output, without infinite recursion.
+	// Tier 2: cycle guard. An input schema that is already being flattened
+	// higher in the call stack stands for that in-flight result — the cyclic
+	// Properties / Items / Contains / PropertyNames link in the input is
+	// preserved as a cyclic link in the merged output, without infinite
+	// recursion. When the whole set is one such schema, the result is that
+	// in-flight value; a set that also carries other schemas keeps their
+	// constraints as a residual allOf of the anchors and the merge of the
+	// rest, unflattened at this node but complete (#1242).
+	var anchors []*openapi3.Schema
+	rest := make(openapi3.SchemaRefs, 0, len(schemas))
 	for _, s := range schemas {
 		if s == nil || s.Value == nil {
 			continue
 		}
 		if inFlight, ok := state.flattening[s.Value]; ok {
-			result.Value = inFlight
-			state.anchored = append(state.anchored, result)
-			return nil
+			if !slices.Contains(anchors, inFlight) {
+				anchors = append(anchors, inFlight)
+			}
+		} else {
+			rest = append(rest, s)
 		}
+	}
+	if len(anchors) == 1 && len(rest) == 0 {
+		result.Value = anchors[0]
+		state.anchored = append(state.anchored, result)
+		return nil
+	}
+	if len(anchors) > 0 {
+		residual := make(openapi3.SchemaRefs, 0, len(anchors)+1)
+		for _, anchor := range anchors {
+			ref := openapi3.NewSchemaRef("", anchor)
+			state.anchored = append(state.anchored, ref)
+			residual = append(residual, ref)
+		}
+		if len(rest) > 0 {
+			merged := openapi3.NewSchemaRef("", openapi3.NewSchema())
+			if err := flattenSchemas(state, merged, rest); err != nil {
+				return err
+			}
+			residual = append(residual, merged)
+		}
+		result.Value.AllOf = residual
+		return nil
 	}
 
 	// Mark each non-nil input schema as in-flight, mapped to the

--- a/flatten/allof/merge_allof.go
+++ b/flatten/allof/merge_allof.go
@@ -431,24 +431,9 @@ func mergeSchemaRefs(state *state, srefs openapi3.SchemaRefs) (openapi3.SchemaRe
 	return result, nil
 }
 
-// Given a list of schemas that are free of AllOf or nested AllOf components as input,
-// the function produces a single equivalent schema in the resultRef parameter.
-func flattenSchemas(state *state, result *openapi3.SchemaRef, schemas []*openapi3.SchemaRef) error {
-
-	// Tier 1: pointer-dedup the input. The same *Schema appearing
-	// multiple times contributes nothing extra to the merge and, when
-	// the input set reduces to schemas already in flight (Tier 2),
-	// trims work the cycle guard would otherwise have to do.
-	schemas = dedupSchemaRefsByValue(schemas)
-
-	// Tier 2: cycle guard. An input schema that is already being flattened
-	// higher in the call stack stands for that in-flight result — the cyclic
-	// Properties / Items / Contains / PropertyNames link in the input is
-	// preserved as a cyclic link in the merged output, without infinite
-	// recursion. When the whole set is one such schema, the result is that
-	// in-flight value; a set that also carries other schemas keeps their
-	// constraints as a residual allOf of the anchors and the merge of the
-	// rest, unflattened at this node but complete (#1242).
+// splitInFlight partitions the schemas into the in-flight results that inputs
+// already being flattened higher in the call stack stand for, and the rest.
+func splitInFlight(state *state, schemas openapi3.SchemaRefs) ([]*openapi3.Schema, openapi3.SchemaRefs) {
 	var anchors []*openapi3.Schema
 	rest := make(openapi3.SchemaRefs, 0, len(schemas))
 	for _, s := range schemas {
@@ -463,27 +448,61 @@ func flattenSchemas(state *state, result *openapi3.SchemaRef, schemas []*openapi
 			rest = append(rest, s)
 		}
 	}
+	return anchors, rest
+}
+
+// anchorInFlight cuts the cycles in a set containing schemas that are already
+// being flattened higher in the call stack, and reports whether it produced
+// the result. Such a schema stands for its in-flight result: a cyclic
+// Properties / Items / Contains / PropertyNames link in the input is
+// preserved as a cyclic link in the merged output, without infinite
+// recursion. A set that is one such schema merges to that in-flight value; a
+// set that also carries other schemas keeps their constraints as a residual
+// allOf of the anchors and the merge of the rest, unflattened at this node
+// but complete (#1242). Every anchor edge joins state.anchored so
+// nameAnchoredCycles can give it a $ref.
+func anchorInFlight(state *state, result *openapi3.SchemaRef, schemas openapi3.SchemaRefs) (bool, error) {
+	anchors, rest := splitInFlight(state, schemas)
+	if len(anchors) == 0 {
+		return false, nil
+	}
+
 	if len(anchors) == 1 && len(rest) == 0 {
 		result.Value = anchors[0]
 		state.anchored = append(state.anchored, result)
-		return nil
+		return true, nil
 	}
-	if len(anchors) > 0 {
-		residual := make(openapi3.SchemaRefs, 0, len(anchors)+1)
-		for _, anchor := range anchors {
-			ref := openapi3.NewSchemaRef("", anchor)
-			state.anchored = append(state.anchored, ref)
-			residual = append(residual, ref)
+
+	residual := make(openapi3.SchemaRefs, 0, len(anchors)+1)
+	for _, anchor := range anchors {
+		ref := openapi3.NewSchemaRef("", anchor)
+		state.anchored = append(state.anchored, ref)
+		residual = append(residual, ref)
+	}
+	if len(rest) > 0 {
+		merged := openapi3.NewSchemaRef("", openapi3.NewSchema())
+		if err := flattenSchemas(state, merged, rest); err != nil {
+			return true, err
 		}
-		if len(rest) > 0 {
-			merged := openapi3.NewSchemaRef("", openapi3.NewSchema())
-			if err := flattenSchemas(state, merged, rest); err != nil {
-				return err
-			}
-			residual = append(residual, merged)
-		}
-		result.Value.AllOf = residual
-		return nil
+		residual = append(residual, merged)
+	}
+	result.Value.AllOf = residual
+	return true, nil
+}
+
+// Given a list of schemas that are free of AllOf or nested AllOf components as input,
+// the function produces a single equivalent schema in the resultRef parameter.
+func flattenSchemas(state *state, result *openapi3.SchemaRef, schemas []*openapi3.SchemaRef) error {
+
+	// Tier 1: pointer-dedup the input. The same *Schema appearing
+	// multiple times contributes nothing extra to the merge and, when
+	// the input set reduces to schemas already in flight (Tier 2),
+	// trims work the cycle guard would otherwise have to do.
+	schemas = dedupSchemaRefsByValue(schemas)
+
+	// Tier 2: cycle guard.
+	if done, err := anchorInFlight(state, result, schemas); done || err != nil {
+		return err
 	}
 
 	// Mark each non-nil input schema as in-flight, mapped to the

--- a/flatten/allof/merge_allof_spec_test.go
+++ b/flatten/allof/merge_allof_spec_test.go
@@ -156,3 +156,23 @@ func Test_MergeSpec_TwoRecursiveBranchesSerializes(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, string(first), string(second))
 }
+
+// A child set mixing an in-flight cyclic branch with another schema keeps
+// the other schema's constraints: the node becomes a residual allOf of the
+// named anchor and the merge of the rest, unflattened there but complete.
+func Test_MergeSpec_MixedCycleBranchKeepsSiblingConstraints(t *testing.T) {
+	spec, err := load.NewSpecInfo(openapi3.NewLoader(), load.NewSource("../../data/allof/mixed-cycle-branch.yaml"), load.WithFlattenAllOf())
+	require.NoError(t, err)
+
+	tree := spec.Spec.Paths.Value("/x").Post.RequestBody.Value.Content["application/json"].
+		Schema.Value.Properties["tree"]
+	child := tree.Value.Properties["child"]
+	require.Len(t, child.Value.AllOf, 2)
+	require.Equal(t, "#/components/schemas/AllOfMerged1", child.Value.AllOf[0].Ref)
+	require.Same(t, tree.Value, child.Value.AllOf[0].Value)
+	require.True(t, child.Value.AllOf[1].Value.Properties["leaf"].Value.Type.Is("string"),
+		"the non-cyclic sibling's constraint must survive")
+
+	_, err = spec.Spec.MarshalJSON()
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Fixes #1242, the last item from the #1240 boundary probe.

## The defect

`flattenSchemas`' in-flight guard returned on the **first** input already being flattened higher up and discarded the rest of the set. For an all-in-flight set that is exact — the anchored ancestor merges every branch, which is why #1240's n-ary cases are correct. For a **mixed** set (an in-flight cyclic branch plus other schemas), the others' constraints silently vanished at the cycle-closing node. On the issue's reproducer, `child` should be NodeA ∧ Plain but came out as the bare anchor, dropping `Plain.leaf`.

Severity-wise that is a wire-contract weakening of the flattened output, so `breaking --flatten-allof` on such shapes could miss a real breaking change on the dropped constraint — an error in the dangerous direction.

## The fix

A mixed set now produces a residual instead of a bare anchor:

```yaml
child:
  allOf:
    - $ref: '#/components/schemas/AllOfMerged1'   # the anchor, named by the #1240 pass
    - properties:
        leaf: {type: string}                        # merge of the non-in-flight schemas
```

Correct and serializable, just not fully flattened at that one node — the same honest-incompleteness precedent as the documented `contains` over-constraint (docs/ALLOF.md). The anchor refs join `state.anchored`, so `nameAnchoredCycles` names them like any other anchored edge; no changes to the naming pass were needed. As a side effect, a set anchoring to several *distinct* in-flight results (previously first-wins) now keeps all of them as a residual of the anchors.

## Verification

- New fixture + `Test_MergeSpec_MixedCycleBranchKeepsSiblingConstraints`: the sibling's constraint survives, the anchor carries the hoisted name and shares identity with the merged node, and the document marshals.
- The all-in-flight paths are pinned unchanged by #1233/#1240's existing tests (recursive overlay, two and three recursive branches, the #890 pair).
- Full suite and lint pass.